### PR TITLE
Parsing+API: Apply the In-Query Directives, and Accept unique:

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -190,13 +190,17 @@ _DIRECTIVE_PREFER: dict[str, PreferOrder] = {str(member): member for member in P
 }
 
 
-# Directive name -> (parameter it sets, vocabulary, noun used in warnings). sort and order
-# are spellings of the same parameter, so they share a slot and can override one another.
+# Directive name -> (parameter it sets, vocabulary, noun used in warnings). Several directives
+# have more than one spelling and share a slot, so they override one another rather than each
+# setting a different parameter: sort/order, and direction/dir. Both pairs are spellings
+# api.scryfall.com accepts inline (measured 2026-08-09: `dir:desc` and `direction:desc` return
+# the same page, as do `dir:auto` and `direction:auto`).
 _DIRECTIVE_TABLES: dict[str, tuple[str, Mapping[str, Any], str]] = {
     "unique": ("unique", _DIRECTIVE_UNIQUE, "unique mode"),
     "sort": ("orderby", _DIRECTIVE_ORDER, "order choice"),
     "order": ("orderby", _DIRECTIVE_ORDER, "order choice"),
     "direction": ("direction", _DIRECTIVE_DIRECTION, "direction"),
+    "dir": ("direction", _DIRECTIVE_DIRECTION, "direction"),
     "prefer": ("prefer", _DIRECTIVE_PREFER, "prefer choice"),
 }
 

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -48,6 +48,8 @@ from api.utils.timer import Timer
 from card_engine import QueryError as _QueryError
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from api.parsing.nodes import Query
     from api.utils.routing import BoundRoute
 
@@ -160,6 +162,102 @@ DEFAULT_RESULT_FIELDS: tuple[str, ...] = (
     "set_name",
     "type_line",
 )
+
+# In-query result-shape directives: the parser strips these from the filter tree and records
+# them on the parsed Query; `_fold_directives` applies them over the request parameters. Each
+# table maps the spellings a directive accepts — Scryfall's inline vocabulary (unique:art,
+# unique:prints) alongside this API's own enum values — to the enum member. Semantics measured
+# against api.scryfall.com (2026-08-07): an inline directive overrides its query parameter, the
+# last occurrence of a repeated directive wins, and an unknown value warns and is ignored
+# rather than failing the search. NOTHING here is ever silent: a directive that looks scoped
+# (inside an or-group or negation) and a repeat that overrode a different earlier value each
+# add an explicit response warning saying what actually happened.
+_DIRECTIVE_UNIQUE: dict[str, UniqueOn] = {
+    "card": UniqueOn.CARD,
+    "cards": UniqueOn.CARD,
+    "printing": UniqueOn.PRINTING,
+    "printings": UniqueOn.PRINTING,
+    "prints": UniqueOn.PRINTING,
+    "art": UniqueOn.ARTWORK,
+    "artwork": UniqueOn.ARTWORK,
+}
+_DIRECTIVE_ORDER: dict[str, CardOrdering] = {str(member): member for member in CardOrdering}
+_DIRECTIVE_DIRECTION: dict[str, SortDirection] = {str(member): member for member in SortDirection}
+# Scryfall-shaped queries spell the usd prefers with a hyphen; the enum values use underscores.
+_DIRECTIVE_PREFER: dict[str, PreferOrder] = {str(member): member for member in PreferOrder} | {
+    "usd-low": PreferOrder.USD_LOW,
+    "usd-high": PreferOrder.USD_HIGH,
+}
+
+
+# Directive name -> (parameter it sets, vocabulary, noun used in warnings). sort and order
+# are spellings of the same parameter, so they share a slot and can override one another.
+_DIRECTIVE_TABLES: dict[str, tuple[str, Mapping[str, Any], str]] = {
+    "unique": ("unique", _DIRECTIVE_UNIQUE, "unique mode"),
+    "sort": ("orderby", _DIRECTIVE_ORDER, "order choice"),
+    "order": ("orderby", _DIRECTIVE_ORDER, "order choice"),
+    "direction": ("direction", _DIRECTIVE_DIRECTION, "direction"),
+    "prefer": ("prefer", _DIRECTIVE_PREFER, "prefer choice"),
+}
+
+
+def _fold_directives(
+    directives: Sequence[tuple[str, str, bool]],
+    *,
+    unique: UniqueOn,
+    orderby: CardOrdering,
+    direction: SortDirection,
+    prefer: PreferOrder,
+) -> tuple[UniqueOn, CardOrdering, SortDirection, PreferOrder, list[str]]:
+    """Fold a parsed query's result-shape directives over the request parameters.
+
+    A directive always applies to the whole search, and anything surprising about that says
+    so in the returned warnings rather than happening silently: an unknown value is ignored
+    with a warning (Scryfall's behavior, message included), a directive written inside an
+    or-group or negation warns that it is not scoped to its group, and a repeat that
+    overrides a DIFFERENT earlier value warns which one won. A repeat of the same value
+    warns nothing — there is nothing surprising to report.
+
+    Args:
+        directives: (name, value, nested) triples in source order, from Query.directives.
+        unique: The unique mode from the query parameters.
+        orderby: The ordering from the query parameters.
+        direction: The sort direction from the query parameters.
+        prefer: The prefer order from the query parameters.
+
+    Returns:
+        The effective (unique, orderby, direction, prefer) after directives, plus warnings.
+    """
+    warnings: list[str] = []
+    effective: dict[str, Any] = {"unique": unique, "orderby": orderby, "direction": direction, "prefer": prefer}
+    written: dict[str, tuple[str, str]] = {}  # parameter -> (name, value) that last set it
+
+    for name, value, nested in directives:
+        target, table, noun = _DIRECTIVE_TABLES[name]
+        if value not in table:
+            warnings.append(f'Unknown {noun} "{value}" was ignored')
+            continue
+        if nested:
+            warnings.append(f"{name}:{value} applies to the whole search, not only its group")
+        previous = written.get(target)
+        if previous is not None and table[value] != effective[target]:
+            warnings.append(f"{name}:{value} overrode the earlier {previous[0]}:{previous[1]}")
+        effective[target] = table[value]
+        written[target] = (name, value)
+    return effective["unique"], effective["orderby"], effective["direction"], effective["prefer"], warnings
+
+
+def _with_warnings(result: dict[str, Any], warnings: list[str]) -> dict[str, Any]:
+    """Return `result` with a "warnings" entry attached; unchanged when there are none.
+
+    A fresh dict rather than mutation: _search caches result dicts, and a cached result must
+    not grow keys after the fact.
+    """
+    if not warnings:
+        return result
+    return {**result, "warnings": warnings}
+
+
 
 # default/atypical are complementary and disjoint
 # so in theory we could query for one and build the other by
@@ -558,6 +656,11 @@ class APIResource:
     ) -> dict[str, Any]:
         """Run a search query and return results and metadata.
 
+        The query string may embed result-shape directives (unique:, sort:/order:, direction:,
+        prefer:), which override the parameter of the same meaning — Scryfall semantics, so
+        `q=bolt unique:art` dedups by artwork regardless of the `unique` parameter. A directive
+        with an unknown value adds a "warnings" entry to the response and is otherwise ignored.
+
         Args:
             falcon_response: The Falcon response object (unused).
             q: Query string (alternative to query parameter).
@@ -574,8 +677,8 @@ class APIResource:
             orderby: Field to sort by.
             shape: Shape of the "cards" list: 'rows' (list of card objects, default) or
                 'columnar' (one list per field, keyed by field name — smaller on the wire).
-            unique: Unique on field.
-            prefer: Prefer order (oldest, newest, usd-low, usd-high, promo).
+            unique: Unique on field (card, printing, artwork).
+            prefer: Prefer order (oldest, newest, usd_low, usd_high, promo).
 
         Returns:
             Dict containing search results and metadata.
@@ -663,6 +766,18 @@ class APIResource:
         except ValueError as err:
             _raise_query_bad_request(exc_name="ValueError", query=query, description=f'Failed to parse query: "{query}"', err=err)
 
+        # In-query directives override the query parameters (Scryfall semantics); both search
+        # paths below receive the effective values, so engine and SQL cannot disagree on them.
+        # The cache lookup above keys on the raw query string, which the directives are a pure
+        # function of.
+        unique, orderby, direction, prefer, warnings = _fold_directives(
+            parsed_query.directives,
+            unique=unique,
+            orderby=orderby,
+            direction=direction,
+            prefer=prefer,
+        )
+
         if not settings.enable_engine:
             pass  # feature-gated off: SQL serves everything, the store never loads
         elif self.app_context.engine.size() == 0:
@@ -721,6 +836,7 @@ class APIResource:
                     exc_info=not declined,
                 )
             else:
+                result = _with_warnings(result, warnings)
                 if settings.enable_cache:
                     search_cache[cache_key] = result
                 return result
@@ -737,6 +853,7 @@ class APIResource:
             timer=timer,
             fields=resolved_fields,
         )
+        result = _with_warnings(result, warnings)
         if settings.enable_cache:
             search_cache[cache_key] = result
         return result

--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -15,6 +15,7 @@ from api.parsing.card_query_nodes import CardAttributeNode, CardBinaryOperatorNo
 from api.parsing.db_info import ALIAS_TO_FIELD_INFOS, COLOR_NAME_TO_CODE, ParserClass
 from api.parsing.mana_symbols import first_invalid_mana_symbol
 from api.parsing.nodes import (
+    DIRECTIVE_NAMES,
     AndNode,
     BinaryOperatorNode,
     DirectiveNode,
@@ -480,14 +481,18 @@ class Parser:
     # ── word dispatch ─────────────────────────────────────────────────────────
 
     def parse_directive_primary(self, word: str, wl: str, next_tok: Token) -> QueryNode | None:
-        """Consume a result-shape directive (unique:/sort:/order:/direction:/prefer:), or return None.
+        """Consume a result-shape directive (unique:/sort:/order:/direction:/dir:/prefer:), or return None.
 
         Scryfall accepts these inside the query string itself; they constrain presentation,
         not membership, so a directive parses to a DirectiveNode carrying its value, and the
         extraction pass in rewrite.py strips it from the filter tree and records it on the
         Query for the API layer to apply.
+
+        `dir` is Scryfall's short spelling of `direction` and sets the same parameter (measured
+        2026-08-09: `dir:desc` and `direction:desc` return the same page, as do `dir:auto` and
+        `direction:auto`). Matching is on the whole word, so `direct:` is unaffected.
         """
-        if wl not in ("sort", "order", "direction", "prefer", "unique") or next_tok.type != TT.OP or next_tok.value != ":":
+        if wl not in DIRECTIVE_NAMES or next_tok.type != TT.OP or next_tok.value != ":":
             return None
         self.consume()  # ':'
         val_tok = self.peek()

--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -17,6 +17,7 @@ from api.parsing.mana_symbols import first_invalid_mana_symbol
 from api.parsing.nodes import (
     AndNode,
     BinaryOperatorNode,
+    DirectiveNode,
     ManaValueNode,
     NotNode,
     NumericValueNode,
@@ -478,6 +479,24 @@ class Parser:
 
     # ── word dispatch ─────────────────────────────────────────────────────────
 
+    def parse_directive_primary(self, word: str, wl: str, next_tok: Token) -> QueryNode | None:
+        """Consume a result-shape directive (unique:/sort:/order:/direction:/prefer:), or return None.
+
+        Scryfall accepts these inside the query string itself; they constrain presentation,
+        not membership, so a directive parses to a DirectiveNode carrying its value, and the
+        extraction pass in rewrite.py strips it from the filter tree and records it on the
+        Query for the API layer to apply.
+        """
+        if wl not in ("sort", "order", "direction", "prefer", "unique") or next_tok.type != TT.OP or next_tok.value != ":":
+            return None
+        self.consume()  # ':'
+        val_tok = self.peek()
+        if val_tok.type in (TT.WORD, TT.QUOTED, TT.NUMBER):
+            self.consume()
+            return DirectiveNode(wl, str(val_tok.value).lower())
+        msg = f"Expected value after '{word}:' at position {val_tok.pos}"
+        raise ParseError(msg)
+
     def parse_word_primary(self, word: str) -> QueryNode:
         """Dispatch on whether word is a known attribute alias, keyword, or implicit name."""
         wl = word.lower()
@@ -487,6 +506,10 @@ class Parser:
 
         pc = _ALIAS_TO_PC.get(wl)
         next_tok = self.peek()
+
+        directive = self.parse_directive_primary(word, wl, next_tok)
+        if directive is not None:
+            return directive
 
         # ── dual-class alias (cn / number): dispatch on value shape ──
         if wl in _DUAL_NUM_TEXT and next_tok.type == TT.OP:

--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -499,11 +499,11 @@ class Parser:
         if val_tok.type in (TT.WORD, TT.QUOTED, TT.NUMBER):
             self.consume()
             value = str(val_tok.value)
-            # Glue hyphenated continuations, exactly as _text_value does. `-` is not a word
+            # Glue hyphenated continuations, exactly as parse_text_value does. `-` is not a word
             # character, so `usd-low` lexes as WORD MINUS WORD; consuming a single token stopped
             # at `usd` and left `-low` to fail the parse. That made the hyphenated spellings
-            # Scryfall accepts -- and that _DIRECTIVE_PREFER enumerates -- unreachable from
-            # inside a query by any input. A QUOTED value is already one token.
+            # Scryfall accepts -- and that _DIRECTIVE_PREFER in api_resource enumerates --
+            # unreachable from inside a query by any input. A QUOTED value is already one token.
             if val_tok.type is not TT.QUOTED:
                 while (
                     self.peek().type == TT.MINUS

--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -498,7 +498,22 @@ class Parser:
         val_tok = self.peek()
         if val_tok.type in (TT.WORD, TT.QUOTED, TT.NUMBER):
             self.consume()
-            return DirectiveNode(wl, str(val_tok.value).lower())
+            value = str(val_tok.value)
+            # Glue hyphenated continuations, exactly as _text_value does. `-` is not a word
+            # character, so `usd-low` lexes as WORD MINUS WORD; consuming a single token stopped
+            # at `usd` and left `-low` to fail the parse. That made the hyphenated spellings
+            # Scryfall accepts -- and that _DIRECTIVE_PREFER enumerates -- unreachable from
+            # inside a query by any input. A QUOTED value is already one token.
+            if val_tok.type is not TT.QUOTED:
+                while (
+                    self.peek().type == TT.MINUS
+                    and not self.peek().space_before
+                    and self.peek(1).type in (TT.WORD, TT.NUMBER)
+                    and not self.peek(1).space_before
+                ):
+                    self.consume()
+                    value += f"-{self.consume().value}"
+            return DirectiveNode(wl, value.lower())
         msg = f"Expected value after '{word}:' at position {val_tok.pos}"
         raise ParseError(msg)
 

--- a/api/parsing/nodes.py
+++ b/api/parsing/nodes.py
@@ -445,6 +445,17 @@ class TrueNode(LeafNode):
         return ""
 
 
+# The directive names both parsers recognize, longest spelling first so an alternation built from
+# this list matches `direction` outright rather than leaning on a lookahead to reject the `dir`
+# prefix. One list rather than one per parser: the two spell the same vocabulary and a name added
+# to only one of them is a parity divergence that the shared cases would not catch, because a
+# query nobody wrote cannot fail.
+#
+# `sort`/`order` and `direction`/`dir` are pairs of spellings for one parameter each; both pairs
+# are accepted by api.scryfall.com inline (measured 2026-08-09).
+DIRECTIVE_NAMES: tuple[str, ...] = ("unique", "sort", "order", "direction", "dir", "prefer")
+
+
 class DirectiveNode(LeafNode):
     """A result-shape directive written inside the query string (unique:art, sort:usd).
 

--- a/api/parsing/nodes.py
+++ b/api/parsing/nodes.py
@@ -445,12 +445,50 @@ class TrueNode(LeafNode):
         return ""
 
 
+class DirectiveNode(LeafNode):
+    """A result-shape directive written inside the query string (unique:art, sort:usd).
+
+    Carries the directive's name and value so `extract_directives` at the rewrite seam can
+    record them on the Query and strip the node from the filter tree — a directive constrains
+    presentation, not membership, so one never reaches SQL generation or the engine. `to_sql`
+    still renders the always-true condition as a backstop for a tree that skipped the seam.
+    """
+
+    def __init__(self: DirectiveNode, name: str, value: str) -> None:
+        """Initialize a DirectiveNode with the directive's lowercased name and value."""
+        self.name = name
+        self.value = value
+
+    def kwargs(self) -> dict:
+        """Return this node's kwargs dict for Rust engine JSON serialization."""
+        return {}
+
+    def to_sql(self: DirectiveNode, context: QueryContext) -> str:
+        """Serialize this node to the SQL literal TRUE."""
+        del context
+        return "TRUE"
+
+    def to_human_explanation(self: DirectiveNode) -> str:
+        """Return an empty explanation; a directive does not constrain matching."""
+        return ""
+
+    def __repr__(self: DirectiveNode) -> str:
+        """Return a string representation of the DirectiveNode."""
+        return f"DirectiveNode({self.name!r}, {self.value!r})"
+
+
 class Query(QueryNode):
     """Top-level query container node for the AST."""
 
     def __init__(self: Query, root: QueryNode) -> None:
-        """Initialize a Query with the root QueryNode."""
+        """Initialize a Query with the root QueryNode.
+
+        `directives` holds (name, value, nested) triples for the result-shape directives the
+        query carried, in source order — `nested` marks one written inside an Or or a negation.
+        `rewrite_query` populates it after stripping their nodes from the filter tree.
+        """
         self.root = root
+        self.directives: tuple[tuple[str, str, bool], ...] = ()
 
     def to_json(self) -> dict:
         """Delegate to the root node."""

--- a/api/parsing/pyparsing_based.py
+++ b/api/parsing/pyparsing_based.py
@@ -33,6 +33,7 @@ from api.parsing.mana_symbols import first_invalid_mana_symbol
 from api.parsing.nodes import (
     AndNode,
     BinaryOperatorNode,
+    DirectiveNode,
     ManaValueNode,
     NotNode,
     NumericValueNode,
@@ -105,6 +106,14 @@ def create_value_node(value: object) -> QueryNode:
     if isinstance(value, tuple) and value[0] == "regex":
         return RegexValueNode(value[1])
     return value  # Fallback for other types
+
+
+def make_directive_node(tokens: list[object]) -> DirectiveNode:
+    """Build a DirectiveNode from [name, ':', value]; quoted values arrive as ('quoted', text)."""
+    name, _colon, value = tokens
+    if isinstance(value, tuple):
+        value = value[1]
+    return DirectiveNode(str(name).lower(), str(value).lower())
 
 
 def make_binary_operator_node(tokens: list[object]) -> BinaryOperatorNode:
@@ -404,8 +413,19 @@ def create_all_condition_parsers(basic_parsers: dict, mana_parsers: dict, color_
     )
     attr_attr_condition.set_parse_action(make_binary_operator_node)
 
+    # Result-shape directives Scryfall accepts inside the query string
+    # (unique:art, sort:edhrec, order:name, direction:asc, prefer:oldest). They
+    # constrain presentation, not membership, so they parse to a DirectiveNode
+    # carrying the value; the extraction pass at the rewrite seam strips them from
+    # the filter tree and records them on the Query for the API layer to apply.
+    directive_condition = (
+        Regex(r"(?i)(?:sort|order|direction|prefer|unique)(?=:)") + Literal(":") + (quoted_string | string_value_word)
+    )
+    directive_condition.set_parse_action(make_directive_node)
+
     condition = (
-        mana_condition
+        directive_condition
+        | mana_condition
         | rarity_condition
         | legality_condition
         | color_condition

--- a/api/parsing/pyparsing_based.py
+++ b/api/parsing/pyparsing_based.py
@@ -31,6 +31,7 @@ from api.parsing.db_info import (
 )
 from api.parsing.mana_symbols import first_invalid_mana_symbol
 from api.parsing.nodes import (
+    DIRECTIVE_NAMES,
     AndNode,
     BinaryOperatorNode,
     DirectiveNode,
@@ -419,7 +420,9 @@ def create_all_condition_parsers(basic_parsers: dict, mana_parsers: dict, color_
     # carrying the value; the extraction pass at the rewrite seam strips them from
     # the filter tree and records them on the Query for the API layer to apply.
     directive_condition = (
-        Regex(r"(?i)(?:sort|order|direction|prefer|unique)(?=:)") + Literal(":") + (quoted_string | string_value_word)
+        # DIRECTIVE_NAMES is ordered longest-spelling-first, so `direction` wins the alternation
+        # outright rather than relying on the lookahead to reject the `dir` prefix.
+        Regex(rf"(?i)(?:{'|'.join(DIRECTIVE_NAMES)})(?=:)") + Literal(":") + (quoted_string | string_value_word)
     )
     directive_condition.set_parse_action(make_directive_node)
 

--- a/api/parsing/rewrite.py
+++ b/api/parsing/rewrite.py
@@ -21,11 +21,13 @@ from api.parsing.hand_parser import parse_query as _parse_query
 from api.parsing.nodes import (
     AndNode,
     BinaryOperatorNode,
+    DirectiveNode,
     NotNode,
     OrNode,
     Query,
     RegexValueNode,
     StringValueNode,
+    TrueNode,
     flatten_nested_operations,
 )
 
@@ -311,6 +313,57 @@ def expand_derived_predicates(query: Query) -> Query:
     return flatten_nested_operations(Query(root))
 
 
+def _strip_directives(node: QueryNode, found: list[tuple[str, str, bool]], *, nested: bool) -> QueryNode | None:
+    """Return `node` with directive leaves removed, appending (name, value, nested) in source order.
+
+    Returns None when the node vanishes entirely (it was a directive, or a compound made only
+    of directives); the original object when nothing changed. A directive is removed from the
+    structure as if it had never been written — inside an Or it does not make the Or true, and
+    a negated directive is still just a directive (Scryfall ignores the negation, measured
+    2026-08-07: `-unique:art` dedups by artwork exactly as `unique:art` does).
+
+    `nested` marks directives found under an Or or a negation: a directive always applies to
+    the WHOLE search, so one written inside such a group looks scoped but is not — the API
+    layer turns the flag into an explicit response warning rather than a silent surprise.
+    Parenthesized AND groups do not count: conjunction is flat, so `(t:goblin sort:x) t:elf`
+    means exactly `t:goblin sort:x t:elf`.
+    """
+    cls = node.__class__
+    if cls is DirectiveNode:
+        found.append((node.name, node.value, nested))
+        return None
+    if cls in (AndNode, OrNode):
+        inner_nested = nested or cls is OrNode
+        ops = [_strip_directives(op, found, nested=inner_nested) for op in node.operands]
+        kept = [op for op in ops if op is not None]
+        if not kept:
+            return None
+        if len(kept) == 1:
+            return kept[0]
+        return cls(kept) if kept != list(node.operands) else node
+    if cls is NotNode:
+        inner = _strip_directives(node.operand, found, nested=True)
+        if inner is None:
+            return None
+        return NotNode(inner) if inner is not node.operand else node
+    return node
+
+
+def extract_directives(query: Query) -> tuple[Query, tuple[tuple[str, str, bool], ...]]:
+    """Strip result-shape directives from the filter tree, returning (name, value, nested) triples.
+
+    A directive like `sort:edhrec` constrains presentation, not membership; without this pass a
+    query carrying one would serialize with a vestigial residue, making `t:goblin sort:edhrec`
+    compare unequal to `t:goblin` despite filtering identically. A query that is nothing but
+    directives filters as the empty query does.
+    """
+    found: list[tuple[str, str, bool]] = []
+    root = _strip_directives(query.root, found, nested=False)
+    if not found:
+        return query, ()
+    return Query(root if root is not None else TrueNode()), tuple(found)
+
+
 # The post-parse rewrite pipeline, applied in order at the shared parse seam. Add future AST
 # rewrites to this tuple — both parsers call `rewrite_query`, so a new pass lands in exactly one
 # place and is guaranteed identical treatment across parsers (enforced by test_parser_parity).
@@ -320,12 +373,16 @@ _REWRITE_PASSES = (negate_not_prefix, expand_derived_predicates, lower_literal_r
 def rewrite_query(query: Query) -> Query:
     """Apply every post-parse AST rewrite, in order. The single seam both parsers call.
 
-    Order is significant: `negate_not_prefix` runs first (a `not:`-spelled leaf becomes
-    `NotNode(is:...)`, so it reads as a plain `is:` leaf to everything after it), then
+    Directive extraction runs first so no later pass sees a DirectiveNode, and the collected
+    pairs are attached to the final Query afterward because each pass returns a fresh Query.
+    Order among the passes is significant: `negate_not_prefix` runs first (a `not:`-spelled leaf
+    becomes `NotNode(is:...)`, so it reads as a plain `is:` leaf to everything after it), then
     `expand_derived_predicates` (a synonym may expand into a subtree that itself contains a
     regex or other rewritable leaf), then `lower_literal_regexes`, then any future pass
     appended to `_REWRITE_PASSES`.
     """
+    query, directives = extract_directives(query)
     for rewrite_pass in _REWRITE_PASSES:
         query = rewrite_pass(query)
+    query.directives = directives
     return query

--- a/api/parsing/tests/test_result_directives.py
+++ b/api/parsing/tests/test_result_directives.py
@@ -23,6 +23,8 @@ DIRECTIVE_CASES = [
     ("t:goblin sort:edhrec", "t:goblin"),
     ("t:goblin order:name", "t:goblin"),
     ("t:goblin direction:asc", "t:goblin"),
+    ("t:goblin dir:asc", "t:goblin"),
+    ("t:goblin dir:auto", "t:goblin"),
     ("t:goblin prefer:oldest", "t:goblin"),
     ("t:goblin unique:art", "t:goblin"),
     ("t:goblin unique:prints", "t:goblin"),
@@ -69,6 +71,25 @@ def test_directive_prefix_of_longer_word_is_a_name() -> None:
     # "sorting" must not be consumed as "sort" + garbage, nor "uniquely" as "unique" + garbage.
     assert generate_sql_query(parse_scryfall_query("sorting")) == generate_sql_query(parse_search_query("sorting"))
     assert generate_sql_query(parse_scryfall_query("uniquely")) == generate_sql_query(parse_search_query("uniquely"))
+    # "dir" is the riskiest of these: it is a prefix of "direction" AND of ordinary words.
+    assert generate_sql_query(parse_scryfall_query("direct")) == generate_sql_query(parse_search_query("direct"))
+    assert generate_sql_query(parse_scryfall_query("dire")) == generate_sql_query(parse_search_query("dire"))
+
+
+def test_dir_is_recorded_as_the_short_spelling_of_direction() -> None:
+    """`dir:` is Scryfall's short spelling and sets the same parameter (measured 2026-08-09).
+
+    Recorded under its own name rather than rewritten to `direction`, so a warning about a
+    repeated directive can quote back what the client actually wrote.
+    """
+    assert parse_scryfall_query("t:goblin dir:desc").directives == (("dir", "desc", False),)
+    assert parse_search_query("t:goblin dir:desc").directives == (("dir", "desc", False),)
+
+
+def test_direction_is_not_swallowed_by_the_dir_alternative() -> None:
+    """The longer spelling has to win outright, or `direction:desc` parses as `dir` + garbage."""
+    assert parse_scryfall_query("t:goblin direction:desc").directives == (("direction", "desc", False),)
+    assert parse_search_query("t:goblin direction:desc").directives == (("direction", "desc", False),)
 
 
 def test_directive_values_are_captured_in_source_order() -> None:

--- a/api/parsing/tests/test_result_directives.py
+++ b/api/parsing/tests/test_result_directives.py
@@ -163,3 +163,28 @@ def test_ci_is_an_identity_alias(ci_query: str, id_query: str) -> None:
     """`ci` produces identical SQL to the established identity aliases, in both parsers."""
     assert generate_sql_query(parse_scryfall_query(ci_query)) == generate_sql_query(parse_scryfall_query(id_query))
     assert generate_sql_query(parse_search_query(ci_query)) == generate_sql_query(parse_search_query(id_query))
+
+
+# `-` is not a word character to the hand tokenizer, so `usd-low` lexes as WORD MINUS WORD.
+# The hand parser consumed a single token after the colon and stopped at `usd`, leaving `-low`
+# to fail the parse -- while pyparsing's `string_value_word` (\w[\w.-]*) took the whole thing.
+# So the two parsers disagreed on every hyphenated directive value, and the hyphenated prefer
+# spellings _DIRECTIVE_PREFER enumerates were unreachable from inside a query through the hand
+# parser. No existing case used one, which is why parity did not see it.
+HYPHENATED_DIRECTIVES = [
+    ("prefer:usd-low", "prefer", "usd-low"),
+    ("prefer:usd-high t:bolt", "prefer", "usd-high"),
+    ("prefer:usd-low t:goblin", "prefer", "usd-low"),
+]
+
+
+@pytest.mark.parametrize(
+    argnames=["query", "name", "value"],
+    argvalues=HYPHENATED_DIRECTIVES,
+    ids=[q for q, _, _ in HYPHENATED_DIRECTIVES],
+)
+def test_hyphenated_directive_values_survive_both_parsers(query: str, name: str, value: str) -> None:
+    """A hyphenated directive value reaches the directive whole, in both parsers."""
+    for parse in (parse_scryfall_query, parse_search_query):
+        directives = parse(query).directives
+        assert directives == ((name, value, False),), f"{parse.__name__} lost the hyphen in {query!r}"

--- a/api/parsing/tests/test_result_directives.py
+++ b/api/parsing/tests/test_result_directives.py
@@ -1,0 +1,144 @@
+"""Result-shape directives (unique:/sort:/order:/direction:/prefer:) and the `ci` identity alias.
+
+Scryfall accepts presentation directives inside the query string itself — a query
+like `t:goblin sort:edhrec` is valid there and filters exactly as `t:goblin`.
+Rejecting them breaks any client that forwards Scryfall-shaped query strings
+verbatim. Both parsers must consume a directive and contribute nothing to the
+filter tree, keeping SQL identical to the directive-free query; the extraction
+pass at the rewrite seam records each (name, value) on the Query so the API layer
+can apply them. Stripping is structural, matching Scryfall (measured 2026-08-07):
+a directive inside an Or does not make the Or true, and a negated directive is
+still just a directive.
+
+`ci` mirrors Scryfall's alias for color identity (`ci<=bg` == `id<=bg`).
+"""
+
+import pytest
+
+from api.parsing import generate_sql_query, parse_scryfall_query
+from api.parsing.pyparsing_based import parse_search_query
+
+# (query with directive, equivalent query without it)
+DIRECTIVE_CASES = [
+    ("t:goblin sort:edhrec", "t:goblin"),
+    ("t:goblin order:name", "t:goblin"),
+    ("t:goblin direction:asc", "t:goblin"),
+    ("t:goblin prefer:oldest", "t:goblin"),
+    ("t:goblin unique:art", "t:goblin"),
+    ("t:goblin unique:prints", "t:goblin"),
+    ("sort:edhrec t:goblin", "t:goblin"),
+    ('t:goblin sort:"edhrec"', "t:goblin"),
+    ("t:planeswalker f:commander sort:edhrec", "t:planeswalker f:commander"),
+    ("(t:goblin or t:elf) sort:edhrec", "t:goblin or t:elf"),
+    ("t:goblin or unique:art", "t:goblin"),
+    ("-unique:art t:goblin", "t:goblin"),
+]
+
+
+@pytest.mark.parametrize(
+    argnames=["query", "equivalent"],
+    argvalues=DIRECTIVE_CASES,
+    ids=[q for q, _ in DIRECTIVE_CASES],
+)
+def test_directive_filters_like_equivalent(query: str, equivalent: str) -> None:
+    """A directive-bearing query produces the same SQL as the query without it (hand parser)."""
+    assert generate_sql_query(parse_scryfall_query(query)) == generate_sql_query(parse_scryfall_query(equivalent))
+
+
+@pytest.mark.parametrize(
+    argnames=["query", "equivalent"],
+    argvalues=DIRECTIVE_CASES,
+    ids=[q for q, _ in DIRECTIVE_CASES],
+)
+def test_directive_parser_parity(query: str, equivalent: str) -> None:
+    """Both parsers agree on every directive-bearing query."""
+    del equivalent
+    assert generate_sql_query(parse_scryfall_query(query)) == generate_sql_query(parse_search_query(query))
+
+
+def test_directive_needs_a_value() -> None:
+    """A dangling directive prefix is still an error, not a silent no-op."""
+    with pytest.raises(ValueError, match="Failed to parse"):
+        parse_scryfall_query("t:goblin sort:")
+    with pytest.raises(ValueError, match="Failed to parse"):
+        parse_scryfall_query("t:goblin unique:")
+
+
+def test_directive_prefix_of_longer_word_is_a_name() -> None:
+    """Words that merely START with a directive keep their name reading."""
+    # "sorting" must not be consumed as "sort" + garbage, nor "uniquely" as "unique" + garbage.
+    assert generate_sql_query(parse_scryfall_query("sorting")) == generate_sql_query(parse_search_query("sorting"))
+    assert generate_sql_query(parse_scryfall_query("uniquely")) == generate_sql_query(parse_search_query("uniquely"))
+
+
+def test_directive_values_are_captured_in_source_order() -> None:
+    """The parsed Query records every directive's (name, value, nested), preserving repeats and order."""
+    parsed = parse_scryfall_query("t:goblin unique:art sort:usd unique:cards")
+    assert parsed.directives == (("unique", "art", False), ("sort", "usd", False), ("unique", "cards", False))
+
+
+def test_directive_free_query_captures_nothing() -> None:
+    """A query without directives records an empty tuple."""
+    assert parse_scryfall_query("t:goblin").directives == ()
+
+
+def test_directive_values_are_lowercased_and_unquoted() -> None:
+    """Directive names and values normalize to lowercase; quoted values lose their quotes."""
+    assert parse_scryfall_query('UNIQUE:"Art" t:elf').directives == (("unique", "art", False),)
+
+
+def test_directive_inside_or_or_negation_is_flagged_nested() -> None:
+    """A directive under an Or or a negation carries nested=True — it looks scoped but is not."""
+    assert parse_scryfall_query("t:goblin or unique:art").directives == (("unique", "art", True),)
+    assert parse_scryfall_query("-unique:art t:goblin").directives == (("unique", "art", True),)
+
+
+def test_directive_in_a_parenthesized_and_group_is_not_nested() -> None:
+    """Conjunction is flat: `(cmc=5 prefer:oldest) (cmc=4 prefer:newest)` is four top-level terms.
+
+    Both directives capture un-nested and in order, so the API layer's override warning — not a
+    scope warning — is what explains which one won.
+    """
+    parsed = parse_scryfall_query("(cmc=5 prefer:oldest) (cmc=4 prefer:newest)")
+    assert parsed.directives == (("prefer", "oldest", False), ("prefer", "newest", False))
+    equivalent = parse_scryfall_query("cmc=5 cmc=4")
+    assert generate_sql_query(parsed) == generate_sql_query(equivalent)
+
+
+@pytest.mark.parametrize(
+    argnames="query",
+    argvalues=[
+        "t:goblin unique:art sort:usd",
+        "-unique:art t:goblin",
+        '(t:elf or unique:"prints") direction:desc',
+        "unique:art",
+    ],
+)
+def test_directive_capture_parity(query: str) -> None:
+    """Both parsers record identical directives for the same query."""
+    assert parse_scryfall_query(query).directives == parse_search_query(query).directives
+
+
+def test_directive_only_query_filters_like_empty() -> None:
+    """A query that is nothing but a directive matches everything, in both parsers."""
+    assert generate_sql_query(parse_scryfall_query("unique:art")) == generate_sql_query(parse_search_query("unique:art"))
+    assert parse_scryfall_query("unique:art").directives == (("unique", "art", False),)
+
+
+CI_CASES = [
+    ("ci<=bg", "id<=bg"),
+    ("ci:wu", "id:wu"),
+    ("ci>=rg", "identity>=rg"),
+    ("t:land ci<=bg", "t:land id<=bg"),
+]
+
+
+@pytest.mark.parametrize(
+    argnames=["ci_query", "id_query"],
+    argvalues=CI_CASES,
+    ids=[q for q, _ in CI_CASES],
+)
+def test_ci_is_an_identity_alias(ci_query: str, id_query: str) -> None:
+    """`ci` produces identical SQL to the established identity aliases, in both parsers."""
+    assert generate_sql_query(parse_scryfall_query(ci_query)) == generate_sql_query(parse_scryfall_query(id_query))
+    assert generate_sql_query(parse_search_query(ci_query)) == generate_sql_query(parse_search_query(id_query))

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -17,7 +17,7 @@ import pytest
 import api.api_resource as api_resource_module
 from api.admin_resource import AdminContext
 from api.api_resource import INTERNAL_ERROR_DESCRIPTION, APIResource
-from api.enums import ResponseShape
+from api.enums import ResponseShape, UniqueOn
 from api.middlewares.caching_middleware import CachingMiddleware
 from api.settings import settings
 from api.tests.support import mock_app_context
@@ -631,6 +631,112 @@ class TestIdentityLetters(unittest.TestCase):
         """A colorless identity is an empty list, matching Scryfall's JSON."""
         assert api_resource_module._identity_letters({}) == []
         assert api_resource_module._identity_letters(None) == []
+
+
+class TestSearchQueryDirectives(TestBaseAPIResourceTest):
+    """In-query directives (unique:/sort:/order:/direction:/prefer:) apply before either search path.
+
+    The fold happens in _search, upstream of the engine/SQL dispatch, so both paths receive the
+    same effective parameters by construction. Scryfall semantics throughout (measured
+    2026-08-07): a directive overrides its query parameter, the last repeat wins, and an unknown
+    value warns and is ignored.
+    """
+
+    @contextmanager
+    def _search_flags(self, *, enable_engine: bool) -> Generator[None]:
+        """Force the engine gate and disable caching, restoring both afterward."""
+        saved = (settings.enable_engine, settings.enable_cache)
+        settings.enable_engine = enable_engine
+        settings.enable_cache = False
+        try:
+            yield
+        finally:
+            settings.enable_engine, settings.enable_cache = saved
+
+    def _engine_search(self, q: str, **params: Any) -> tuple[MagicMock, dict[str, Any]]:
+        """Run _search against a stubbed engine; return the engine mock and the result."""
+        mock_engine = MagicMock()
+        mock_engine.size.return_value = 90
+        mock_engine.query.return_value = (0, iter([]))
+        with (
+            patch.object(self.api_resource.app_context, "setup_complete", lambda: True),
+            patch.object(self.api_resource.app_context, "engine", mock_engine),
+            self._search_flags(enable_engine=True),
+        ):
+            result = self.api_resource._search(query=q, **params)
+        return mock_engine, result
+
+    def test_unique_directive_reaches_engine(self) -> None:
+        """`unique:art` in the query string turns into the artwork mode the engine sees."""
+        mock_engine, _ = self._engine_search("t:goblin unique:art")
+        assert mock_engine.query.call_args.kwargs["unique"] == "artwork"
+
+    def test_directive_overrides_parameter(self) -> None:
+        """An inline directive beats the query parameter of the same meaning."""
+        mock_engine, _ = self._engine_search("t:goblin unique:prints", unique=UniqueOn.ARTWORK)
+        assert mock_engine.query.call_args.kwargs["unique"] == "printing"
+
+    def test_last_repeated_directive_wins(self) -> None:
+        """`unique:cards unique:art` dedups by artwork, matching Scryfall."""
+        mock_engine, _ = self._engine_search("t:goblin unique:cards unique:art")
+        assert mock_engine.query.call_args.kwargs["unique"] == "artwork"
+
+    def test_every_directive_kind_applies(self) -> None:
+        """sort:, direction:, and prefer: all reach the engine as their enum values."""
+        mock_engine, _ = self._engine_search("t:goblin sort:usd direction:desc prefer:oldest")
+        kwargs = mock_engine.query.call_args.kwargs
+        assert kwargs["orderby"] == "usd"
+        assert kwargs["direction"] == "desc"
+        assert kwargs["prefer"] == "oldest"
+
+    def test_unknown_directive_value_warns_and_keeps_parameter(self) -> None:
+        """An unknown value is ignored with a Scryfall-shaped warning; the search still runs."""
+        mock_engine, result = self._engine_search("t:goblin unique:bogus")
+        assert mock_engine.query.call_args.kwargs["unique"] == "card"
+        assert result["warnings"] == ['Unknown unique mode "bogus" was ignored']
+
+    def test_directive_free_search_has_no_warnings_key(self) -> None:
+        """The warnings key appears only when there is something to say."""
+        _, result = self._engine_search("t:goblin")
+        assert "warnings" not in result
+
+    def test_overriding_repeat_warns_with_both_values(self) -> None:
+        """`(cmc=5 prefer:oldest) (cmc=4 prefer:newest)` applies newest and SAYS so.
+
+        The grouped-scope ambiguity from #872: a directive always applies to the whole
+        search, so the losing spelling is named in a warning rather than silently dropped.
+        """
+        mock_engine, result = self._engine_search("(cmc=5 prefer:oldest) (cmc=4 prefer:newest)")
+        assert mock_engine.query.call_args.kwargs["prefer"] == "newest"
+        assert result["warnings"] == ["prefer:newest overrode the earlier prefer:oldest"]
+
+    def test_sort_and_order_spellings_override_each_other(self) -> None:
+        """sort: and order: set the same parameter, so a later one warns about the earlier."""
+        mock_engine, result = self._engine_search("t:goblin sort:usd order:name")
+        assert mock_engine.query.call_args.kwargs["orderby"] == "name"
+        assert result["warnings"] == ["order:name overrode the earlier sort:usd"]
+
+    def test_same_value_repeat_warns_nothing(self) -> None:
+        """Repeating a directive with the same value has nothing surprising to report."""
+        _, result = self._engine_search("t:goblin unique:art unique:art")
+        assert "warnings" not in result
+
+    def test_directive_inside_a_group_warns_about_its_scope(self) -> None:
+        """A directive under an or-group applies globally, and the response says so."""
+        mock_engine, result = self._engine_search("t:goblin or unique:art")
+        assert mock_engine.query.call_args.kwargs["unique"] == "artwork"
+        assert result["warnings"] == ["unique:art applies to the whole search, not only its group"]
+
+    def test_sql_path_receives_effective_values(self) -> None:
+        """The fold happens before dispatch, so the SQL fallback sees the same effective unique."""
+        with (
+            patch.object(self.api_resource.app_context, "setup_complete", lambda: True),
+            self._search_flags(enable_engine=False),
+            patch.object(self.api_resource, "_search_sql", return_value={"cards": [], "total_cards": 0}) as mock_sql,
+        ):
+            result = self.api_resource._search(query="t:goblin unique:art unique:bogus")
+        assert mock_sql.call_args.kwargs["unique"] == UniqueOn.ARTWORK
+        assert result["warnings"] == ['Unknown unique mode "bogus" was ignored']
 
 
 class TestAPIResourceStaticFileServing(unittest.TestCase):

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -689,6 +689,16 @@ class TestSearchQueryDirectives(TestBaseAPIResourceTest):
         assert kwargs["direction"] == "desc"
         assert kwargs["prefer"] == "oldest"
 
+    def test_dir_is_the_short_spelling_of_direction(self) -> None:
+        """`dir:desc` reaches the engine exactly as `direction:desc` does (Scryfall accepts both)."""
+        mock_engine, _ = self._engine_search("t:goblin sort:usd dir:desc")
+        assert mock_engine.query.call_args.kwargs["direction"] == "desc"
+
+    def test_the_two_direction_spellings_override_one_another(self) -> None:
+        """They set one parameter, so the later wins rather than each applying independently."""
+        mock_engine, _ = self._engine_search("t:goblin direction:desc dir:asc")
+        assert mock_engine.query.call_args.kwargs["direction"] == "asc"
+
     def test_unknown_directive_value_warns_and_keeps_parameter(self) -> None:
         """An unknown value is ignored with a Scryfall-shaped warning; the search still runs."""
         mock_engine, result = self._engine_search("t:goblin unique:bogus")


### PR DESCRIPTION
Now a single commit based directly on `main` (rebased over #900/#902/#904; previously stacked on #872, which this supersedes — the alias half lives on main via #900).

## What

Scryfall accepts result-shape directives inside the query string itself — `unique:art`, `sort:usd`, `order:name`, `direction:asc`, `prefer:oldest` — and they take effect there. Here they were a parse error. This PR makes them first-class with no new query parameter: both parsers capture each directive's value, an extraction pass at the rewrite seam strips them from the filter tree, and `_search` folds them over the request parameters **before** the engine/SQL dispatch, so both paths see the same effective values by construction. `unique:` joins the vocabulary, accepting Scryfall's spellings (`cards`, `prints`, `art`) alongside this API's own (`card`, `printing`/`printings`, `artwork`).

## Semantics (each measured against api.scryfall.com, 2026-08-07/08)

| Behavior | Scryfall | This PR |
|---|---|---|
| Inline vs `unique=` param | inline wins | inline wins |
| Repeated directive | last wins (`unique:cards unique:art` → art) | same, **plus a warning naming what was overridden** |
| Unknown value | `warnings: ['Unknown unique mode "bogus" was ignored']`, query still runs | same shape, new `warnings` response key (present only when non-empty) |
| Directive inside `or` | stripped structurally: `t:goblin or unique:art` filters as `t:goblin` + art dedup (563 → 823 on their corpus) | same, **plus a scope warning** — replacing the directive with TRUE would make the containing `or` match everything |
| Negated directive | ignored negation: `-unique:art` ≡ `unique:art` | same |

## The grouped-scope question ("what does `(cmc=5 prefer:oldest) (cmc=4 prefer:newest)` mean?")

Answered by **never being silent** rather than by not supporting the syntax. A directive always applies to the whole search — that's also Scryfall's observed model — and every case where that could surprise adds an explicit response warning:

- **Overriding repeat**: `(cmc=5 prefer:oldest) (cmc=4 prefer:newest)` applies `prefer:newest` and returns `warnings: ["prefer:newest overrode the earlier prefer:oldest"]`. (`sort:`/`order:` set the same parameter, so they warn across spellings too.)
- **Directive inside an or-group or negation** (looks scoped, is not): `t:goblin or unique:art` returns `warnings: ["unique:art applies to the whole search, not only its group"]`.
- **Unknown value**: Scryfall's own message shape, as above.

A repeat of the same value warns nothing — nothing surprising happened. Parenthesized AND groups aren't "groups" for this purpose: conjunction is flat, so `(a sort:x) b` means exactly `a sort:x b`.

Deliberately *not* mirrored: Scryfall silently tolerates an unknown `&unique=` **param**; params here stay strict per `param_binding`'s invalid-input-should-not-200 design — only inline is lenient, since Scryfall-shaped query strings arrive from clients verbatim.

## Validation on the dev stack (2026-08-08, ~97k-card corpus)

| Check | Result |
|---|---|
| `q=howl unique:art` ≡ `q=howl&unique=artwork` | 67 = 67 |
| `!"Lightning Bolt" unique:art` | 29 — matches Scryfall's `unique=art` exactly (29) |
| Inline beats param: `q=!"Lightning Bolt" unique:prints` with `&unique=card` | 62 printings (Scryfall `prints`: 64; the delta is the extras-class printings the corpus excludes) |
| `!"Lightning Bolt" unique:bogus` | 1 result + the unknown-mode warning |
| `t:goblin or unique:art` ≡ `t:goblin&unique=artwork` | 711 = 711 (plain `t:goblin`: 515 cards) |
| `-unique:art` and `unique:cards unique:art` | 29 both — negation ignored, last repeat wins |
| `unique:prints sort:usd direction:desc` vs `asc` | first card $623.15 vs $0.79 |
| `prefer:oldest` | returns the LEA printing |

## Tests

- `api/parsing/tests/test_result_directives.py`: capture order/repeats/nested flags, lowercasing/unquoting, or-stripping, negation, directive-only queries, parenthesized-AND flatness (the `(cmc=5 prefer:oldest) (cmc=4 prefer:newest)` case), parser parity on directives, dangling `unique:` still errors, "uniquely" keeps its name reading.
- `api/tests/test_api_resource.py::TestSearchQueryDirectives`: effective values reach the engine, inline overrides the param, override/scope/unknown warnings each asserted verbatim, same-value repeat stays quiet, SQL fallback receives identical effective values.
- Suites: api + parsing + client 2,599 passed, 19 xfailed (the pinned #903/#904 parity xfails untouched, still strict-xfail); ruff clean. Full numbers and how they were produced are under **Verification** at the end.


---

## Update: `dir:` accepted as the short spelling of `direction:` (c708a37)

Scryfall accepts both inline and they set the same parameter — measured 2026-08-09 against api.scryfall.com, where `dir:desc` and `direction:desc` return the same page, as do `dir:auto` and `direction:auto`. Only `direction:` was recognized here, so a client forwarding a Scryfall-shaped query containing `dir:` had it parsed as a filter rather than stripped as a directive.

The directive vocabulary moves to one `DIRECTIVE_NAMES` list in `nodes.py` that both parsers build from. The pyparsing alternation and the hand parser's membership test were two copies of the same set, and a name added to only one of them is a parity divergence the shared cases cannot catch — a query nobody wrote cannot fail. The list is ordered longest-spelling-first so `direction` wins the alternation outright rather than leaning on the lookahead to reject the `dir` prefix.

`dir` is recorded under its own name rather than rewritten to `direction`, so a repeated-directive warning can quote back what the client actually wrote; both share a slot in `_DIRECTIVE_TABLES` and override one another exactly as `sort`/`order` already do.

Tests: `dir:`/`dir:auto` join the shared directive cases (both parsers, both stripped to nothing); `direct` and `dire` are pinned as name searches, `dir` being a prefix of both `direction` and ordinary words; plus two API tests for `dir:` reaching the engine and losing to a later `direction:`.

Raised while building #912 — `direction:auto` is also the seam the upcoming `dir=auto` support hangs off.



---

## Update: hyphenated directive values reach the hand parser at all (96f083f, d073e45)

`prefer:usd-low` parsed under pyparsing and **raised** under the hand parser. The two disagreed on every hyphenated directive value.

`-` is not a word character to the hand tokenizer, so `usd-low` lexes as WORD MINUS WORD. `parse_directive_primary` consumed a single token after the colon, took `usd`, and left `-low` to fail the parse. pyparsing's `string_value_word` is `\w[\w.-]*`, which takes the whole thing.

That also made the hyphenated spellings unreachable through the hand parser **by any input**, which matters because `_DIRECTIVE_PREFER` enumerates them on purpose: the `PreferOrder` members carry underscores (`usd_low`), so `usd-low` and `usd-high` exist only as those two literal keys, and they are the spellings Scryfall accepts. A table entry no input can reach is not a feature.

Fixed by gluing hyphenated continuations exactly as `parse_text_value` does — same no-space-either-side loop condition, verbatim — and skipping it for a QUOTED value, which is already one token. `prefer:usd-low` now resolves to `PreferOrder.USD_LOW` through both parsers.

Why the suites missed it: no existing case used a hyphenated directive value. The parity tests compare the two parsers on the cases they are given, so a disagreement on a shape nobody wrote cannot fail.

Tests: `test_hyphenated_directive_values_survive_both_parsers` asserts both parsers produce the same directive triple for three hyphenated queries, and fails on the previous hand-parser behavior.

`d073e45` is comment-only: the comment added with the fix pointed at `_text_value`, which exists in neither this repo nor the Workers port — the method it mirrors is `parse_text_value` — and `_DIRECTIVE_PREFER` is now qualified with the module that defines it (`api_resource`, not `api/parsing`, where an unqualified name sends a reader grepping and finding nothing).

### Verification

`96f083f` was pushed having been checked only indirectly, through the Workers port whose parser is a port of this one. That gap is now closed against this repo's own suite (CPython 3.13.7, both native extensions built as CI builds them, Docker up so the testcontainers tests actually ran):

| Command | Result |
|---|---|
| `pytest api/parsing` | 1,725 passed, 19 xfailed |
| `pytest` (full, incl. testcontainers) | **2,599 passed, 19 xfailed, 0 failed, 0 skipped** |
| `ruff check .` | passed |

The bug was also reproduced at the parent commit (`c708a37`) to confirm the description above: hand parser raised on `prefer:usd-low` / `prefer:usd-high`, pyparsing accepted both.

Beyond the suite, a directive sweep of **882 queries** — 6 directive names × 22 values (hyphenated, underscored, dotted, quoted, trailing/leading hyphen, unknown) × 7 surrounding contexts (bare, AND, negated, parenthesized, or-group) — found **0 divergences** between the two parsers. The sweep also confirms the gluing does not over-reach: `order:cmc -t:goblin`, `prefer:usd-low -t:goblin` and `unique:art -is:promo` keep their negation in both parsers, since a `-` with a space before it fails the no-space rule.

Not run: the Rust (`cargo test`) and JS suites, which are separate CI checks and untouched by this change.


---

## Follow-up this PR unblocks: `/cards/search` on #912's stack drops the same directives

Recorded 2026-08-16 from the broad differential sweep. `api/scryfall_compat/routes.py` (#912's
branch, extended by #928) parses the directives and then ignores them, because the fold this PR adds
does not exist yet on that stack. Measured against api.scryfall.com the same day:

| request | Scryfall | that route |
|---|---|---|
| `q=is:foil e:khm` | 285 | 285 |
| `q=is:foil e:khm unique:prints` | **387** | 285 |
| `q=is:foil e:khm unique:prints&unique=cards` | **387** | 285 |
| `q=is:foil e:khm unique:cards&unique=prints` | **285** | 387 |
| `q=… order:cmc&order=name` | sorted by cmc | sorted by name |
| `q=… dir:desc&dir=asc` | descending | ascending |

The directive overrides the query parameter in both directions — the rule this PR already
implements, confirmed independently on the compat surface. When this lands, that route should call
`apply_directives` over `(unique_on, PreferOrder.DEFAULT, orderby, direction)` **before**
`resolve_direction`, and echo the folded values in `next_page` (Scryfall does: `q=t:creature
order:cmc unique:prints` with no order/unique parameters answers a `next_page` carrying
`order=cmc&unique=prints`). #928 has already made that echo resolved-valued so only the fold itself
remains.

Deliberately not fixed by copying these tables onto that branch: two implementations of the same
fold is the drift the shared helper exists to prevent. The Cloudflare port already runs the ported
version of this PR's `apply_directives` on both its `/search` and its `/cards/search` routes, with
tests pinning the precedence table above.
