### PR TITLE
API: Expose the Engine's Offset Pagination Through /search

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -1127,6 +1127,7 @@ class APIResource:
         direction: SortDirection = SortDirection.ASC,
         fields: Sequence[str] | None = None,
         limit: int = 100,
+        offset: int = 0,
         orderby: CardOrdering = CardOrdering.EDHREC,
         prefer: PreferOrder = PreferOrder.DEFAULT,
         q: str | None = None,
@@ -1145,6 +1146,10 @@ class APIResource:
                 to the usual 9 (name, set_code, collector_number, power, toughness, mana_cost,
                 oracle_text, set_name, type_line). See RESULT_FIELD_COLUMNS for the full vocabulary.
             limit: Maximum number of results to return.
+            offset: Number of results to skip before the first returned card, in the
+                same sort order the query uses -- limit/offset together give clients
+                pagination over the full result set (total_cards is always the
+                unpaginated count).
             orderby: Field to sort by.
             shape: Shape of the "cards" list: 'rows' (list of card objects, default) or
                 'columnar' (one list per field, keyed by field name — smaller on the wire).
@@ -1161,6 +1166,7 @@ class APIResource:
             direction=direction,
             fields=fields,
             limit=limit,
+            offset=offset,
             unique=unique,
             prefer=prefer,
         )
@@ -1168,6 +1174,15 @@ class APIResource:
             # Shallow copy: _search returns cached dicts, which must stay row-shaped.
             results = {**results, "cards": _columnarize_cards(results["cards"])}
         return results
+
+    def _validate_offset(self, offset: int) -> int:
+        """Validate the offset and return it if valid."""
+        if not isinstance(offset, int) or offset < 0:
+            raise falcon.HTTPBadRequest(
+                title="Invalid Offset",
+                description="Offset must be a non-negative integer.",
+            )
+        return offset
 
     def _validate_limit(self, limit: int | None) -> int | None:
         """Validate the limit and return it if valid."""
@@ -1204,6 +1219,7 @@ class APIResource:
         direction: SortDirection = SortDirection.ASC,
         fields: Sequence[str] | None = None,
         limit: int = 100,
+        offset: int = 0,
         orderby: CardOrdering = CardOrdering.EDHREC,
         prefer: PreferOrder = PreferOrder.DEFAULT,
         query: str | None = None,
@@ -1211,13 +1227,14 @@ class APIResource:
     ) -> dict[str, Any]:
         self._require_setup_complete()
         limit = self._validate_limit(limit)
+        offset = self._validate_offset(offset)
         # Resolved once here (rather than inside _search_sql/_search_engine) so an unknown field
         # name always raises HTTPBadRequest instead of being swallowed by the engine's blanket
         # except-and-fall-back-to-SQL below.
         resolved_fields = self._resolve_result_fields(fields)
 
         if settings.enable_cache:
-            cache_key = (direction, limit, orderby, prefer, query, unique, tuple(resolved_fields))
+            cache_key = (direction, limit, offset, orderby, prefer, query, unique, tuple(resolved_fields))
             gen = self._cache_generation.value
             try:
                 search_cache = self._search_gen_cache[gen]
@@ -1256,6 +1273,7 @@ class APIResource:
                     orderby=orderby,
                     direction=direction,
                     limit=limit,
+                    offset=offset,
                     timer=timer,
                     fields=resolved_fields,
                 )
@@ -1292,6 +1310,7 @@ class APIResource:
             orderby=orderby,
             direction=direction,
             limit=limit,
+            offset=offset,
             timer=timer,
             fields=resolved_fields,
         )
@@ -1309,6 +1328,7 @@ class APIResource:
         orderby: CardOrdering,
         direction: SortDirection,
         limit: int,
+        offset: int,
         timer: Timer,
         fields: Sequence[str] | None = None,
     ) -> dict[str, Any]:
@@ -1324,6 +1344,7 @@ class APIResource:
                     direction=str(direction),
                     # limit=None means "no limit"; the engine requires an int, so use a large number
                     limit=limit if limit is not None else 1_000_000,
+                    offset=offset,
                     fields=fields,
                 )
         except _QueryError as err:
@@ -1355,6 +1376,7 @@ class APIResource:
         orderby: CardOrdering,
         direction: SortDirection,
         limit: int,
+        offset: int,
         timer: Timer,
         fields: Sequence[str] | None = None,
     ) -> dict[str, Any]:
@@ -1439,6 +1461,8 @@ class APIResource:
                     {_order_by}
                 LIMIT
                     %(limit)s
+                OFFSET
+                    %(offset)s
             )
             UNION ALL
             (
@@ -1473,6 +1497,8 @@ class APIResource:
                     {_order_by}
                 LIMIT
                     %(limit)s
+                OFFSET
+                    %(offset)s
             )
             UNION ALL
             (
@@ -1484,6 +1510,7 @@ class APIResource:
             )"""
 
         params["limit"] = limit
+        params["offset"] = offset
         query_sql = rewrap(query_sql)
         logger.info("Full query: %s", query_sql)
         logger.info("Params: %s", params)

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -266,6 +266,11 @@ _ENGINE_RELOAD_BATCH_SIZE = 2_000
 # have a same-named entry in FIELD_TABLE with matching semantics, so a `fields=` request for one
 # of these names gets identically-shaped results regardless of which path serves it; FIELD_TABLE
 # is free to have entries with no counterpart here.
+# Pagination default: offset 0 everywhere it appears, extracted so the internal
+# search methods keep it optional (per review) and route/internal defaults can
+# never drift apart.
+DEFAULT_OFFSET = 0
+
 RESULT_FIELD_COLUMNS: dict[str, str] = {
     "name": "card_name",
     "set_code": "card_set_code",
@@ -1127,7 +1132,7 @@ class APIResource:
         direction: SortDirection = SortDirection.ASC,
         fields: Sequence[str] | None = None,
         limit: int = 100,
-        offset: int = 0,
+        offset: int = DEFAULT_OFFSET,
         orderby: CardOrdering = CardOrdering.EDHREC,
         prefer: PreferOrder = PreferOrder.DEFAULT,
         q: str | None = None,
@@ -1219,7 +1224,7 @@ class APIResource:
         direction: SortDirection = SortDirection.ASC,
         fields: Sequence[str] | None = None,
         limit: int = 100,
-        offset: int = 0,
+        offset: int = DEFAULT_OFFSET,
         orderby: CardOrdering = CardOrdering.EDHREC,
         prefer: PreferOrder = PreferOrder.DEFAULT,
         query: str | None = None,
@@ -1328,8 +1333,8 @@ class APIResource:
         orderby: CardOrdering,
         direction: SortDirection,
         limit: int,
-        offset: int,
         timer: Timer,
+        offset: int = DEFAULT_OFFSET,
         fields: Sequence[str] | None = None,
     ) -> dict[str, Any]:
         logger.info("Searching engine for %r", query)
@@ -1376,8 +1381,8 @@ class APIResource:
         orderby: CardOrdering,
         direction: SortDirection,
         limit: int,
-        offset: int,
         timer: Timer,
+        offset: int = DEFAULT_OFFSET,
         fields: Sequence[str] | None = None,
     ) -> dict[str, Any]:
         logger.info("Searching SQL for %r", query)

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -627,6 +627,18 @@ class TestSearchResponseShape(TestBaseAPIResourceTest):
         assert list(api_resource_module._columnarize_cards(cards)) == ["b", "a"]
 
 
+class TestOffsetValidation(TestBaseAPIResourceTest):
+    """offset must be a non-negative integer; violations are 400s, not silent clamps."""
+
+    def test_negative_offset_rejected(self) -> None:
+        with pytest.raises(falcon.HTTPBadRequest):
+            self.api_resource._validate_offset(-1)
+
+    def test_valid_offsets_pass_through(self) -> None:
+        assert self.api_resource._validate_offset(0) == 0
+        assert self.api_resource._validate_offset(175) == 175
+
+
 class TestAPIResourceStaticFileServing(unittest.TestCase):
     """Test static file serving methods."""
 

--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -82,6 +82,7 @@ def _run(
     orderby: str = "edhrec",
     direction: str = "asc",
     limit: int = 200,
+    offset: int = 0,
     fields: list[str] | None = None,
 ) -> tuple[int, list[dict]]:
     """Parse q, run engine.query(), return (total, cards). q='' matches all."""
@@ -93,6 +94,7 @@ def _run(
         orderby=orderby,
         direction=direction,
         limit=limit,
+        offset=offset,
         fields=fields,
     )
     return total, list(cards)
@@ -1194,6 +1196,28 @@ class TestCommonCardKeywords:
         result = engine.common_card_keywords()
         for keyword, count in result.items():
             assert count > 0, f"Keyword {keyword!r} has non-positive count {count}"
+
+
+class TestOffsetPagination:
+    """offset skips rows in sort order; total_cards stays the unpaginated count."""
+
+    def test_offset_windows_tile_the_full_ordering(self, engine: QueryEngine) -> None:
+        _, full = _run(engine, "t:creature", unique="card", limit=20)
+        _, first = _run(engine, "t:creature", unique="card", limit=10)
+        _, second = _run(engine, "t:creature", unique="card", limit=10, offset=10)
+        names = [c["name"] for c in full]
+        assert [c["name"] for c in first] == names[:10]
+        assert [c["name"] for c in second] == names[10:20]
+
+    def test_total_cards_ignores_offset(self, engine: QueryEngine) -> None:
+        total_plain, _ = _run(engine, "t:creature", unique="card", limit=5)
+        total_offset, _ = _run(engine, "t:creature", unique="card", limit=5, offset=50)
+        assert total_offset == total_plain
+
+    def test_offset_past_the_end_is_empty(self, engine: QueryEngine) -> None:
+        total, cards = _run(engine, 'name="Lightning Bolt"', unique="card", offset=1000)
+        assert cards == []
+        assert total >= 1
 
 
 class TestFieldSelection:


### PR DESCRIPTION
## What

The engine's `query()` has accepted `offset` since the popcount-skip pagination work (`select_page`, `QueryParams.page_offset`) — but the API layer never passed it, so `/search` clients have only an unbounded `limit`, and paging a large result set means refetching everything above the window.

This threads `offset` end to end:

- `/search?offset=N` (default 0; negative or non-integer → 400 `Invalid Offset`, not a silent clamp)
- **engine path**: passed straight to the existing `offset` parameter — no engine changes
- **SQL path**: `OFFSET` after `LIMIT` in both the `unique=printing` and `DISTINCT ON` branches
- `total_cards` remains the unpaginated count in every case, so `limit`/`offset` + `total_cards` is complete pagination for a client
- the result cache key includes `offset`

## Validation

- New engine unit tests prove the property that matters: `limit=10` and `limit=10&offset=10` **tile the full `limit=20` ordering exactly**, and `total_cards` ignores `offset`; offset past the end returns an empty page with the true total
- `api/tests` 303 passed; ruff + format clean
- Runtime-checked on a full-corpus dev stack across both serving paths

## Why

We're paginating seek results server-side against a Sylvan instance; with `offset` exposed, a page-N request stops being an N-page refetch. Scryfall's `page=` param maps to `offset = (page-1) * page_size` at the client, so this also closes another syntax-compat gap for anyone fronting the API with Scryfall-shaped requests.