### PR TITLE
Import+Frontend: Merge Card Faces Into One Searchable Row, and Flip to the Back

### DIFF
--- a/api/card_processing.py
+++ b/api/card_processing.py
@@ -119,7 +119,10 @@ def extract_frame_data_from_raw_card(raw_card: dict) -> dict[str, bool]:
 # on top of colliding on the scryfall_id primary key, which is how the back face silently won
 # until now. Front-face scalars (cmc, mana cost, illustration, image, prices) match Scryfall's
 # own top-level fields, verified on its card objects.
-_FACE_LIST_UNIONS = ("card_types", "card_subtypes")
+# `illustration_ids` is here and not among the front-face scalars because a printing SHOWS every
+# face's art, and the art tags attached to it are the union over all of them (api/tag_import.py).
+# `illustration_id` stays the front's, matching Scryfall's own top-level field.
+_FACE_LIST_UNIONS = ("card_types", "card_subtypes", "illustration_ids")
 _FACE_FLAG_UNIONS = ("card_colors", "card_keywords", "produced_mana")
 _FACE_JOINED_TEXTS = ("oracle_text", "flavor_text", "type_line")
 # Copied per GROUP from the first face that has any of the group, so the numeric columns and
@@ -339,6 +342,12 @@ def preprocess_card(card: dict[str, Any]) -> list[dict[str, Any]]:  # noqa: PLR0
     card["collector_number"] = collector_number
     card["collector_number_int"] = extract_collector_number_int(collector_number)
     card["illustration_id"] = card.get("illustration_id")
+    # Every illustration this row SHOWS, front first. One entry here, and `_FACE_LIST_UNIONS`
+    # below appends the other faces' when the faces merge, so a merged row lists the front's
+    # (which is also `illustration_id`) followed by each later face's. A face carrying no art of
+    # its own -- split, adventure and flip cards put one `illustration_id` on the card and none on
+    # the faces -- inherits the card's here and dedupes back to one on merge.
+    card["illustration_ids"] = [card["illustration_id"]] if card["illustration_id"] else []
 
     # Handle legalities and produced_mana defaults
     card.setdefault("card_legalities", card.get("legalities", {}))

--- a/api/card_processing.py
+++ b/api/card_processing.py
@@ -224,10 +224,19 @@ def preprocess_card(card: dict[str, Any]) -> list[dict[str, Any]]:  # noqa: PLR0
         if not face_rows:
             return []
         merged_row = _merge_processed_faces(face_rows)
-        # The blob is the front face's dict, so every existing top-level read (image_uris, lang,
-        # finishes, ...) keeps meaning "the front". Re-attach the raw faces for consumers that
-        # need per-face data — the back-face image sync in scripts/copy_images_to_s3.py.
-        merged_row["raw_card_blob"]["card_faces"] = card_faces
+        # The blob is the card-level object with its faces re-attached — what Scryfall sent, not a
+        # face promoted to look like a card. Every searchable field is already merged onto the row
+        # above, so the blob has no derivation left to do, and keeping it verbatim is what makes it
+        # answerable: a card object cannot be rebuilt from a face (`card_faces` is gone, `name` and
+        # `type_line` are the front's, and which fields a real card carries at top level varies by
+        # layout — a split card has `mana_cost` and `image_uris` there, a transform card does not).
+        #
+        # The one consumer that read a *face* field off the blob is `image_uris`, which for a
+        # transform card now lives only under `card_faces`; every reader coalesces to
+        # `card_faces->0` (scripts/copy_images_to_s3.py, scripts/prefer_weights.py). Everything else
+        # read from the blob — lang, set_type, games, finishes, frame_effects, image_status,
+        # reserved, game_changer — is card-level and identical either way.
+        merged_row["raw_card_blob"] = copy.deepcopy(card) | {"card_faces": card_faces}
         return [merged_row]
 
     # Single face case - set defaults

--- a/api/card_processing.py
+++ b/api/card_processing.py
@@ -110,13 +110,66 @@ def extract_frame_data_from_raw_card(raw_card: dict) -> dict[str, bool]:
         frame_data[effect.title()] = True
 
     return frame_data
+# Face-merge policy for multi-face cards (#400, #873). Scryfall AND's search predicates at the
+# CARD level, each satisfiable by any face — measured against api.scryfall.com 2026-08-08:
+# `t:sorcery t:land` returns the MDFC lands (no single face is both), o: conjunctions match
+# across faces (Ral, Monsoon Mage), and `c:b` matches Westvale Abbey's back-face-only color.
+# One row per printing carrying any-face unions reproduces those semantics directly; one row
+# per face would instead break every cross-face conjunction (no face-row satisfies both terms)
+# on top of colliding on the scryfall_id primary key, which is how the back face silently won
+# until now. Front-face scalars (cmc, mana cost, illustration, image, prices) match Scryfall's
+# own top-level fields, verified on its card objects.
+_FACE_LIST_UNIONS = ("card_types", "card_subtypes")
+_FACE_FLAG_UNIONS = ("card_colors", "card_keywords", "produced_mana")
+_FACE_JOINED_TEXTS = ("oracle_text", "flavor_text", "type_line")
+# Copied per GROUP from the first face that has any of the group, so the numeric columns and
+# their _text twins always describe the same face (the schema's check constraints couple them).
+_FACE_STAT_GROUPS = (
+    ("creature_power", "creature_toughness", "creature_power_text", "creature_toughness_text"),
+    ("planeswalker_loyalty", "planeswalker_loyalty_text"),
+)
+# Joins face texts. "\n" so substring/regex matches cannot span faces in practice (`.` does not
+# cross newlines), "//" because that is the face separator Scryfall itself renders.
+_FACE_TEXT_SEPARATOR = "\n//\n"
+
+
+def _merge_processed_faces(faces: list[dict[str, Any]]) -> dict[str, Any]:
+    """Collapse fully-processed per-face rows into the card's single searchable row.
+
+    The first face (the front) supplies the row and with it every identity and display
+    scalar; later faces fold in per the policy tables above. Known residual, sized in
+    the tests: when several faces carry a stat group (Brutal Cathar's 2/2 // 3/3), only
+    the first face's values are searchable — Scryfall also matches the back's.
+
+    Args:
+        faces: Non-empty list of processed rows, one per surviving face, front first.
+
+    Returns:
+        The merged row (the front face's dict, mutated in place).
+    """
+    merged, *rest = faces
+    for face in rest:
+        for key in _FACE_LIST_UNIONS:
+            seen = merged[key]
+            seen.extend(value for value in face[key] if value not in seen)
+        for key in _FACE_FLAG_UNIONS:
+            merged[key].update(face[key])
+        for key in _FACE_JOINED_TEXTS:
+            parts = [part for part in (merged.get(key), face.get(key)) if part]
+            merged[key] = (" // " if key == "type_line" else _FACE_TEXT_SEPARATOR).join(parts)
+        for group in _FACE_STAT_GROUPS:
+            if all(merged.get(field) is None for field in group) and any(face.get(field) is not None for field in group):
+                for field in group:
+                    merged[field] = face.get(field)
+    return merged
 
 
 def preprocess_card(card: dict[str, Any]) -> list[dict[str, Any]]:  # noqa: PLR0915,C901,PLR0912
     """Preprocess a card to remove invalid cards and add necessary fields.
 
-    For Double-Faced Cards (DFCs), returns multiple dictionaries (one per face).
-    For single-faced cards, returns a list with one dictionary.
+    A multi-face card (transform, MDFC, split, adventure, flip) is merged into ONE row
+    carrying the front face's identity and every face's searchable data — see
+    `_merge_processed_faces`. Single-faced cards return a list with one dictionary.
     Returns an empty list for invalid/filtered cards.
     """
     if not set(card["legalities"].values()) & {"legal", "restricted"}:
@@ -154,21 +207,28 @@ def preprocess_card(card: dict[str, Any]) -> list[dict[str, Any]]:  # noqa: PLR0
         # Recursive case: processing a face
         card["face_name"] = card.get("name")
 
-    # Handle cards with card_faces (DFCs)
+    # Handle cards with card_faces (DFCs): process each face through the full pipeline below,
+    # then collapse the per-face rows into the card's one searchable row.
     card_faces = card.get("card_faces")
     if card_faces:
         for creature_attribute in ["creature_power", "creature_toughness"]:
             card.pop(creature_attribute, None)
             card.pop(f"{creature_attribute}_text", None)
-        processed_faces = []
-        for face_idx, face_data in enumerate(card_faces, start=1):
+        face_rows = []
+        for face_data in card_faces:
             # Merge card-level data with face-specific data
-            # Precedence: face_idx override > face_data (name, type_line, etc.) > card (legalities, games, etc.)
-            merged = copy.deepcopy(card) | face_data | {"face_idx": face_idx}
+            # Precedence: face_data (name, type_line, etc.) > card (legalities, games, etc.)
+            merged = copy.deepcopy(card) | face_data
             merged.pop("card_faces", None)  # Don't keep recursing
-            processed_faces_for_face = preprocess_card(merged)
-            processed_faces.extend(processed_faces_for_face)
-        return processed_faces
+            face_rows.extend(preprocess_card(merged))
+        if not face_rows:
+            return []
+        merged_row = _merge_processed_faces(face_rows)
+        # The blob is the front face's dict, so every existing top-level read (image_uris, lang,
+        # finishes, ...) keeps meaning "the front". Re-attach the raw faces for consumers that
+        # need per-face data — the back-face image sync in scripts/copy_images_to_s3.py.
+        merged_row["raw_card_blob"]["card_faces"] = card_faces
+        return [merged_row]
 
     # Single face case - set defaults
     card.setdefault("face_name", card.get("name"))

--- a/api/db/2026-08-16-01-illustration-ids.sql
+++ b/api/db/2026-08-16-01-illustration-ids.sql
@@ -1,0 +1,46 @@
+-- Every illustration a printing SHOWS, front first -- not just the front face's.
+--
+-- `illustration_id` is the FRONT face's once faces merge into one row (#894, matching Scryfall's
+-- own top-level field), so a double-faced card's back art had no column at all. `card_art_tags` is
+-- attached by joining on it (api/tag_import.py), which made a tag that exists only on the back art
+-- unreachable by any query: `arttag:snow e:khm` is 75 on Scryfall and was 73 here, missing
+-- Birgi // Harnfel and Esika // The Prismatic Bridge.
+--
+-- jsonb rather than uuid[] to match the other list columns (card_types, card_subtypes) and, more to
+-- the point, because api/db/bulk_upsert.py maps a column's declared type through _PG_TYPE: jsonb is
+-- extracted with `obj->`, while an ARRAY column falls through to text and would fail the insert.
+ALTER TABLE magic.cards ADD COLUMN illustration_ids jsonb DEFAULT '[]'::jsonb NOT NULL;
+ALTER TABLE magic.cards ADD CONSTRAINT illustration_ids_must_be_array CHECK (jsonb_typeof(illustration_ids) = 'array');
+
+COMMENT ON COLUMN magic.cards.illustration_ids IS
+    'Every illustration this printing shows, front first, deduped: illustration_id plus each face''s. '
+    'The join key for card_art_tags -- a card answers for every face it shows, not just its front.';
+
+-- Backfill from what the row already carries, so the next art-tag import finds a populated column
+-- whether or not a card import has run since. A `card_faces` array in the blob is what a merged
+-- multi-face row looks like; every other row backfills to the single-element list its
+-- illustration_id already implies, which is exactly what preprocess_card writes for it.
+WITH shown AS (
+    SELECT
+        c.scryfall_id,
+        face.illustration_id,
+        MIN(face.position) AS position
+    FROM magic.cards AS c
+    CROSS JOIN LATERAL (
+        SELECT c.illustration_id::text AS illustration_id, 0 AS position
+        UNION ALL
+        SELECT element.value->>'illustration_id', element.position::int
+        FROM jsonb_array_elements(COALESCE(c.raw_card_blob->'card_faces', '[]'::jsonb))
+            WITH ORDINALITY AS element(value, position)
+    ) AS face
+    WHERE face.illustration_id IS NOT NULL
+    GROUP BY c.scryfall_id, face.illustration_id
+)
+UPDATE magic.cards
+SET illustration_ids = shown_ids.illustration_ids
+FROM (
+    SELECT scryfall_id, jsonb_agg(illustration_id ORDER BY position) AS illustration_ids
+    FROM shown
+    GROUP BY scryfall_id
+) AS shown_ids
+WHERE magic.cards.scryfall_id = shown_ids.scryfall_id;

--- a/api/parsing/db_info.py
+++ b/api/parsing/db_info.py
@@ -320,6 +320,7 @@ CARD_SUPERTYPES = {
 
 CARD_TYPES = {
     "Artifact",
+    "Battle",  # reaches the corpus once faces merge (#400): every battle is a transform front
     "Conspiracy",
     "Creature",
     "Enchantment",

--- a/api/parsing/tests/test_pyparsing_parser.py
+++ b/api/parsing/tests/test_pyparsing_parser.py
@@ -1257,3 +1257,24 @@ def test_hyphenated_words_edge_cases_fail(invalid_query: str) -> None:
     """
     with pytest.raises(ValueError, match="Failed to parse query"):
         parsing.parse_search_query(invalid_query)
+
+
+class TestBattleTypeRouting:
+    """`t:battle` routes to card_types, matching every other card type.
+
+    Battle was absent from CARD_TYPES, so it fell through to the subtype arm on both the
+    SQL and engine paths — invisible while the corpus stored every battle as its back face
+    (#400), a guaranteed zero-match once the face merge put Battle into card_types.
+    """
+
+    def test_battle_routes_like_a_card_type(self) -> None:
+        """t:battle generates card_types SQL binding ['Battle'], as t:creature does for its type."""
+        sql, params = parsing.generate_sql_query(parsing.parse_scryfall_query("t:battle"))
+        assert "card_types" in sql
+        assert "card_subtypes" not in sql
+        assert ["Battle"] in params.values()
+
+    def test_siege_still_routes_as_a_subtype(self) -> None:
+        """t:siege stays on the subtype arm; only the card type moved."""
+        siege_sql = str(parsing.generate_sql_query(parsing.parse_scryfall_query("t:siege")))
+        assert "card_subtypes" in siege_sql

--- a/api/static/app.js
+++ b/api/static/app.js
@@ -1038,7 +1038,12 @@ class CardSearch {
     button.className = 'card-flip-button';
     button.title = 'Transform';
     button.setAttribute('aria-label', 'Show other face');
-    button.textContent = '⟳';
+    button.setAttribute('aria-pressed', 'false');
+    // An SVG, not a text glyph: a glyph's ink box is not its em box, so no amount of
+    // flex centring puts it in the middle of the disc. currentColor means the inverted
+    // back-face state restyles it with no extra rule.
+    button.innerHTML =
+      '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" focusable="false"><path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" /></svg>';
     button.addEventListener('click', event => {
       event.preventDefault();
       event.stopPropagation();
@@ -1064,6 +1069,14 @@ class CardSearch {
     }
     const nextFace = faceHolder.dataset.shownFace === '2' ? 1 : 2;
     faceHolder.dataset.shownFace = String(nextFace);
+    // The button inverts while the back is showing: once the art has changed it is
+    // the only thing that still says which face this is. Toggled immediately, not
+    // inside the timeout, so the control answers the click rather than lagging it.
+    const flipButton = faceHolder.querySelector('.card-flip-button');
+    if (flipButton) {
+      flipButton.classList.toggle('showing-back', nextFace === 2);
+      flipButton.setAttribute('aria-pressed', nextFace === 2 ? 'true' : 'false');
+    }
     img.classList.add('card-image-flipping');
     setTimeout(() => {
       img.src = this.buildImageUrl(card, size, nextFace);

--- a/api/static/app.js
+++ b/api/static/app.js
@@ -1032,6 +1032,33 @@ class CardSearch {
     }
   }
 
+  // The button is positioned as a percentage of the CARD IMAGE, so it needs a
+  // containing block that is exactly the image's box. Neither natural parent is:
+  // a grid tile is the image plus the name/type/text rows, and the modal's image
+  // wrapper is a flex area far wider than the picture inside it — which is how
+  // the button ended up floating in the margin beside a large card.
+  //
+  // The frame cannot be the <a> that already wraps the image: a <button> inside
+  // an <a> is interactive content nested in interactive content, which is invalid
+  // and breaks keyboard traversal. So JS inserts a plain <div> around the link.
+  // Injecting it here rather than in the server markup keeps the no-JS render —
+  // and its parity fixture — untouched, and the frame only ever exists on the
+  // cards that actually get a button.
+  frameFor(container, imageSelector) {
+    const existing = container.querySelector('.card-image-frame');
+    if (existing) return existing;
+    const img = container.querySelector(imageSelector);
+    if (!img) return null;
+    // Frame the link if the image is wrapped in one, so the whole clickable area
+    // stays inside the frame; otherwise frame the bare image.
+    const node = img.closest('a') || img;
+    const frame = document.createElement('div');
+    frame.className = 'card-image-frame';
+    node.parentNode.insertBefore(frame, node);
+    frame.appendChild(node);
+    return frame;
+  }
+
   createFlipButton(onFlip) {
     const button = document.createElement('button');
     button.type = 'button';
@@ -1058,8 +1085,12 @@ class CardSearch {
     if (!item || item.querySelector('.card-flip-button')) {
       return;
     }
-    item.appendChild(
-      this.createFlipButton(() => this.flipCardImage(item.querySelector('.card-image'), card, item, '388', true))
+    const frame = this.frameFor(item, '.card-image');
+    if (!frame) {
+      return;
+    }
+    frame.appendChild(
+      this.createFlipButton(() => this.flipCardImage(item.querySelector('.card-image'), card, frame, '388', true))
     );
   }
 
@@ -1262,9 +1293,13 @@ class CardSearch {
       if (!wrapper || wrapper.querySelector('.card-flip-button')) {
         return;
       }
-      wrapper.appendChild(
+      const frame = this.frameFor(wrapper, '.modal-image');
+      if (!frame) {
+        return;
+      }
+      frame.appendChild(
         this.createFlipButton(() =>
-          this.flipCardImage(wrapper.querySelector('.modal-image'), card, wrapper, '745', false)
+          this.flipCardImage(wrapper.querySelector('.modal-image'), card, frame, '745', false)
         )
       );
     });

--- a/api/static/app.js
+++ b/api/static/app.js
@@ -94,6 +94,7 @@ class CardSearch {
     this.currentRequestUrl = null; // URL of the in-flight request, if any
     this.imageObserver = null;
     this.cardsData = new Map(); // Store card data by ID
+    this.backFaceKeys = new Map(); // "set/collector" -> bool, cached back-face image probes
     this.lastCompletedUrl = null; // URL whose results are currently displayed; null when results are cleared
     this.isAscending = true; // Track order direction
     this.currentCardCount = 0; // Track current number of cards displayed for resize handling
@@ -938,6 +939,9 @@ class CardSearch {
         .join('');
     }
 
+    // Runs against the DOM, so it enhances SSR-rendered and JS-rendered cards alike.
+    this.enhanceDoubleFacedCards();
+
     // Record arrival time; we only push this state when leaving if they stayed > DWELL_MS and it's not already saved (updateURL)
     const url = this.buildCurrentSearchUrl();
     window.history.replaceState({ arrivalTime: Date.now() }, '', url);
@@ -984,9 +988,90 @@ class CardSearch {
     this.resultsContainer.style.gridTemplateColumns = `repeat(${actualColumns}, 1fr)`;
   }
 
-  buildImageUrl(card, size) {
-    const face = card.face_idx || 1;
-    return `https://d1hot9ps2xugbc.cloudfront.net/img/${card.set_code}/${card.collector_number}/${face}/${size}.webp`;
+  buildImageUrl(card, size, face) {
+    const resolvedFace = face || card.face_idx || 1;
+    return `https://d1hot9ps2xugbc.cloudfront.net/img/${card.set_code}/${card.collector_number}/${resolvedFace}/${size}.webp`;
+  }
+
+  buildSrcset(card, face) {
+    return ['280', '388', '538', '745'].map(size => `${this.buildImageUrl(card, size, face)} ${size}w`).join(', ');
+  }
+
+  // ── Double-faced cards: flip button (progressive enhancement) ──
+  // The rendered card HTML is shared with the no-JS server renderer (parity fixture), so the
+  // flip button is injected AFTER render rather than templated in. A card gets one when a
+  // face-2 image exists on the CDN — which is exactly the set of cards with a physical back
+  // face (transform/MDFC), since the image sync only uploads face 2 for those. Split and
+  // adventure cards share a "//" name but have no face-2 image, so they correctly get none.
+
+  cardBackFaceKey(card) {
+    return `${card.set_code}/${card.collector_number}`;
+  }
+
+  probeBackFace(card, onExists) {
+    if (!card.name || !card.name.includes(' // ') || !card.set_code || !card.collector_number) {
+      return;
+    }
+    const key = this.cardBackFaceKey(card);
+    if (this.backFaceKeys.has(key)) {
+      if (this.backFaceKeys.get(key)) onExists();
+      return;
+    }
+    const probe = new Image();
+    probe.onload = () => {
+      this.backFaceKeys.set(key, true);
+      onExists();
+    };
+    probe.onerror = () => this.backFaceKeys.set(key, false);
+    probe.src = this.buildImageUrl(card, '280', 2);
+  }
+
+  enhanceDoubleFacedCards() {
+    for (const [cardId, card] of this.cardsData) {
+      this.probeBackFace(card, () => this.attachGridFlipButton(cardId, card));
+    }
+  }
+
+  createFlipButton(onFlip) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'card-flip-button';
+    button.title = 'Transform';
+    button.setAttribute('aria-label', 'Show other face');
+    button.textContent = '⟳';
+    button.addEventListener('click', event => {
+      event.preventDefault();
+      event.stopPropagation();
+      onFlip();
+    });
+    return button;
+  }
+
+  attachGridFlipButton(cardId, card) {
+    // cardId is the numeric grid index (displayCards), safe to interpolate directly.
+    const item = this.resultsContainer && this.resultsContainer.querySelector(`.card-item[data-card-id="${cardId}"]`);
+    if (!item || item.querySelector('.card-flip-button')) {
+      return;
+    }
+    item.appendChild(
+      this.createFlipButton(() => this.flipCardImage(item.querySelector('.card-image'), card, item, '388', true))
+    );
+  }
+
+  flipCardImage(img, card, faceHolder, size, withSrcset) {
+    if (!img) {
+      return;
+    }
+    const nextFace = faceHolder.dataset.shownFace === '2' ? 1 : 2;
+    faceHolder.dataset.shownFace = String(nextFace);
+    img.classList.add('card-image-flipping');
+    setTimeout(() => {
+      img.src = this.buildImageUrl(card, size, nextFace);
+      if (withSrcset) {
+        img.srcset = this.buildSrcset(card, nextFace);
+      }
+      img.classList.remove('card-image-flipping');
+    }, 150);
   }
 
   createCardHTML(card, index, isFirstRow = false) {
@@ -1157,6 +1242,19 @@ class CardSearch {
         })()}
       </div>
     `;
+
+    // Flip button for cards with a physical back face (cached probe from the grid, or fresh)
+    this.probeBackFace(card, () => {
+      const wrapper = modalContent.querySelector('.modal-image-wrapper');
+      if (!wrapper || wrapper.querySelector('.card-flip-button')) {
+        return;
+      }
+      wrapper.appendChild(
+        this.createFlipButton(() =>
+          this.flipCardImage(wrapper.querySelector('.modal-image'), card, wrapper, '745', false)
+        )
+      );
+    });
 
     // Show modal
     modalOverlay.style.display = 'flex';

--- a/api/static/app.test.js
+++ b/api/static/app.test.js
@@ -574,3 +574,70 @@ describe('CardSearch getColumnsFromViewportWidth', () => {
     expect(search.getColumnsFromViewportWidth()).toBe(expectedColumns);
   });
 });
+
+describe('CardSearch double-faced flip', () => {
+  const dfc = { name: 'Front // Back', set_code: 'mid', collector_number: '5' };
+
+  test('buildImageUrl face parameter overrides the card face', () => {
+    expect(search.buildImageUrl(dfc, '388')).toContain('/mid/5/1/388.webp');
+    expect(search.buildImageUrl(dfc, '388', 2)).toContain('/mid/5/2/388.webp');
+  });
+
+  test('buildSrcset builds all four sizes for the requested face', () => {
+    const srcset = search.buildSrcset(dfc, 2);
+    for (const size of ['280', '388', '538', '745']) {
+      expect(srcset).toContain(`/mid/5/2/${size}.webp ${size}w`);
+    }
+  });
+
+  test('probeBackFace skips cards without a // name', () => {
+    const onExists = jest.fn();
+    search.probeBackFace({ name: 'Lightning Bolt', set_code: 'm15', collector_number: '1' }, onExists);
+    expect(onExists).not.toHaveBeenCalled();
+    expect(search.backFaceKeys.size).toBe(0);
+  });
+
+  test('probeBackFace uses the cached probe result', () => {
+    const onExists = jest.fn();
+    search.backFaceKeys.set('mid/5', true);
+    search.probeBackFace(dfc, onExists);
+    expect(onExists).toHaveBeenCalledTimes(1);
+
+    search.backFaceKeys.set('mid/5', false);
+    search.probeBackFace(dfc, onExists);
+    expect(onExists).toHaveBeenCalledTimes(1);
+  });
+
+  test('flip button toggles the image between faces', () => {
+    jest.useFakeTimers();
+    try {
+      search.resultsContainer.innerHTML =
+        '<div class="card-item" data-card-id="0"><img class="card-image" src="x" srcset="y" /></div>';
+      search.attachGridFlipButton('0', dfc);
+
+      const item = search.resultsContainer.querySelector('.card-item');
+      const button = item.querySelector('.card-flip-button');
+      expect(button).not.toBeNull();
+
+      button.click();
+      jest.runAllTimers();
+      const img = item.querySelector('.card-image');
+      expect(img.src).toContain('/mid/5/2/388.webp');
+      expect(img.srcset).toContain('/mid/5/2/745.webp 745w');
+
+      button.click();
+      jest.runAllTimers();
+      expect(img.src).toContain('/mid/5/1/388.webp');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('attachGridFlipButton injects at most one button', () => {
+    search.resultsContainer.innerHTML =
+      '<div class="card-item" data-card-id="0"><img class="card-image" src="x" /></div>';
+    search.attachGridFlipButton('0', dfc);
+    search.attachGridFlipButton('0', dfc);
+    expect(search.resultsContainer.querySelectorAll('.card-flip-button')).toHaveLength(1);
+  });
+});

--- a/api/static/card.js
+++ b/api/static/card.js
@@ -26,7 +26,12 @@ function attachFlipButton(container, card) {
     button.className = 'card-flip-button';
     button.title = 'Transform';
     button.setAttribute('aria-label', 'Show other face');
-    button.textContent = '⟳';
+    button.setAttribute('aria-pressed', 'false');
+    // An SVG, not a text glyph: a glyph's ink box is not its em box, so no amount of
+    // flex centring puts it in the middle of the disc. currentColor means the inverted
+    // back-face state restyles it with no extra rule.
+    button.innerHTML =
+      '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" focusable="false"><path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" /></svg>';
     button.addEventListener('click', event => {
       event.preventDefault();
       event.stopPropagation();
@@ -34,6 +39,10 @@ function attachFlipButton(container, card) {
       if (!img) return;
       const nextFace = wrapper.dataset.shownFace === '2' ? 1 : 2;
       wrapper.dataset.shownFace = String(nextFace);
+      // Inverted while the back is showing, toggled now rather than after the
+      // transition so the control answers the click.
+      button.classList.toggle('showing-back', nextFace === 2);
+      button.setAttribute('aria-pressed', nextFace === 2 ? 'true' : 'false');
       img.classList.add('card-image-flipping');
       setTimeout(() => {
         img.src = buildImageUrl(card, '745', nextFace);

--- a/api/static/card.js
+++ b/api/static/card.js
@@ -21,6 +21,18 @@ function attachFlipButton(container, card) {
   probe.onload = () => {
     const wrapper = container.querySelector('.modal-image-wrapper');
     if (!wrapper || wrapper.querySelector('.card-flip-button')) return;
+    // A frame that hugs the image, so the button's percentage offsets resolve
+    // against the picture rather than the flex area around it. See app.js.
+    const img = wrapper.querySelector('.modal-image');
+    if (!img) return;
+    let frame = wrapper.querySelector('.card-image-frame');
+    if (!frame) {
+      const node = img.closest('a') || img;
+      frame = document.createElement('div');
+      frame.className = 'card-image-frame';
+      node.parentNode.insertBefore(frame, node);
+      frame.appendChild(node);
+    }
     const button = document.createElement('button');
     button.type = 'button';
     button.className = 'card-flip-button';
@@ -49,7 +61,7 @@ function attachFlipButton(container, card) {
         img.classList.remove('card-image-flipping');
       }, 150);
     });
-    wrapper.appendChild(button);
+    frame.appendChild(button);
   };
   probe.src = buildImageUrl(card, '280', 2);
 }

--- a/api/static/card.js
+++ b/api/static/card.js
@@ -7,9 +7,42 @@ function escapeHtml(str) {
   return String(str).replace(HTML_ESCAPE_RE, c => HTML_ESCAPE_MAP[c]);
 }
 
-function buildImageUrl(card, size) {
-  const face = card.face_idx || 1;
-  return `https://d1hot9ps2xugbc.cloudfront.net/img/${card.set_code}/${card.collector_number}/${face}/${size}.webp`;
+function buildImageUrl(card, size, face) {
+  const resolvedFace = face || card.face_idx || 1;
+  return `https://d1hot9ps2xugbc.cloudfront.net/img/${card.set_code}/${card.collector_number}/${resolvedFace}/${size}.webp`;
+}
+
+// Flip button for double-faced cards, mirroring the search page's progressive enhancement:
+// shown only when a face-2 image exists on the CDN (transform/MDFC backs; split and
+// adventure cards have no back image and correctly get no button).
+function attachFlipButton(container, card) {
+  if (!card.name || !card.name.includes(' // ') || !card.set_code || !card.collector_number) return;
+  const probe = new Image();
+  probe.onload = () => {
+    const wrapper = container.querySelector('.modal-image-wrapper');
+    if (!wrapper || wrapper.querySelector('.card-flip-button')) return;
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'card-flip-button';
+    button.title = 'Transform';
+    button.setAttribute('aria-label', 'Show other face');
+    button.textContent = '⟳';
+    button.addEventListener('click', event => {
+      event.preventDefault();
+      event.stopPropagation();
+      const img = wrapper.querySelector('.modal-image');
+      if (!img) return;
+      const nextFace = wrapper.dataset.shownFace === '2' ? 1 : 2;
+      wrapper.dataset.shownFace = String(nextFace);
+      img.classList.add('card-image-flipping');
+      setTimeout(() => {
+        img.src = buildImageUrl(card, '745', nextFace);
+        img.classList.remove('card-image-flipping');
+      }, 150);
+    });
+    wrapper.appendChild(button);
+  };
+  probe.src = buildImageUrl(card, '280', 2);
 }
 
 const MANA_SYMBOLS = new Map([
@@ -205,6 +238,7 @@ async function main() {
   const cardFace = document.getElementById('card-face');
   cardFace.innerHTML = renderCardFace(card);
   cardFace.style.display = '';
+  attachFlipButton(cardFace, card);
   document.getElementById('card-loading').style.display = 'none';
 
   try {

--- a/api/static/styles.css
+++ b/api/static/styles.css
@@ -356,6 +356,7 @@ body {
   cursor: pointer;
   display: flex;
   flex-direction: column;
+  position: relative; /* anchors the injected .card-flip-button over the image */
   height: 100%;
   width: 100%;
   min-width: 0;
@@ -527,6 +528,44 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+  position: relative; /* anchors the injected .card-flip-button over the image */
+}
+
+/* Flip button for double-faced cards, injected by JS when a back-face image exists.
+   Sits over the card image's top-right corner, like Scryfall's transform button. */
+.card-flip-button {
+  position: absolute;
+  top: 1.6em;
+  right: 1.6em;
+  z-index: 2;
+  width: 2.2em;
+  height: 2.2em;
+  border: none;
+  border-radius: 50%;
+  background: var(--color-card-background);
+  color: var(--color-text-primary);
+  box-shadow: 0 2px 8px var(--color-shadow-dark);
+  font-size: 1em;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0.85;
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
+}
+
+.card-flip-button:hover {
+  opacity: 1;
+  transform: rotate(180deg);
+}
+
+.card-image-flipping {
+  transform: rotateY(90deg);
+}
+
+.card-image,
+.modal-image {
+  transition: transform 0.15s ease;
 }
 
 .modal-image-link {

--- a/api/static/styles.css
+++ b/api/static/styles.css
@@ -360,12 +360,6 @@ body {
   width: 100%;
   min-width: 0;
   overflow: hidden;
-  /* Anchors the injected .card-flip-button, and makes the tile a query container
-     so that button can be placed against the ARTWORK rather than against the
-     tile. The two differ: the tile is the image PLUS the name, type and text
-     rows, so a percentage offset measured from it lands well below the art. */
-  position: relative;
-  container-type: inline-size;
 }
 
 .card-item:hover {
@@ -544,9 +538,8 @@ body {
   position: absolute;
   /* NOT a corner. Scryfall places it over the right edge of the artwork about a
      quarter of the way down — roughly where the transform icon sits on the
-     printed card. These percentages are correct wherever the containing block
-     is the image alone (the modal); the grid overrides them below, because
-     there the containing block is the whole tile. */
+     printed card. Percentages OF .card-image-frame, which hugs the image, so
+     they mean the same thing in a grid tile and in a full-size modal. */
   top: 26%;
   left: 75%;
   z-index: 2;
@@ -579,18 +572,6 @@ body {
   background: #343242;
   border-color: #fff;
   color: #fff;
-}
-
-/* In the results grid the containing block is the whole tile, so a plain
-   percentage would measure the image PLUS the text rows and drop the button
-   into the card body. A Magic card's art has a fixed 488x680 aspect, so the
-   image's height is 1.3934x the tile's content width — which container units
-   can express exactly: 26% of that height is 36.23cqw, and 0.8em is the tile's
-   padding. The modal keeps the plain percentages above, because its wrapper
-   holds the image and nothing else. */
-.card-item .card-flip-button {
-  top: calc(0.8em + 36.23cqw);
-  left: calc(0.8em + 75cqw);
 }
 
 /* 22px inside the 44px disc. Scryfall insets its icon by 7px, but its artwork
@@ -628,6 +609,20 @@ body {
 
 .card-image-flipping {
   transform: rotateY(90deg);
+}
+
+/* Hugs the card image so the flip button can be positioned as a percentage OF
+   THE IMAGE. Injected by JS alongside the button, never present in the server
+   render. Neither natural parent works: a grid tile also contains the name,
+   type and text rows, and the modal's image wrapper is a flex area much wider
+   than the picture — which is how the button ended up beside a large card
+   rather than on it. fit-content makes the box the image's box in both. */
+.card-image-frame {
+  position: relative;
+  width: fit-content;
+  max-width: 100%;
+  margin-inline: auto;
+  line-height: 0;
 }
 
 .card-image,

--- a/api/static/styles.css
+++ b/api/static/styles.css
@@ -356,11 +356,16 @@ body {
   cursor: pointer;
   display: flex;
   flex-direction: column;
-  position: relative; /* anchors the injected .card-flip-button over the image */
   height: 100%;
   width: 100%;
   min-width: 0;
   overflow: hidden;
+  /* Anchors the injected .card-flip-button, and makes the tile a query container
+     so that button can be placed against the ARTWORK rather than against the
+     tile. The two differ: the tile is the image PLUS the name, type and text
+     rows, so a percentage offset measured from it lands well below the art. */
+  position: relative;
+  container-type: inline-size;
 }
 
 .card-item:hover {
@@ -533,30 +538,92 @@ body {
 
 /* Flip button for double-faced cards, injected by JS when a back-face image exists.
    Sits over the card image's top-right corner, like Scryfall's transform button. */
+/* Geometry, colours and timing taken from Scryfall's own
+   .card-grid-item-transform-button, so the control reads as the same control. */
 .card-flip-button {
   position: absolute;
-  top: 1.6em;
-  right: 1.6em;
+  /* NOT a corner. Scryfall places it over the right edge of the artwork about a
+     quarter of the way down — roughly where the transform icon sits on the
+     printed card. These percentages are correct wherever the containing block
+     is the image alone (the modal); the grid overrides them below, because
+     there the containing block is the whole tile. */
+  top: 26%;
+  left: 75%;
   z-index: 2;
-  width: 2.2em;
-  height: 2.2em;
-  border: none;
-  border-radius: 50%;
-  background: var(--color-card-background);
-  color: var(--color-text-primary);
-  box-shadow: 0 2px 8px var(--color-shadow-dark);
-  font-size: 1em;
+  box-sizing: border-box;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* White disc, dark ring — it has to read against both a black card border and
+     bright artwork, and inverting to a dark fill loses it against the border. */
+  border: 2px solid #343242;
+  border-radius: 100%;
+  background: #fff;
+  color: #343242;
   line-height: 1;
   cursor: pointer;
-  opacity: 0.85;
+  /* Always present, dimmed. Revealing on hover would make it undiscoverable on
+     touch, where there is no hover at all — and Scryfall does not hide it either. */
+  opacity: 0.6;
   transition:
-    opacity 0.15s ease,
-    transform 0.15s ease;
+    background-color 200ms linear,
+    opacity 50ms linear;
 }
 
-.card-flip-button:hover {
+/* Inverted while the BACK face is showing (Scryfall's `.spooky`). The button is
+   the only thing on screen that says which face you are looking at once the art
+   has changed, so it carries the state rather than just the action. */
+.card-flip-button.showing-back {
+  background: #343242;
+  border-color: #fff;
+  color: #fff;
+}
+
+/* In the results grid the containing block is the whole tile, so a plain
+   percentage would measure the image PLUS the text rows and drop the button
+   into the card body. A Magic card's art has a fixed 488x680 aspect, so the
+   image's height is 1.3934x the tile's content width — which container units
+   can express exactly: 26% of that height is 36.23cqw, and 0.8em is the tile's
+   padding. The modal keeps the plain percentages above, because its wrapper
+   holds the image and nothing else. */
+.card-item .card-flip-button {
+  top: calc(0.8em + 36.23cqw);
+  left: calc(0.8em + 75cqw);
+}
+
+/* 22px inside the 44px disc. Scryfall insets its icon by 7px, but its artwork
+   carries padding inside its own viewBox; this outline stroke runs to the edge
+   of the 24-unit box, so matching their inset makes a visibly bigger mark.
+   Matching the resulting INK is what makes it read the same.
+   display:block drops the inline baseline gap, which is what otherwise leaves
+   an SVG sitting a pixel or two high in a flex-centred button. */
+.card-flip-button svg {
+  display: block;
+  width: 22px;
+  height: 22px;
+}
+
+.card-flip-button:hover,
+.card-flip-button:active,
+.card-flip-button:focus-visible {
   opacity: 1;
-  transform: rotate(180deg);
+}
+
+.card-flip-button:focus-visible {
+  outline: 2px solid #343242;
+  outline-offset: 2px;
+}
+
+.card-flip-button.showing-back:focus-visible {
+  outline-color: #fff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card-flip-button {
+    transition: none;
+  }
 }
 
 .card-image-flipping {

--- a/api/tag_import.py
+++ b/api/tag_import.py
@@ -13,6 +13,8 @@ from psycopg.types.json import Jsonb
 from api.scryfall_bulk_data_fetcher import BulkDataKey, ScryfallBulkDataFetcher
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     import psycopg
     import psycopg_pool
 
@@ -141,6 +143,54 @@ def _sync_card_tags(
     return cards_updated, len(to_clear)
 
 
+def _fetch_illustrations_shown(conn: psycopg.Connection) -> list[tuple[str, list[str]]]:
+    """Return (scryfall_id, illustration_ids) for every card that shows any illustration.
+
+    Narrow on purpose: `illustration_ids` is a small maintained column (api/card_processing.py), so
+    this reads no `raw_card_blob` and detoasts nothing. Cards showing no illustration are excluded
+    because they can never carry an art tag, which keeps the result at the size of the tagged
+    corpus rather than the whole table.
+    """
+    with conn.cursor() as cursor:
+        cursor.execute("SELECT scryfall_id, illustration_ids FROM magic.cards WHERE illustration_ids <> '[]'::jsonb")
+        return [(str(row["scryfall_id"]), row["illustration_ids"]) for row in cursor.fetchall()]
+
+
+def _union_art_tags(
+    illustrations_shown: Iterable[tuple[str, list[str]]],
+    illustration_id_to_tags: dict[str, dict[str, bool]],
+) -> dict[str, dict[str, bool]]:
+    """Map each card to the UNION of the art tags of every illustration it shows.
+
+    A printing shows all of its art, so the tags on it are every illustration's, not the front
+    face's alone. Measured against api.scryfall.com on 2026-08-16: `arttag:snow e:khm` is 75 there
+    and was 73 with the front-only reading -- Birgi // Harnfel and Esika // The Prismatic Bridge
+    carry their snow on the BACK face's art -- and `-art:human e:khm t:creature` is 135 there
+    against 136, the surplus being Valki // Tibalt, whose human is Tibalt and whose Tibalt is the
+    back.
+
+    Cards with no tagged illustration are omitted rather than mapped to `{}`: _sync_card_tags reads
+    absence as "clear this row", which is the same outcome and a much smaller payload.
+
+    The overwhelming majority of rows show exactly ONE illustration, and those reference the
+    existing tag dict rather than copying it -- only a genuinely multi-illustration row (9,368 of
+    them on the 2026-08-16 bulk, of which 5,491 gain a tag from a non-front face) allocates.
+    """
+    card_id_to_tags: dict[str, dict[str, bool]] = {}
+    for scryfall_id, illustration_ids in illustrations_shown:
+        tagged = [tags for tags in (illustration_id_to_tags.get(iid) for iid in illustration_ids) if tags]
+        if not tagged:
+            continue
+        if len(tagged) == 1:
+            card_id_to_tags[scryfall_id] = tagged[0]
+            continue
+        union: dict[str, bool] = {}
+        for tags in tagged:
+            union.update(tags)
+        card_id_to_tags[scryfall_id] = union
+    return card_id_to_tags
+
+
 def import_oracle_tags(
     conn_pool: psycopg_pool.ConnectionPool,
     bulk_data_fetcher: ScryfallBulkDataFetcher,
@@ -204,12 +254,19 @@ def import_art_tags(
     logger.info("Syncing %d art tags covering %d illustrations", len(tags), len(illustration_id_to_tags))
     with conn_pool.connection() as conn:
         _sync_hierarchy(conn, "art_tags", "art_tag_relationships", tags, uuid_to_slug)
-        cards_updated, cards_cleared = _sync_card_tags(conn, "illustration_id", "card_art_tags", illustration_id_to_tags)
+        # Keyed on scryfall_id, not illustration_id: a card's tags are the union over the
+        # illustrations it shows (see _union_art_tags), so the row -- not the illustration -- is
+        # the only thing a single incoming record can fully determine. Resolving the union here
+        # rather than in SQL is also what keeps _sync_card_tags batchable: a batch of illustration
+        # ids can split a card's illustrations across two statements, a batch of cards cannot.
+        card_id_to_tags = _union_art_tags(_fetch_illustrations_shown(conn), illustration_id_to_tags)
+        cards_updated, cards_cleared = _sync_card_tags(conn, "scryfall_id", "card_art_tags", card_id_to_tags)
 
     result = {
         "duration_seconds": round(time.monotonic() - start, 2),
         "tags_imported": len(tags),
-        "cards_with_tags": len(illustration_id_to_tags),
+        "illustrations_with_tags": len(illustration_id_to_tags),
+        "cards_with_tags": len(card_id_to_tags),
         "cards_updated": cards_updated,
         "cards_cleared": cards_cleared,
     }

--- a/api/tests/test_card_processing.py
+++ b/api/tests/test_card_processing.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import pathlib
 import uuid
-from typing import Any
+from typing import Any, ClassVar
+
+import pytest
 
 from api.card_processing import extract_frame_data_from_raw_card, preprocess_card
 
@@ -597,3 +600,128 @@ class TestFaceMerging:
             ],
         )
         assert preprocess_card(card) == []
+
+
+class TestMultiFaceRawBlob:
+    """`raw_card_blob` on a merged row is the card Scryfall sent, not a face promoted to look like one.
+
+    Every searchable field is merged onto the row's own columns, so the blob has no derivation left
+    to do — and keeping it verbatim is what makes it answerable. A card object cannot be rebuilt
+    from a face: `card_faces` is gone, `name` and `type_line` are the front's, and which fields a
+    real card carries at top level varies by layout. These tests pin both layouts that differ.
+    """
+
+    # The importer lifts the combined name before splitting faces; it is the only key the blob
+    # gains, and the only one a reader has to strip to recover Scryfall's object exactly.
+    IMPORTER_ADDED: ClassVar[set[str]] = {"card_name"}
+
+    @staticmethod
+    def _transform_card() -> dict:
+        """A transform card: images and text live per face, with nothing at top level."""
+        card = create_test_card(
+            name="Test Delver // Test Aberration",
+            object="card",
+            layout="transform",
+            type_line="Creature — Human Wizard // Creature — Human Insect",
+            colors=["U"],
+            color_identity=["U"],
+            card_faces=[
+                {
+                    "object": "card_face",
+                    "name": "Test Delver",
+                    "mana_cost": "{U}",
+                    "type_line": "Creature — Human Wizard",
+                    "oracle_text": "Look at the top card of your library.",
+                    "power": "1",
+                    "toughness": "1",
+                    "colors": ["U"],
+                    "image_uris": {"normal": "https://cards.test/front.jpg"},
+                },
+                {
+                    "object": "card_face",
+                    "name": "Test Aberration",
+                    "mana_cost": "",
+                    "type_line": "Creature — Human Insect",
+                    "oracle_text": "Flying",
+                    "power": "3",
+                    "toughness": "2",
+                    "colors": ["U"],
+                    "image_uris": {"normal": "https://cards.test/back.jpg"},
+                },
+            ],
+        )
+        card.pop("image_uris", None)
+        card.pop("mana_cost", None)
+        return card
+
+    @staticmethod
+    def _split_card() -> dict:
+        """A split card: one physical face, so `mana_cost` and `image_uris` stay at top level."""
+        return create_test_card(
+            name="Test Fire // Test Ice",
+            object="card",
+            layout="split",
+            type_line="Instant // Instant",
+            mana_cost="{1}{R} // {1}{U}",
+            colors=["R", "U"],
+            color_identity=["R", "U"],
+            image_uris={"normal": "https://cards.test/split.jpg"},
+            card_faces=[
+                {
+                    "object": "card_face",
+                    "name": "Test Fire",
+                    "mana_cost": "{1}{R}",
+                    "type_line": "Instant",
+                    "oracle_text": "Deals 2.",
+                },
+                {
+                    "object": "card_face",
+                    "name": "Test Ice",
+                    "mana_cost": "{1}{U}",
+                    "type_line": "Instant",
+                    "oracle_text": "Tap it.",
+                },
+            ],
+        )
+
+    @pytest.mark.parametrize("builder", ["_transform_card", "_split_card"], ids=["transform", "split"])
+    def test_the_blob_is_the_card_it_was_given(self, builder) -> None:
+        """Whatever the layout, the blob differs from the input by the lifted name and nothing else."""
+        card = getattr(self, builder)()
+        original = copy.deepcopy(card)
+        blob = preprocess_card(card)[0]["raw_card_blob"]
+
+        assert set(blob) - set(original) == self.IMPORTER_ADDED
+        assert set(original) - set(blob) == set()
+        assert {key: value for key, value in blob.items() if key not in self.IMPORTER_ADDED} == original
+
+    def test_a_transform_card_keeps_its_images_only_on_the_faces(self) -> None:
+        """The reason every blob image read coalesces to `card_faces->0` (scripts/prefer_weights.py)."""
+        blob = preprocess_card(self._transform_card())[0]["raw_card_blob"]
+        assert "image_uris" not in blob
+        assert blob["card_faces"][0]["image_uris"]["normal"] == "https://cards.test/front.jpg"
+
+    def test_a_split_card_keeps_its_top_level_image(self) -> None:
+        """Which is why stripping the promoted fields by rule could not have worked: layout decides."""
+        blob = preprocess_card(self._split_card())[0]["raw_card_blob"]
+        assert blob["image_uris"]["normal"] == "https://cards.test/split.jpg"
+        assert blob["mana_cost"] == "{1}{R} // {1}{U}"
+
+    def test_the_faces_round_trip_untouched(self) -> None:
+        card = self._transform_card()
+        faces = copy.deepcopy(card["card_faces"])
+        assert preprocess_card(card)[0]["raw_card_blob"]["card_faces"] == faces
+
+    def test_the_blob_is_not_a_face(self) -> None:
+        blob = preprocess_card(self._transform_card())[0]["raw_card_blob"]
+        assert blob["object"] == "card"
+        assert blob["name"] == "Test Delver // Test Aberration"
+        assert blob["type_line"] == "Creature — Human Wizard // Creature — Human Insect"
+
+    def test_the_searchable_row_still_carries_the_merged_faces(self) -> None:
+        """The blob going verbatim must not have cost the merge — that is what #400 was about."""
+        row = preprocess_card(self._transform_card())[0]
+        assert row["card_name"] == "Test Delver // Test Aberration"
+        assert "Flying" in row["oracle_text"]
+        assert "Look at the top card" in row["oracle_text"]
+        assert row["creature_power"] == 1

--- a/api/tests/test_card_processing.py
+++ b/api/tests/test_card_processing.py
@@ -117,21 +117,24 @@ class TestCardProcessing:
         result = preprocess_card(invalid_card)
         assert result == []
 
-    def test_preprocess_card_processes_double_faced_cards(self) -> None:
-        """Test preprocess_card processes cards with card_faces (DFCs) correctly."""
+    def test_preprocess_card_merges_double_faced_cards_into_one_row(self) -> None:
+        """A multi-face card produces exactly ONE row, so faces no longer fight for the PK.
+
+        The old per-face fan-out emitted N rows sharing one scryfall_id; the upsert's
+        ON CONFLICT then kept whichever face came last — the back — which is how every
+        battle, MDFC spell side, and front-face text went missing (#400, #873).
+        """
         dfc_card = create_test_card(
             card_faces=[{"name": "Front", "type_line": "Creature — Human"}, {"name": "Back", "type_line": "Creature — Werewolf"}],
         )
 
         result = preprocess_card(dfc_card)
-        # DFCs should return 2 cards (one per face)
-        assert len(result) == 2
-        assert result[0]["face_idx"] == 1
-        assert result[0]["face_name"] == "Front"
-        assert result[0]["card_name"] == "Test Card"
-        assert result[1]["face_idx"] == 2
-        assert result[1]["face_name"] == "Back"
-        assert result[1]["card_name"] == "Test Card"
+        assert len(result) == 1
+        merged = result[0]
+        assert merged["card_name"] == "Test Card"
+        assert merged["scryfall_id"] == dfc_card["id"]
+        assert merged["card_subtypes"] == ["Human", "Werewolf"]
+        assert merged["type_line"] == "Creature — Human // Creature — Werewolf"
 
     def test_preprocess_card_filters_same_faced_double_side_cards(self) -> None:
         """Test preprocess_card filters out cards with the same name on both faces (X // X)."""
@@ -158,8 +161,8 @@ class TestCardProcessing:
         )
 
         result = preprocess_card(normal_dfc)
-        # Different names — should be processed normally (2 faces)
-        assert len(result) == 2
+        assert len(result) == 1
+        assert result[0]["card_name"] == "Hound Tamer // Untamed Pup"
 
     def test_preprocess_card_filters_all_not_legal_cards(self) -> None:
         """Test preprocess_card filters out cards that are not legal in any format."""
@@ -398,48 +401,199 @@ class TestCardProcessing:
         assert result["creature_toughness"] is None
 
     def test_preprocess_hound_tamer_dfc(self) -> None:
-        """Test preprocess_card processes Hound Tamer DFC sample data correctly."""
+        """A real transform card merges to one row: front stats, both faces searchable."""
         sample_file = _SAMPLE_DATA_DIR / "hound_tamer.json"
         with sample_file.open() as f:
             hound_tamer = json.load(f)
 
         result = preprocess_card(hound_tamer)
 
-        # Should return 2 faces
-        assert len(result) == 2
-
-        # Check front face
-        front = result[0]
-        assert front["face_idx"] == 1
-        assert front["face_name"] == "Hound Tamer"
-        assert front["card_name"] == "Hound Tamer // Untamed Pup"
-        assert front["creature_power"] == 3
-        assert front["creature_toughness"] == 3
-        assert "Creature" in front["card_types"]
-        assert front["cmc"] == 3
-
-        # Check back face
-        back = result[1]
-        assert back["face_idx"] == 2
-        assert back["face_name"] == "Untamed Pup"
-        assert back["card_name"] == "Hound Tamer // Untamed Pup"
-        assert back["creature_power"] == 4
-        assert back["creature_toughness"] == 4
-        assert "Creature" in back["card_types"]
-        # CMC is inherited from the card (3), even though back face has no mana cost
-        assert back["cmc"] == 3
+        assert len(result) == 1
+        merged = result[0]
+        assert merged["card_name"] == "Hound Tamer // Untamed Pup"
+        # Front face supplies the stat group (the 3/3, not the pup's 4/4)
+        assert merged["creature_power"] == 3
+        assert merged["creature_toughness"] == 3
+        assert merged["cmc"] == 3
+        assert merged["mana_cost_text"] == "{2}{G}"
+        # Both faces' searchable data is present
+        assert merged["card_subtypes"] == ["Human", "Werewolf"]
+        assert merged["type_line"] == "Creature — Human Werewolf // Creature — Werewolf"
+        assert "Trample" in merged["oracle_text"]  # front-face text
+        assert "Nightbound" in merged["oracle_text"]  # back-face text
+        assert "nightbound" in merged["card_keywords"]
 
     def test_preprocess_obyras_attendants(self) -> None:
-        """Test preprocess_card processes Obyra's Attendants DFC sample data correctly."""
+        """A real adventure card merges to one row with both faces' types searchable."""
         sample_file = _SAMPLE_DATA_DIR / "obyras_attendants.json"
         with sample_file.open() as f:
             obyras_attendants = json.load(f)
 
         result = preprocess_card(obyras_attendants)
 
-        # Should return 2 faces
-        front, back = result
-        assert front["creature_power"] == 3
-        assert back.get("creature_power") is None
-        assert front["card_types"] == ["Creature"]
-        assert back["card_types"] == ["Instant"]
+        assert len(result) == 1
+        merged = result[0]
+        # Creature body's stats, both faces' types: `t:creature t:instant` both match now
+        assert merged["creature_power"] == 3
+        assert merged["card_types"] == ["Creature", "Instant"]
+        assert merged["card_subtypes"] == ["Faerie", "Wizard", "Adventure"]
+
+
+class TestFaceMerging:
+    """The face-merge policy: front-face identity, any-face searchability (#400, #873).
+
+    Scryfall AND's predicates at the card level, each satisfiable by any face (measured
+    2026-08-08: `t:sorcery t:land` returns MDFC lands, `o:` conjunctions match across
+    faces, `c:b` matches Westvale Abbey's back-face-only color). These tests pin the
+    merged row to those semantics.
+    """
+
+    @staticmethod
+    def _battle_card() -> dict:
+        """A transform battle shaped like Invasion of Kamigawa // Rooftop Saboteurs."""
+        return create_test_card(
+            name="Invasion of Testing // Test Saboteurs",
+            layout="transform",
+            cmc=3,
+            card_faces=[
+                {
+                    "name": "Invasion of Testing",
+                    "type_line": "Battle — Siege",
+                    "mana_cost": "{2}{U}",
+                    "colors": ["U"],
+                    "oracle_text": "When this Siege enters, look at the top card.",
+                    "illustration_id": "11111111-1111-1111-1111-111111111111",
+                },
+                {
+                    "name": "Test Saboteurs",
+                    "type_line": "Creature — Moonfolk Ninja",
+                    "mana_cost": "",
+                    "colors": ["U"],
+                    "power": "3",
+                    "toughness": "2",
+                    "oracle_text": "This creature can't be blocked.",
+                    "illustration_id": "22222222-2222-2222-2222-222222222222",
+                },
+            ],
+        )
+
+    def test_battle_front_types_are_searchable(self) -> None:
+        """`t:battle` must match transform battles — the union carries the front's types.
+
+        The acceptance test from #400: Battle appears in zero type lines corpus-wide today
+        because every battle is stored as its back face.
+        """
+        merged = preprocess_card(self._battle_card())[0]
+        assert merged["card_types"] == ["Battle", "Creature"]
+        assert merged["card_subtypes"] == ["Siege", "Moonfolk", "Ninja"]
+
+    def test_front_face_supplies_identity_scalars(self) -> None:
+        """Mana cost, illustration, and image come from the front face, as on Scryfall."""
+        merged = preprocess_card(self._battle_card())[0]
+        assert merged["mana_cost_text"] == "{2}{U}"
+        assert merged["illustration_id"] == "11111111-1111-1111-1111-111111111111"
+
+    def test_oracle_text_joins_faces_with_separator(self) -> None:
+        """Each face's text is substring-searchable in the one joined column.
+
+        The newline separator keeps `.`-based regexes from matching across the face boundary.
+        """
+        merged = preprocess_card(self._battle_card())[0]
+        assert merged["oracle_text"] == ("When this Siege enters, look at the top card.\n//\nThis creature can't be blocked.")
+
+    def test_back_face_stats_used_when_front_has_none(self) -> None:
+        """A land-front / creature-back card (Westvale Abbey) keeps the back's P/T.
+
+        The front offers none, and Scryfall's pow: matches the back there too.
+        """
+        card = create_test_card(
+            name="Test Abbey // Test Prince",
+            card_faces=[
+                {"name": "Test Abbey", "type_line": "Land", "colors": [], "oracle_text": "{T}: Add {C}."},
+                {
+                    "name": "Test Prince",
+                    "type_line": "Legendary Creature — Demon",
+                    "colors": ["B"],
+                    "power": "9",
+                    "toughness": "7",
+                    "oracle_text": "Flying, lifelink.",
+                },
+            ],
+        )
+        merged = preprocess_card(card)[0]
+        assert merged["creature_power"] == 9
+        assert merged["creature_toughness"] == 7
+        # ...and the back-face-only color is searchable (c:b matches on Scryfall)
+        assert merged["card_colors"] == {"B": True}
+
+    def test_front_face_stats_win_when_both_faces_have_them(self) -> None:
+        """Two creature faces (Brutal Cathar's 2/2 // 3/3): the front's group wins.
+
+        Known residual vs Scryfall, which also matches the back's pow=3; documented in
+        the merge policy and left for a per-face follow-up if measurement warrants.
+        """
+        card = create_test_card(
+            name="Test Cathar // Test Brute",
+            card_faces=[
+                {"name": "Test Cathar", "type_line": "Creature — Human Soldier", "colors": ["W"], "power": "2", "toughness": "2"},
+                {"name": "Test Brute", "type_line": "Creature — Werewolf", "colors": [], "power": "3", "toughness": "3"},
+            ],
+        )
+        merged = preprocess_card(card)[0]
+        assert merged["creature_power"] == 2
+        assert merged["creature_toughness"] == 2
+        assert merged["creature_power_text"] == "2"
+
+    def test_stat_group_stays_face_consistent(self) -> None:
+        """The numeric and _text stat columns always describe the same face.
+
+        A `*`-power back face still counts as carrying the group: its text is real data.
+        """
+        card = create_test_card(
+            name="Test Land // Test Goyf",
+            card_faces=[
+                {"name": "Test Land", "type_line": "Land", "colors": []},
+                {"name": "Test Goyf", "type_line": "Creature — Lhurgoyf", "colors": ["G"], "power": "*", "toughness": "1+*"},
+            ],
+        )
+        merged = preprocess_card(card)[0]
+        assert merged["creature_power"] is None  # "*" is non-numeric
+        assert merged["creature_power_text"] == "*"
+        assert merged["creature_toughness_text"] == "1+*"
+
+    def test_mdfc_spell_and_land_types_both_searchable(self) -> None:
+        """`t:sorcery t:land` matches an MDFC (Agadeem's Awakening) — #400's acceptance."""
+        card = create_test_card(
+            name="Test Awakening // Test Undercrypt",
+            layout="modal_dfc",
+            card_faces=[
+                {
+                    "name": "Test Awakening",
+                    "type_line": "Sorcery",
+                    "mana_cost": "{X}{B}{B}{B}",
+                    "colors": ["B"],
+                    "oracle_text": "Return cards from your graveyard.",
+                },
+                {
+                    "name": "Test Undercrypt",
+                    "type_line": "Land",
+                    "mana_cost": "",
+                    "colors": [],
+                    "oracle_text": "As this land enters, you may pay 3 life.",
+                },
+            ],
+        )
+        merged = preprocess_card(card)[0]
+        assert merged["card_types"] == ["Sorcery", "Land"]
+        assert merged["mana_cost_text"] == "{X}{B}{B}{B}"
+
+    def test_all_faces_filtered_drops_the_card(self) -> None:
+        """A card whose every face is filtered (e.g. Token type lines) yields no row."""
+        card = create_test_card(
+            name="Test A // Test B",
+            card_faces=[
+                {"name": "Test A", "type_line": "Token Creature — Goblin"},
+                {"name": "Test B", "type_line": "Token Creature — Elf"},
+            ],
+        )
+        assert preprocess_card(card) == []

--- a/api/tests/test_card_processing.py
+++ b/api/tests/test_card_processing.py
@@ -262,6 +262,15 @@ class TestCardProcessing:
         assert result["price_tix"] == 0.01
         assert result["card_set_code"] == "m15"
 
+    def test_preprocess_card_lists_its_one_illustration(self) -> None:
+        """A single-faced card shows one piece of art, and a card with none shows an empty list."""
+        with_art = preprocess_card(create_test_card(illustration_id="44444444-4444-4444-4444-444444444444"))[0]
+        assert with_art["illustration_ids"] == ["44444444-4444-4444-4444-444444444444"]
+
+        without_art = preprocess_card(create_test_card())[0]
+        assert without_art["illustration_id"] is None
+        assert without_art["illustration_ids"] == []
+
     def test_preprocess_card_processes_frame_data(self) -> None:
         """Test preprocess_card processes frame data correctly."""
         card_with_frame = create_test_card(
@@ -495,6 +504,43 @@ class TestFaceMerging:
         merged = preprocess_card(self._battle_card())[0]
         assert merged["mana_cost_text"] == "{2}{U}"
         assert merged["illustration_id"] == "11111111-1111-1111-1111-111111111111"
+
+    def test_illustration_ids_list_every_face_front_first(self) -> None:
+        """The art a printing SHOWS is all of it, which is what art tags attach to.
+
+        `illustration_id` stays the front's for display, so the back's art exists nowhere else on
+        the row -- and `arttag:snow e:khm` is 75 on Scryfall against 73 for the front-only reading.
+        """
+        merged = preprocess_card(self._battle_card())[0]
+        assert merged["illustration_ids"] == [
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+        ]
+
+    def test_faces_sharing_the_cards_art_collapse_to_one_illustration(self) -> None:
+        """A split card (Fire // Ice) has one illustration on the CARD and none on its faces.
+
+        Both face rows therefore inherit the same id, and the merge must dedupe rather than list
+        it twice -- there is one piece of art to attach tags to.
+        """
+        card = create_test_card(
+            name="Flame // Frost",
+            layout="split",
+            illustration_id="33333333-3333-3333-3333-333333333333",
+            card_faces=[
+                {"name": "Flame", "type_line": "Instant", "mana_cost": "{R}", "oracle_text": "Deal 2 damage."},
+                {"name": "Frost", "type_line": "Instant", "mana_cost": "{U}", "oracle_text": "Tap target creature."},
+            ],
+        )
+        merged = preprocess_card(card)[0]
+        assert merged["illustration_ids"] == ["33333333-3333-3333-3333-333333333333"]
+
+    def test_a_face_with_no_art_at_all_contributes_nothing(self) -> None:
+        """A missing illustration is absent from the list, not a null entry in it."""
+        card = self._battle_card()
+        del card["card_faces"][1]["illustration_id"]
+        merged = preprocess_card(card)[0]
+        assert merged["illustration_ids"] == ["11111111-1111-1111-1111-111111111111"]
 
     def test_oracle_text_joins_faces_with_separator(self) -> None:
         """Each face's text is substring-searchable in the one joined column.

--- a/api/tests/test_tagging_integration.py
+++ b/api/tests/test_tagging_integration.py
@@ -254,7 +254,7 @@ class TestUnionArtTags:
 
 
 def _art_tags_of(api_resource: APIResource, scryfall_id: str) -> dict:
-    with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+    with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
         cursor.execute("SELECT card_art_tags FROM magic.cards WHERE scryfall_id = %(sid)s", {"sid": scryfall_id})
         row = cursor.fetchone()
     return row["card_art_tags"] if row else {}
@@ -290,7 +290,7 @@ class TestArtTagsAgainstPostgres:
             {"name": "Snowfront Tester", "type_line": "Creature — Human", "illustration_id": self.FRONT_ILLUSTRATION},
             {"name": "Snowback Tester", "type_line": "Creature — Insect", "illustration_id": self.BACK_ILLUSTRATION},
         ]
-        assert api_resource._upsert_cards([card])["status"] == "success"
+        assert api_resource.admin._upsert_cards([card])["status"] == "success"
         return card["id"]
 
     def test_a_back_face_tagging_lands_on_the_card(self, api_resource: APIResource) -> None:
@@ -298,7 +298,7 @@ class TestArtTagsAgainstPostgres:
         fetcher = MagicMock()
         fetcher.stream_data_for_key.return_value = iter(self._art_dump(self.BACK_ILLUSTRATION, "snow"))
 
-        import_art_tags(api_resource._conn_pool, fetcher)
+        import_art_tags(api_resource.app_context.reader_pool, fetcher)
 
         assert _art_tags_of(api_resource, scryfall_id) == {"snow": True}
 
@@ -308,7 +308,7 @@ class TestArtTagsAgainstPostgres:
         fetcher = MagicMock()
         fetcher.stream_data_for_key.return_value = iter(self._art_dump(self.FRONT_ILLUSTRATION, "human"))
 
-        import_art_tags(api_resource._conn_pool, fetcher)
+        import_art_tags(api_resource.app_context.reader_pool, fetcher)
 
         assert _art_tags_of(api_resource, scryfall_id) == {"human": True}
 
@@ -317,10 +317,10 @@ class TestArtTagsAgainstPostgres:
         scryfall_id = self._import_dfc(api_resource)
         fetcher = MagicMock()
         fetcher.stream_data_for_key.return_value = iter(self._art_dump(self.BACK_ILLUSTRATION, "snow"))
-        import_art_tags(api_resource._conn_pool, fetcher)
+        import_art_tags(api_resource.app_context.reader_pool, fetcher)
         assert _art_tags_of(api_resource, scryfall_id) == {"snow": True}
 
         fetcher.stream_data_for_key.return_value = iter([])
-        import_art_tags(api_resource._conn_pool, fetcher)
+        import_art_tags(api_resource.app_context.reader_pool, fetcher)
 
         assert _art_tags_of(api_resource, scryfall_id) == {}

--- a/api/tests/test_tagging_integration.py
+++ b/api/tests/test_tagging_integration.py
@@ -1,9 +1,17 @@
 """Integration tests for tag import functions."""
 
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, ClassVar
 from unittest.mock import MagicMock, patch
 
 from api.scryfall_bulk_data_fetcher import BulkDataKey
-from api.tag_import import _build_uuid_to_slug, import_art_tags, import_oracle_tags
+from api.tag_import import _build_uuid_to_slug, _union_art_tags, import_art_tags, import_oracle_tags
+from api.tests.helpers import make_raw_card
+
+if TYPE_CHECKING:
+    from api.api_resource import APIResource
 
 ORACLE_TAGS_FIXTURE = [
     {
@@ -170,8 +178,149 @@ class TestImportArtTags:
         fetcher = MagicMock()
         fetcher.stream_data_for_key.return_value = iter(ART_TAGS_FIXTURE)
 
-        result = import_art_tags(pool, fetcher)
+        with patch("api.tag_import._fetch_illustrations_shown", return_value=[("card-1", ["illus-x"])]):
+            result = import_art_tags(pool, fetcher)
 
         assert result["tags_imported"] == 1
+        # The dump covers one illustration; one card in the corpus shows it.
+        assert result["illustrations_with_tags"] == 1
         assert result["cards_with_tags"] == 1
         assert "duration_seconds" in result
+
+    def test_syncs_card_art_tags_keyed_on_the_card(self) -> None:
+        """The column a record identifies is scryfall_id, because the union is per card.
+
+        An illustration id no longer determines a row's whole value: a double-faced card's tags
+        come from two of them, so nothing keyed on one illustration could write the row.
+        """
+        pool, _ = _make_mock_conn_pool()
+        fetcher = MagicMock()
+        fetcher.stream_data_for_key.return_value = iter(ART_TAGS_FIXTURE)
+
+        captured: dict = {}
+
+        def capture(conn, id_column, tag_column, id_to_tags) -> tuple[int, int]:
+            captured.update(id_column=id_column, tag_column=tag_column, id_to_tags=id_to_tags)
+            return (0, 0)
+
+        with (
+            patch("api.tag_import._sync_card_tags", side_effect=capture),
+            patch("api.tag_import._sync_hierarchy"),
+            patch("api.tag_import._fetch_illustrations_shown", return_value=[("card-1", ["illus-x"])]),
+        ):
+            import_art_tags(pool, fetcher)
+
+        assert captured["id_column"] == "scryfall_id"
+        assert captured["tag_column"] == "card_art_tags"
+        assert captured["id_to_tags"] == {"card-1": {"dragon": True}}
+
+
+class TestUnionArtTags:
+    """A card answers for every face it shows, not just its front.
+
+    `illustration_id` is the FRONT face's on a merged multi-face row, so joining `card_art_tags`
+    on it alone made a back-face-only tag unreachable. Measured against api.scryfall.com on
+    2026-08-16: `arttag:snow e:khm` is 75 there against 73 for the front-only reading (Birgi //
+    Harnfel and Esika // The Prismatic Bridge carry their snow on the back art), and
+    `-art:human e:khm t:creature` is 135 there against 136 (the surplus being Valki // Tibalt).
+    """
+
+    TAGS: ClassVar[dict[str, dict[str, bool]]] = {
+        "illus-front": {"human": True, "window": True},
+        "illus-back": {"insect": True, "window": True},
+    }
+
+    def test_a_back_face_only_tag_reaches_the_card(self) -> None:
+        assert _union_art_tags([("card-dfc", ["illus-front", "illus-back"])], self.TAGS) == {
+            "card-dfc": {"human": True, "window": True, "insect": True},
+        }
+
+    def test_a_single_illustration_card_gets_that_illustrations_tags(self) -> None:
+        assert _union_art_tags([("card-solo", ["illus-front"])], self.TAGS) == {"card-solo": {"human": True, "window": True}}
+
+    def test_a_single_illustration_card_shares_the_dump_dict(self) -> None:
+        """No copy on the overwhelming majority of rows: the union allocates only when it unions."""
+        result = _union_art_tags([("card-solo", ["illus-front"])], self.TAGS)
+        assert result["card-solo"] is self.TAGS["illus-front"]
+
+    def test_an_untagged_illustration_is_omitted_not_emptied(self) -> None:
+        """_sync_card_tags reads absence as "clear this row", so `{}` would only cost payload."""
+        assert _union_art_tags([("card-untagged", ["illus-unknown"])], self.TAGS) == {}
+
+    def test_a_face_whose_art_is_untagged_does_not_suppress_the_others(self) -> None:
+        assert _union_art_tags([("card-dfc", ["illus-unknown", "illus-back"])], self.TAGS) == {
+            "card-dfc": {"insect": True, "window": True},
+        }
+
+
+def _art_tags_of(api_resource: APIResource, scryfall_id: str) -> dict:
+    with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        cursor.execute("SELECT card_art_tags FROM magic.cards WHERE scryfall_id = %(sid)s", {"sid": scryfall_id})
+        row = cursor.fetchone()
+    return row["card_art_tags"] if row else {}
+
+
+class TestArtTagsAgainstPostgres:
+    """The whole path against a real database: import a card, import its art tags, read the row.
+
+    `arttag:snow e:khm` was 73 against Scryfall's 75 for exactly the shape below -- a merged
+    double-faced row whose `snow` tagging names the BACK face's illustration, which is not the
+    `illustration_id` column.
+    """
+
+    FRONT_ILLUSTRATION = "aaaaaaaa-0000-4000-8000-000000000001"
+    BACK_ILLUSTRATION = "aaaaaaaa-0000-4000-8000-000000000002"
+
+    @staticmethod
+    def _art_dump(illustration_id: str, slug: str) -> list[dict]:
+        return [
+            {
+                "id": str(uuid.uuid4()),
+                "slug": slug,
+                "parent_ids": [],
+                "child_ids": [],
+                "taggings": [{"illustration_id": illustration_id, "weight": "very_strong"}],
+            },
+        ]
+
+    def _import_dfc(self, api_resource: APIResource) -> str:
+        card = make_raw_card(name="Snowfront Tester // Snowback Tester")
+        card["layout"] = "transform"
+        card["card_faces"] = [
+            {"name": "Snowfront Tester", "type_line": "Creature — Human", "illustration_id": self.FRONT_ILLUSTRATION},
+            {"name": "Snowback Tester", "type_line": "Creature — Insect", "illustration_id": self.BACK_ILLUSTRATION},
+        ]
+        assert api_resource._upsert_cards([card])["status"] == "success"
+        return card["id"]
+
+    def test_a_back_face_tagging_lands_on_the_card(self, api_resource: APIResource) -> None:
+        scryfall_id = self._import_dfc(api_resource)
+        fetcher = MagicMock()
+        fetcher.stream_data_for_key.return_value = iter(self._art_dump(self.BACK_ILLUSTRATION, "snow"))
+
+        import_art_tags(api_resource._conn_pool, fetcher)
+
+        assert _art_tags_of(api_resource, scryfall_id) == {"snow": True}
+
+    def test_the_front_face_still_lands(self, api_resource: APIResource) -> None:
+        """The union adds the back; it does not cost the front, which is what already worked."""
+        scryfall_id = self._import_dfc(api_resource)
+        fetcher = MagicMock()
+        fetcher.stream_data_for_key.return_value = iter(self._art_dump(self.FRONT_ILLUSTRATION, "human"))
+
+        import_art_tags(api_resource._conn_pool, fetcher)
+
+        assert _art_tags_of(api_resource, scryfall_id) == {"human": True}
+
+    def test_a_tagless_dump_clears_the_row(self, api_resource: APIResource) -> None:
+        """Keying the sync on the card, not the illustration, keeps the clear path exact."""
+        scryfall_id = self._import_dfc(api_resource)
+        fetcher = MagicMock()
+        fetcher.stream_data_for_key.return_value = iter(self._art_dump(self.BACK_ILLUSTRATION, "snow"))
+        import_art_tags(api_resource._conn_pool, fetcher)
+        assert _art_tags_of(api_resource, scryfall_id) == {"snow": True}
+
+        fetcher.stream_data_for_key.return_value = iter([])
+        import_art_tags(api_resource._conn_pool, fetcher)
+
+        assert _art_tags_of(api_resource, scryfall_id) == {}

--- a/api/tests/test_upsert_cards.py
+++ b/api/tests/test_upsert_cards.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import multiprocessing
+import pathlib
 import uuid
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -356,3 +357,70 @@ class TestUpsertBehavior:
             row = cursor.fetchone()
         assert row["prefer_score"] == 42.0
         assert row["card_is_tags"] == {"is:instant": True}
+
+
+# ---------------------------------------------------------------------------
+# illustration_ids: the column the art-tag join reads
+# ---------------------------------------------------------------------------
+
+
+def _dfc_raw_card(front: str, back: str) -> dict:
+    card = make_raw_card(name=f"Illustration Front {uuid.uuid4()} // Illustration Back")
+    card["layout"] = "transform"
+    card["card_faces"] = [
+        {"name": "Illustration Front", "type_line": "Creature — Human", "illustration_id": front},
+        {"name": "Illustration Back", "type_line": "Creature — Insect", "illustration_id": back},
+    ]
+    return card
+
+
+class TestIllustrationIds:
+    """`illustration_ids` is every illustration the row shows, and it must survive an import.
+
+    It is what `card_art_tags` is joined on (api/tag_import.py), so a row that loses it stops
+    answering art-tag queries entirely -- and a merged double-faced row is the only place the
+    back's illustration exists at all, `illustration_id` being the front's.
+    """
+
+    FRONT = "cccccccc-0000-4000-8000-000000000001"
+    BACK = "cccccccc-0000-4000-8000-000000000002"
+
+    @staticmethod
+    def _stored(api_resource: APIResource, scryfall_id: str) -> list[str]:
+        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+            cursor.execute("SELECT illustration_ids FROM magic.cards WHERE scryfall_id = %s", (scryfall_id,))
+            return cursor.fetchone()["illustration_ids"]
+
+    def test_a_merged_row_stores_both_faces(self, api_resource: APIResource) -> None:
+        card = _dfc_raw_card(self.FRONT, self.BACK)
+        api_resource._upsert_cards([card])
+        assert self._stored(api_resource, card["id"]) == [self.FRONT, self.BACK]
+
+    def test_a_single_faced_row_stores_its_one(self, api_resource: APIResource) -> None:
+        card = make_raw_card()
+        card["illustration_id"] = "cccccccc-0000-4000-8000-000000000003"
+        api_resource._upsert_cards([card])
+        assert self._stored(api_resource, card["id"]) == ["cccccccc-0000-4000-8000-000000000003"]
+
+    def test_the_migration_backfill_agrees_with_preprocessing(self, api_resource: APIResource) -> None:
+        """The one-shot backfill must land where the next import would, or art tags go dark until it.
+
+        It reads `raw_card_blob->'card_faces'`, which is the only record of the back's illustration
+        on an already-imported row. Runs the migration's last statement -- the backfill -- against
+        rows written by the real import path.
+        """
+        dfc = _dfc_raw_card(self.FRONT, self.BACK)
+        solo = make_raw_card()
+        solo["illustration_id"] = "cccccccc-0000-4000-8000-000000000004"
+        api_resource._upsert_cards([dfc, solo])
+
+        migration = (pathlib.Path(__file__).parent.parent / "db" / "2026-08-16-01-illustration-ids.sql").read_text()
+        backfill = migration[migration.index("WITH shown") :]
+
+        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+            cursor.execute("UPDATE magic.cards SET illustration_ids = '[]'::jsonb")
+            cursor.execute(backfill)
+            conn.commit()
+
+        assert self._stored(api_resource, dfc["id"]) == [self.FRONT, self.BACK]
+        assert self._stored(api_resource, solo["id"]) == ["cccccccc-0000-4000-8000-000000000004"]

--- a/api/tests/test_upsert_cards.py
+++ b/api/tests/test_upsert_cards.py
@@ -387,19 +387,19 @@ class TestIllustrationIds:
 
     @staticmethod
     def _stored(api_resource: APIResource, scryfall_id: str) -> list[str]:
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute("SELECT illustration_ids FROM magic.cards WHERE scryfall_id = %s", (scryfall_id,))
             return cursor.fetchone()["illustration_ids"]
 
     def test_a_merged_row_stores_both_faces(self, api_resource: APIResource) -> None:
         card = _dfc_raw_card(self.FRONT, self.BACK)
-        api_resource._upsert_cards([card])
+        api_resource.admin._upsert_cards([card])
         assert self._stored(api_resource, card["id"]) == [self.FRONT, self.BACK]
 
     def test_a_single_faced_row_stores_its_one(self, api_resource: APIResource) -> None:
         card = make_raw_card()
         card["illustration_id"] = "cccccccc-0000-4000-8000-000000000003"
-        api_resource._upsert_cards([card])
+        api_resource.admin._upsert_cards([card])
         assert self._stored(api_resource, card["id"]) == ["cccccccc-0000-4000-8000-000000000003"]
 
     def test_the_migration_backfill_agrees_with_preprocessing(self, api_resource: APIResource) -> None:
@@ -412,12 +412,12 @@ class TestIllustrationIds:
         dfc = _dfc_raw_card(self.FRONT, self.BACK)
         solo = make_raw_card()
         solo["illustration_id"] = "cccccccc-0000-4000-8000-000000000004"
-        api_resource._upsert_cards([dfc, solo])
+        api_resource.admin._upsert_cards([dfc, solo])
 
         migration = (pathlib.Path(__file__).parent.parent / "db" / "2026-08-16-01-illustration-ids.sql").read_text()
         backfill = migration[migration.index("WITH shown") :]
 
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute("UPDATE magic.cards SET illustration_ids = '[]'::jsonb")
             cursor.execute(backfill)
             conn.commit()

--- a/scripts/copy_images_to_s3.py
+++ b/scripts/copy_images_to_s3.py
@@ -128,11 +128,8 @@ def fetch_cards_from_db(
         List of dictionaries containing
              card_set_code,
              collector_number,
-             png_url (front face; for merged multi-face rows the top-level image_uris
-                 IS the front's, with the blob's card_faces[0] as fallback),
-             back_png_url (card_faces[1]'s image, present only for cards with a
-                 physical back face — transform/MDFC; split/adventure/flip faces
-                 carry no per-face images)
+             png_url (the FRONT face),
+             back_png_url (the back face, or NULL for a card that has no physical back)
     """
     with conn.cursor() as cursor:
         where_clause = ""
@@ -149,15 +146,39 @@ def fetch_cards_from_db(
 
         where_clause = " AND ".join(conditions)
 
+        # Both URLs are DERIVED from scryfall_id rather than read out of raw_card_blob, and
+        # whether a back face exists is read from card_layout. Two reasons, both load-bearing:
+        #
+        # 1. The blob is wrong for exactly the cards this is about. Until the face merge, a
+        #    multi-face row WAS its last face, so `raw_card_blob->'image_uris'` is that face's
+        #    -- the BACK's -- because Scryfall omits top-level image_uris on a transform card
+        #    and puts one on each face. Every such card therefore has its back image uploaded
+        #    under the face-1 key, and its front uploaded nowhere. (Verified against the live
+        #    CDN: img/bot/6/1/*.webp is Slicer, High-Speed Antagonist -- the back.) A coalesce
+        #    onto card_faces[0] does not rescue it, because the first branch is non-NULL.
+        # 2. The blob is unavailable for the same cards. preprocess_card popped card_faces
+        #    before snapshotting, so no pre-merge row's blob has that key at all, which is why
+        #    2026-08-10-01's backfill leaves card_faces NULL corpus-wide and back_png_url with
+        #    it. Reading the blob means "correct only after a full reimport"; reading columns
+        #    means correct now.
+        #
+        # scryfall_id and card_layout are both NOT NULL/indexed columns populated for every
+        # row today, and Scryfall's image path is a pure function of the id, so this is right
+        # on the existing corpus with no reimport and self-heals rows the blob never captured.
         query = f"""
             SELECT
                 card_set_code,
                 collector_number,
-                coalesce(
-                    raw_card_blob->'image_uris'->>'png',
-                    raw_card_blob->'card_faces'->0->'image_uris'->>'png'
-                ) as png_url,
-                raw_card_blob->'card_faces'->1->'image_uris'->>'png' as back_png_url
+                'https://cards.scryfall.io/png/front/'
+                    || left(scryfall_id::text, 1) || '/' || substr(scryfall_id::text, 2, 1)
+                    || '/' || scryfall_id::text || '.png' as png_url,
+                CASE WHEN card_layout IN (
+                        'transform', 'modal_dfc', 'reversible_card', 'double_faced_token', 'art_series'
+                     ) THEN
+                    'https://cards.scryfall.io/png/back/'
+                        || left(scryfall_id::text, 1) || '/' || substr(scryfall_id::text, 2, 1)
+                        || '/' || scryfall_id::text || '.png'
+                END as back_png_url
             FROM
                 magic.cards
             WHERE

--- a/scripts/copy_images_to_s3.py
+++ b/scripts/copy_images_to_s3.py
@@ -128,8 +128,11 @@ def fetch_cards_from_db(
         List of dictionaries containing
              card_set_code,
              collector_number,
-             png_url,
-             face_idx
+             png_url (front face; for merged multi-face rows the top-level image_uris
+                 IS the front's, with the blob's card_faces[0] as fallback),
+             back_png_url (card_faces[1]'s image, present only for cards with a
+                 physical back face — transform/MDFC; split/adventure/flip faces
+                 carry no per-face images)
     """
     with conn.cursor() as cursor:
         where_clause = ""
@@ -150,8 +153,11 @@ def fetch_cards_from_db(
             SELECT
                 card_set_code,
                 collector_number,
-                raw_card_blob->'image_uris'->>'png' as png_url,
-                coalesce((raw_card_blob->>'face_idx')::int, 1) as face_idx
+                coalesce(
+                    raw_card_blob->'image_uris'->>'png',
+                    raw_card_blob->'card_faces'->0->'image_uris'->>'png'
+                ) as png_url,
+                raw_card_blob->'card_faces'->1->'image_uris'->>'png' as back_png_url
             FROM
                 magic.cards
             WHERE
@@ -344,7 +350,7 @@ def process_card(
                 continue
 
             # Face-aware key structure: img/{set_code}/{collector_number}/{face}/{size}.webp
-            s3_key = f"img/{set_code}/{collector_number}/{DEFAULT_FACE}/{size_name}.webp"
+            s3_key = f"img/{set_code}/{collector_number}/{card.get('face_idx', DEFAULT_FACE)}/{size_name}.webp"
 
             if upload_to_s3(s3_client, webp_path, bucket, s3_key):
                 results[size_name] = True
@@ -507,18 +513,23 @@ def get_db_cards(args: Args) -> set[tuple[str, str, str, str]]:
         return None
 
     sizes = [SMALL_KEY, MEDIUM_KEY, LARGE_KEY, XLARGE_KEY]
-    logger.info("Found %d cards in database, should create %d images", len(db_cards), len(db_cards) * len(sizes))
-    return {
+    images = {
         CardImage(
             set_code=card["card_set_code"],
             collector_number=card["collector_number"],
-            face_idx=str(card["face_idx"]),
-            png_url=card["png_url"],
+            face_idx=face_idx,
+            png_url=png_url,
             size=size,
         )
         for card in db_cards
+        # One image per face that actually has one: every card's front, plus the back for
+        # cards with a physical back face (the flip button's image on the site).
+        for face_idx, png_url in ((DEFAULT_FACE, card["png_url"]), ("2", card["back_png_url"]))
+        if png_url
         for size in sizes
     }
+    logger.info("Found %d cards in database, should create %d images", len(db_cards), len(images))
+    return images
 
 
 def get_s3_cards(args: Args) -> set[CardImage]:

--- a/scripts/prefer_weights.py
+++ b/scripts/prefer_weights.py
@@ -133,7 +133,28 @@ COUNTED_PRINTING_SQL = """
 # Sourced from Scryfall's `normal` rather than the project CDN: the CDN 403s on
 # printings the site does not carry (e.g. pw26/20), which would leave the reviewer
 # comparing a broken image against a card. Scryfall covers 94,718/94,718.
-LEVELS_EXTRA_IMAGE = "raw_card_blob -> 'image_uris' ->> 'normal'"
+
+
+def front_image(size: str, alias: str = "") -> str:
+    """Build the SQL for a printing's front-face image URL at one size.
+
+    `raw_card_blob` holds Scryfall's own card object, and where a card carries its images decides
+    on layout: a single-face or split printing has `image_uris` at top level, a transform or MDFC
+    one has them only under `card_faces`. Reading the front therefore has to try both, which is
+    what every image read in this file goes through.
+
+    Args:
+        size: An `image_uris` key -- "normal", "art_crop", and so on.
+        alias: Table alias to qualify the column with, or "" for an unqualified column.
+
+    Returns:
+        A SQL expression yielding the URL, or NULL when the printing has no image of that size.
+    """
+    column = f"{alias}.raw_card_blob" if alias else "raw_card_blob"
+    return f"COALESCE({column} -> 'image_uris' ->> '{size}', {column} -> 'card_faces' -> 0 -> 'image_uris' ->> '{size}')"
+
+
+LEVELS_EXTRA_IMAGE = front_image("normal")
 
 LEVELS_SQL = """
 SELECT c.scryfall_id::text AS sid,
@@ -168,8 +189,8 @@ SELECT c.scryfall_id::text AS sid,
        ((c.card_art_tags ? 'external-ip' AND NOT (c.card_art_tags ?| {exempt}))
          OR c.card_art_tags ?| {departure})                           AS off_style,
        c.card_set_code, c.collector_number,
-       c.raw_card_blob -> 'image_uris' ->> 'art_crop'                 AS art_url,
-       c.raw_card_blob -> 'image_uris' ->> 'normal'                   AS card_url
+       {art_crop_url}                                                 AS art_url,
+       {normal_url}                                                   AS card_url
 FROM magic.cards c
 WHERE {where}
 """
@@ -275,7 +296,12 @@ def load(where: str) -> list[dict[str, str]]:
     """Fetch component levels for every printing matching `where`."""
     return run_query(
         LEVELS_SQL.format(
-            exempt=pg_arr(STYLE_EXEMPT_TAGS), departure=pg_arr(STYLE_DEPARTURE_TAGS), counted=COUNTED_PRINTING_SQL, where=where
+            exempt=pg_arr(STYLE_EXEMPT_TAGS),
+            departure=pg_arr(STYLE_DEPARTURE_TAGS),
+            counted=COUNTED_PRINTING_SQL,
+            where=where,
+            art_crop_url=front_image("art_crop", "c"),
+            normal_url=front_image("normal", "c"),
         )
     )
 
@@ -330,10 +356,7 @@ def cmd_swaps(sets: list[str], scales: list[str], out: Path, limit: int) -> None
     for k, a, b in changed:
         print(f"  {k:20s} {a:7.2f} -> {b:7.2f}")
 
-    rows = load(
-        "c.raw_card_blob ->> 'lang' = 'en' AND c.prefer_score IS NOT NULL "
-        "AND c.raw_card_blob -> 'image_uris' ->> 'art_crop' IS NOT NULL"
-    )
+    rows = load(f"c.raw_card_blob ->> 'lang' = 'en' AND c.prefer_score IS NOT NULL AND {front_image('art_crop', 'c')} IS NOT NULL")
     by_card: dict[str, list[dict[str, str]]] = {}
     for r in rows:
         by_card.setdefault(r["card_name"], []).append(r)
@@ -485,10 +508,7 @@ def cmd_step(comp: str, direction: str, out: Path) -> None:
     """Find the smallest change to one component that moves TARGET_SWAPS cards."""
     if comp not in WEIGHTS:
         sys.exit(f"unknown component {comp!r}; known: {', '.join(sorted(WEIGHTS))}")
-    rows = load(
-        "c.raw_card_blob ->> 'lang' = 'en' AND c.prefer_score IS NOT NULL "
-        "AND c.raw_card_blob -> 'image_uris' ->> 'art_crop' IS NOT NULL"
-    )
+    rows = load(f"c.raw_card_blob ->> 'lang' = 'en' AND c.prefer_score IS NOT NULL AND {front_image('art_crop', 'c')} IS NOT NULL")
     by: dict[str, list[dict[str, str]]] = {}
     for r in rows:
         by.setdefault(r["card_name"], []).append(r)
@@ -816,7 +836,7 @@ WITH e AS (
   SELECT c.card_name, c.illustration_id, c.card_set_code, c.card_frame_data, c.card_border,
          c.card_rarity_int, c.raw_card_blob ->> 'image_status' AS img,
          c.raw_card_blob ->> 'collector_number' AS cn,
-         c.raw_card_blob -> 'image_uris' ->> 'normal' AS url,
+         {normal_url} AS url,
          CASE WHEN c.raw_card_blob -> 'finishes' ? 'nonfoil' THEN 'nonfoil'
               WHEN c.raw_card_blob -> 'finishes' ? 'foil' THEN 'foil' ELSE 'etched' END AS fin,
          -- Sorted, so ["showcase","legendary"] and ["legendary","showcase"] compare equal --
@@ -836,7 +856,7 @@ WITH e AS (
          COALESCE(c.raw_card_blob ->> 'promo', 'f')         AS promo
   FROM magic.cards c
   WHERE c.raw_card_blob ->> 'lang' = 'en' AND c.illustration_id IS NOT NULL
-    AND c.raw_card_blob -> 'image_uris' ->> 'normal' IS NOT NULL),
+    AND {normal_url} IS NOT NULL),
 -- Grouped rather than self-joined: a self-join on jsonb frame data over 94k rows does not
 -- finish, while one pass bucketing by the same key does. A bucket qualifies when it holds
 -- both finishes, and everything in the key is by construction identical between them.
@@ -863,7 +883,7 @@ def cmd_finishtest(out: Path, n: int) -> None:
     dominated by the 7th-10th Edition `*` foils -- a verdict drawn only from those would
     say something about 2003-era foil stock, not about foil in general.
     """
-    rows = run_query(FINISH_PAIR_SQL)
+    rows = run_query(FINISH_PAIR_SQL.format(normal_url=front_image("normal", "c")))
     by_set: dict[str, list[dict[str, str]]] = {}
     for r in rows:
         by_set.setdefault(r["card_set_code"], []).append(r)

--- a/scripts/tests/test_copy_images_to_s3.py
+++ b/scripts/tests/test_copy_images_to_s3.py
@@ -9,6 +9,7 @@ import requests
 from scripts.copy_images_to_s3 import (
     download_image,
     fetch_cards_from_db,
+    get_db_cards,
 )
 
 
@@ -75,3 +76,44 @@ def test_fetch_cards_from_db() -> None:
     assert cards[0]["card_set_code"] == "iko"
     assert cards[0]["collector_number"] == "123"
     assert cards[1]["card_set_code"] == "thb"
+
+
+def test_get_db_cards_emits_back_face_images() -> None:
+    """A card with a physical back face yields face-2 images alongside the front's.
+
+    The back image feeds the site's flip button; single-faced cards (and split/adventure
+    faces, which carry no per-face images) must stay front-only.
+    """
+    rows = [
+        {"card_set_code": "mid", "collector_number": "5", "png_url": "https://x/front.png", "back_png_url": "https://x/back.png"},
+        {"card_set_code": "m21", "collector_number": "1", "png_url": "https://x/solo.png", "back_png_url": None},
+    ]
+    args = Mock(limit=None, set_code=None)
+    with (
+        patch("scripts.copy_images_to_s3.get_database_connection"),
+        patch("scripts.copy_images_to_s3.fetch_cards_from_db", return_value=rows),
+    ):
+        images = get_db_cards(args)
+
+    keys = {image.get_s3_key() for image in images}
+    assert "img/mid/5/1/388.webp" in keys
+    assert "img/mid/5/2/388.webp" in keys
+    assert "img/m21/1/1/388.webp" in keys
+    assert not any("/m21/1/2/" in key for key in keys)
+    assert len(images) == 12  # (front+back) * 4 sizes + front-only * 4 sizes
+
+
+def test_get_db_cards_back_face_carries_its_own_png_url() -> None:
+    """The face-2 image downloads the back PNG, not the front's."""
+    rows = [
+        {"card_set_code": "mid", "collector_number": "5", "png_url": "https://x/front.png", "back_png_url": "https://x/back.png"},
+    ]
+    args = Mock(limit=None, set_code=None)
+    with (
+        patch("scripts.copy_images_to_s3.get_database_connection"),
+        patch("scripts.copy_images_to_s3.fetch_cards_from_db", return_value=rows),
+    ):
+        images = get_db_cards(args)
+
+    by_face = {image.face_idx: image.png_url for image in images}
+    assert by_face == {"1": "https://x/front.png", "2": "https://x/back.png"}

--- a/scripts/tests/test_copy_images_to_s3.py
+++ b/scripts/tests/test_copy_images_to_s3.py
@@ -117,3 +117,40 @@ def test_get_db_cards_back_face_carries_its_own_png_url() -> None:
 
     by_face = {image.face_idx: image.png_url for image in images}
     assert by_face == {"1": "https://x/front.png", "2": "https://x/back.png"}
+
+
+def test_face_urls_are_derived_from_columns_not_the_blob() -> None:
+    """Both face URLs come from scryfall_id/card_layout, never from raw_card_blob.
+
+    This is the bug that shipped every transform card's BACK image under its face-1 key
+    and its front image nowhere: `raw_card_blob->'image_uris'` is the stored face's, and
+    before the face merge the stored face was the back. Scryfall omits top-level
+    image_uris on a multi-face card, so there was nothing else for it to be.
+
+    Reading the blob is also unavailable, not merely wrong: preprocess_card popped
+    card_faces before snapshotting, so no pre-merge row has that key to fall back to.
+
+    Pinning the query text is unusual, and deliberate. The rest of this file mocks
+    fetchall, so every assertion holds equally well against a query reading the wrong
+    column -- which is precisely how this went unnoticed.
+    """
+    mock_conn = Mock()
+    mock_cursor = Mock()
+    mock_conn.cursor.return_value.__enter__ = Mock(return_value=mock_cursor)
+    mock_conn.cursor.return_value.__exit__ = Mock(return_value=False)
+    mock_cursor.fetchall.return_value = []
+
+    fetch_cards_from_db(mock_conn, limit=1, set_code=None)
+
+    query = mock_cursor.execute.call_args[0][0]
+    assert "scryfall_id" in query, "the image path is a pure function of the card's id"
+    assert "card_layout" in query, "whether a back face exists is a property of the layout"
+    assert "cards.scryfall.io/png/front/" in query
+    assert "cards.scryfall.io/png/back/" in query
+    # The layouts that actually have a second physical face. A split or adventure card
+    # shares a "//" name and must NOT get a back image.
+    assert "transform" in query
+    assert "modal_dfc" in query
+    assert "'split'" not in query
+    # The regression itself: no image URL may be read out of the blob.
+    assert "image_uris" not in query, "raw_card_blob->image_uris is the stored face's, not the front's"


### PR DESCRIPTION
Closes the core of #400 and #873: multi-face cards become **one searchable row carrying every face's data**, the "single conceptual card" direction from the #873 discussion. Based directly on `main`; no overlap with the other open PRs (#872/#877/#879/#888/#889/#890/#893).

## The bug being fixed

`preprocess_card()` fans each multi-face card out to one row per face — all sharing one `scryfall_id` — and the upsert's `ON CONFLICT (scryfall_id)` keeps whichever face came last: **the back**. Hence the #400 audit's findings: `t:battle` matched zero rows corpus-wide, `t:sorcery` missed every MDFC spell side, front-face oracle text was invisible (#873), and ~1,343 printings carried the wrong types/colors/stats. Split cards were hit too (Fire // Ice was findable by Ice's text but not Fire's).

## Why one merged row, not one row per face

Measured against api.scryfall.com (2026-08-08): **Scryfall ANDs search predicates at the card level, each satisfiable by any face.**

- `t:sorcery t:land` returns the MDFC lands — no single face is both
- `o:"flip a coin" o:"instant and sorcery"` matches Ral, Monsoon Mage — the texts live on different faces
- `c:b` matches Westvale Abbey, whose only black face is the back
- `pow=3` matches Brutal Cathar via its back face

One row per printing with any-face unions reproduces those semantics directly. One row per **face** — the original #400 plan — would instead *break every cross-face conjunction* (no face-row satisfies both terms) on top of colliding on the primary key. The merged row isn't a compromise; it's the correct shape.

## What the merge does (`_merge_processed_faces`)

| Field class | Policy |
|---|---|
| Identity/display: `cmc`, `mana_cost`, `illustration_id`, image, prices, raw blob | **front face** — matches Scryfall's own top-level fields (verified on its card objects) |
| `card_types`, `card_subtypes`, `card_colors`, `card_keywords`, `produced_mana`, `illustration_ids` | **union of faces**, order-preserving |
| `oracle_text`, `flavor_text` | faces joined with `\n//\n` — both texts substring-searchable; the newline keeps `.`-based regexes from spanning faces |
| `type_line` | `"Battle — Siege // Creature — Moonfolk Ninja"`, exactly Scryfall's rendering |
| P/T + loyalty | copied per **group** from the first face that has them, so numeric and `_text` columns never describe different faces |

Each face still runs through the full existing pipeline first; the merge is ~40 lines over the processed rows. No schema migration, no engine changes, no SQL-gen changes — the engine inherits everything on reload.

**Plus one vocabulary fix this exposed:** `"Battle"` was missing from the parser's `CARD_TYPES`, so `t:battle` routed to the *subtype* arm on both paths — a guaranteed zero-match the moment battles became visible. The engine was innocent (its `TYPE_BATTLE` bit worked in isolation once the parser sent `card_types`).

## Frontend: back-face flip button

Scryfall-style flip, implemented as progressive enhancement so the no-JS server render (parity fixture) is byte-identical: cards named `A // B` are probed for a face-2 CDN image, and only cards that have one — transform/MDFC, never split/adventure — grow the button (results grid, modal, and card page). `copy_images_to_s3.py` now uploads `card_faces[1]`'s image under the face-2 key (the raw blob keeps the front's `image_uris` at top level for every existing consumer, with the raw `card_faces` re-attached), and the upload path stops hardcoding face 1 in the S3 key. **Ops note:** backs appear on the site after a reimport + image sync run.

## Validation (rebuilt dev stack, full reimport, 97,802 cards, 2026-08-08)

| Check | Before | After | Scryfall |
|---|---|---|---|
| `t:battle` | 0 | **36 cards / 53 printings** | 36 |
| `t:sorcery t:land` | — | **20** | 20 |
| #873's commander query | 21 | **34** | 43, of which 9 are never-legal `draft_innovation` cards the corpus excludes by policy — 34/34 of the achievable set |
| `is:permanent` on battles | 0 | 36 | ✓ |
| Fire // Ice by front-half text | 0 | 1 | ✓ |
| `!"Nissa, Vastwood Seer" t:creature` | 0 | 1 | ✓ |
| `!"Westvale Abbey" c:b` | 0 | 1 | ✓ |
| `!"Brutal Cathar" t:human` | 0 | 1 | ✓ |

**Known residual (tested + documented):** when several faces carry a stat group (Brutal Cathar's 2/2 // 3/3), only the front's values are searchable; Scryfall also matches the back's `pow=3`. Per-face numerics (and back-face `mana:`) are a measured follow-up if wanted.

## Tests

- `test_card_processing.py`: rewritten DFC tests + a `TestFaceMerging` class — battle/MDFC unions, front-priority and back-fallback stat groups, `*`-power group consistency, text joining, all-faces-filtered, one-row-per-printing (the PK-fight regression).
- `test_pyparsing_parser.py`: `t:battle` routes to `card_types`, `t:siege` stays a subtype.
- `test_copy_images_to_s3.py`: face-2 emission with its own PNG URL; single-faced cards stay front-only.
- `app.test.js`: 6 new flip tests (face URLs, probe gating + caching, flip toggling, single-injection). The no-JS parity suite passes untouched.
- Suites: api + parsing + scripts **2,193 passed**; jest **1,747 passed**; ruff + format + prettier clean.


---

## Update: `raw_card_blob` is now the card Scryfall sent (956f8a6)

The merged row's blob was **the front face's dict** with `card_faces` re-attached, so existing top-level reads keep meaning "the front". Going through those reads, exactly one needs that — `image_uris` — and the `copy_images_to_s3.py` change already in this PR gives it a `card_faces->0` fallback. Everything else read from the blob (`lang`, `set_type`, `games`, `finishes`, `frame_effects`, `image_status`, `reserved`, `game_changer`) is card-level and identical either way; `backfill_prefer_scores.sql` never touches `image_uris`.

With that covered, the blob can hold the card verbatim, which buys something the promotion cannot. Every searchable field is merged onto the row's own columns, so the blob has no derivation left to do, and keeping it as Scryfall sent it is what makes the card *answerable* later:

```python
merged_row["raw_card_blob"] = copy.deepcopy(card) | {"card_faces": card_faces}
```

**Why a reader could not have undone the promotion instead.** A card object cannot be rebuilt from a face: `card_faces` is gone, `name` and `type_line` are the front's, and which fields a real card carries at top level varies by **layout** — a split card has `mana_cost` and `image_uris` there, a transform card does not. No rule strips the promoted keys correctly for both.

Measured against the object Scryfall sent, before and after:

| layout | before | after |
|---|---|---|
| transform | 11 extra top-level keys; `object`, `name`, `type_line` all disagree | `card_name` only |
| split | same | `card_name` only |

`card_name` is the combined name the importer lifts before splitting faces — one key, stripped by any reader that wants the original.

**Also in this commit:** `prefer_weights.py`'s seven image reads go through one `front_image()` helper that coalesces to `card_faces->0`, so a transform printing no longer silently drops out of the `art_crop IS NOT NULL` tuning queries. Both of its SQL templates were run against the 97,808-card dev corpus.

**Tests:** five new in `TestMultiFaceRawBlob`, covering both layouts, verified to fail on the previous behavior. Suites: api + parsing + scripts + client **2,514 passed**, jest **1,747 passed**, ruff clean.

**Why now:** #912 needs the card object to serve Scryfall-identical `/cards/*` payloads, and was carrying a `cards.scryfall_json` column to hold a second copy for multi-face rows. With this change that column is gone — the blob is already the answer. #912 is now stacked on this PR.




---

## Update: art tags follow every face the row shows (a9bfc56)

**Folded in from #930, which is now closed.** I opened it as a separate stacked PR first and that was the wrong call: this repairs damage *this* PR does, so merging the two separately would mean merging a regression and its fix as two units, neither of which has landed. One PR that was always correct is strictly better.

### What the merge broke

`card_art_tags` is attached by joining on `magic.cards.illustration_id`:

```python
_sync_card_tags(conn, "illustration_id", "card_art_tags", illustration_id_to_tags)
```

On `main` that is right, and it is right **because** faces are separate rows: a double-faced card's back face is its own row carrying its own `illustration_id`, so a tag on the back art lands on a row and `arttag:` finds the card.

This PR gives the merged row the **front's** `illustration_id` — correctly, matching Scryfall's own top-level field. But then the back's illustration exists nowhere on the row, and a tag that lives only on the back art becomes unreachable by any query. Measured against **api.scryfall.com**, 2026-08-16:

| query | Scryfall | this PR, before a9bfc56 |
|---|---|---|
| `arttag:snow e:khm` | **75** | 73 |
| `-art:human e:khm t:creature` | **135** | 136 |

The two missing from the first are `Birgi, God of Storytelling // Harnfel, Horn of Bounty` and `Esika, God of the Tree // The Prismatic Bridge` — their snow is on the back face's art. The surplus in the second is `Valki, God of Lies // Tibalt, Cosmic Impostor`: Tibalt is the human, and Tibalt is the back.

### The rule, checked against the corpus rather than assumed

Replaying the 2026-08-16 art-tags dump over the bulk cards, the union predicts Scryfall's `arttag:snow e:khm` answer **set-for-set** — 75 names, no surplus and no shortfall — where the front-only reading predicts 73. On the same bulk, **9,368** printings show more than one illustration and **5,491** of them gain at least one tag from a non-front face.

### Mechanism

A row that merges its faces has to carry every illustration it shows, so **`illustration_ids jsonb`** does — front first, deduped. `illustration_id` stays the front's for display.

The merge-side change is one tuple entry, because each face row already computes its own single-element list and `_merge_processed_faces` already unions front-first with dedupe:

```python
_FACE_LIST_UNIONS = ("card_types", "card_subtypes", "illustration_ids")
```

A split or adventure card — one `illustration_id` on the card, none on its faces — has both face rows inherit the same id and collapse back to one entry, which is the right answer: there is one piece of art to tag.

`jsonb` and not `uuid[]`, for a mechanical reason as much as a stylistic one: `api/db/bulk_upsert.py` resolves a column through `_PG_TYPE`, where `jsonb` extracts with `obj->` and an `ARRAY` column falls through to `text` and fails the insert. Matching `card_types`/`card_subtypes` keeps `bulk_upsert` untouched.

**The sync is keyed on `scryfall_id`, not `illustration_id`** — the part I'd most want a second opinion on. An illustration id no longer determines a row's whole value, and it cannot be batched that way either: `_sync_card_tags` batches at 5,000, and a batch of illustration ids can split one card's illustrations across two statements where a batch of cards cannot. So `_union_art_tags` resolves the union in Python and **`_sync_card_tags` is unchanged** — still shared byte-for-byte with the oracle path, still diffing, batching and `IS DISTINCT FROM`-guarded. The costs, stated plainly:

- **Memory: flat.** A single-illustration card references the dump's existing tag dict rather than copying it, so allocation is bounded by those 9,368 multi-illustration printings, not by the corpus.
- **Wire: one record per tagged *card* instead of per tagged *illustration*.** That is the real price. It buys a `scryfall_id` join on the unique index instead of `idx_cards_illustration_id`, and a clear step that is exact per row.

Doing the union in SQL over the array instead needs either a whole-table `UPDATE` with a per-row aggregate — the shape #910 was about — or a temp table plus an unbatched statement. Neither seemed worth giving up the batching for.

**The migration backfills** from `raw_card_blob->'card_faces'`, which on an already-imported row is the only record of the back's illustration. Without it the column is empty until the next card import and `_sync_card_tags` clears every card's art tags in the meantime.

### `prefer_score` reads the union too, deliberately

`art_style` in `backfill_prefer_scores.sql` reads `card_art_tags`, so this moves representative selection. Measured rather than guessed: **exactly three** printings corpus-wide flip `art_style` under the union.

- `Tribute to Horobi // Echo of Death's Wail` neo/356, English and German — back art is `anime`
- `Thaumatic Compass // Spires of Orazca` pxtc/249 — back art is `line-art`

I fed the union to `prefer_score` rather than keeping a front-only reading for it, and that is a choice, not a consequence. For it: `art_style` asks what art a printing shows, and a printing shows all of it — a card whose back is anime *is* partly anime. Against: two readings would protect three rows from a demotion #720's evidence didn't rule on. Three rows is small enough that I'd take either answer; say the word and it's a one-line split.

### `artwork_printings` — still right *given* the merge, and one thing it quietly fixes

The other `card_art_tags`-adjacent consumer in that file is `artwork_printings`, which groups on `(illustration_id, card_name)` and feeds `illustration_count`. It is untouched here, and I checked that it is still **correct** rather than merely unchanged:

- For a transform/MDFC card, each face previously had its own `illustration_id` and so its own group. Post-merge the group keyed on the front illustration has exactly one member per printing — the same membership the front-face row had before — so no surviving row's `illustration_count` moves.
- For **split, adventure and flip** cards it does move, and in the right direction. Both face rows inherited the card's single `illustration_id` *and* the same `card_name`, so they landed in the same group and **each printing was counted twice**. Post-merge each printing counts once. That is ~836 English printings (Scryfall: 345 split, 449 adventure, 42 flip), and the correction is uniform across every printing of such a card, so it cannot flip a representative — `prefer_score` ranks printings within a card, and a monotonic shift applied to all of them preserves the order.

So grouping on the front id remains the right key: it measures how many printings show *this* artwork, and the row shows the front. The residual, unchanged by this PR and a different question, is that two printings sharing a front illustration but differing on the back count as one artwork here while Scryfall's `unique=art` treats them as two.

### Tests

Against real Postgres, not mocks (`test_tagging_integration.py`, `test_upsert_cards.py`):

- a back-face tagging lands on the merged card — **this is the test that proves the fix pins anything**: reverting the keying to `illustration_id` turns it red, which I ran as a negative control rather than assuming
- the front-face tagging still lands, unchanged
- a dump with no taggings clears the row, so the diff-and-clear path stays exact under the new key
- a merged row stores both faces' illustrations, a single-faced row stores its one
- the migration's backfill lands where `preprocess_card` would, on rows written by the real import path

And as units: front-first ordering, a split card's faces collapsing to one illustration, a face with no art contributing nothing, an untagged illustration omitted rather than mapped to `{}`, and the no-copy property of the single-illustration path.

`python -m pytest --ignore=api/tests/test_integration_testcontainers.py`: **2,551 passed, 19 xfailed**. That file errors 22 times for me identically with and without this commit — its class-scoped container binds a fixed host port and collides with the session container locally — so I've left it to CI. `ruff check` and `ruff format --check` clean.
