### PR TITLE
Parsing: Drive is:modal Off the Modal Oracle Tag

### DIFF
--- a/api/parsing/rewrite.py
+++ b/api/parsing/rewrite.py
@@ -138,15 +138,12 @@ _DERIVED_EXPANSIONS: dict[tuple[str, str], str] = {
     # mirror; the local count carries the usual corpus-policy delta only.
     ("is", "adventure"): "layout:adventure",
     ("is", "frenchvanilla"): "otag:french-vanilla",  # community tag, ~+233 looser than "keywords only"
-    # is:modal by the mode-introducing wording. Runs ~+50 over Scryfall's own
-    # count (835 vs 800 live / 770 paper on 2026-08-09): the union reads any
-    # "choose ..." mode header, which is broader than their curated notion --
-    # accepted as a documented delta, per the trust-the-wording policy the
-    # land segment already follows.
-    (
-        "is",
-        "modal",
-    ): 'o:"choose one" or o:"choose two" or o:"choose three" or o:"choose four" or o:"choose up to"',
+    # is:modal is the community tag, not the wording: on Scryfall, is:modal and
+    # otag:modal agree to within 9 cards (800 vs 797 on 2026-08-08), while the
+    # "choose ..." wording union it replaces ran ~+100 locally (835 vs 734) in
+    # both directions -- it caught non-modal choosing ("choose two cards from
+    # it") and missed the modal cards that word it otherwise (Sieges, Confluences).
+    ("is", "modal"): "otag:modal",
 }
 
 

--- a/api/parsing/rewrite.py
+++ b/api/parsing/rewrite.py
@@ -138,11 +138,13 @@ _DERIVED_EXPANSIONS: dict[tuple[str, str], str] = {
     # mirror; the local count carries the usual corpus-policy delta only.
     ("is", "adventure"): "layout:adventure",
     ("is", "frenchvanilla"): "otag:french-vanilla",  # community tag, ~+233 looser than "keywords only"
-    # is:modal is the community tag, not the wording: on Scryfall, is:modal and
-    # otag:modal agree to within 9 cards (800 vs 797 on 2026-08-08), while the
-    # "choose ..." wording union it replaces ran ~+100 locally (835 vs 734) in
-    # both directions -- it caught non-modal choosing ("choose two cards from
-    # it") and missed the modal cards that word it otherwise (Sieges, Confluences).
+    # The community tag tracks is:modal far better than the mode-introducing
+    # wording did, and is cheaper to evaluate. Scored on Scryfall's corpus
+    # against their own is:modal (800 cards, 2026-08-08), otag:modal disagrees
+    # on 9 while the 'o:"choose one" or ...' union it replaces disagrees on 197
+    # -- and in both directions, catching non-modal choosing ("choose two cards
+    # from it") while missing modal cards worded otherwise (Sieges, Confluences).
+    # Not an exact mirror of theirs, just a much closer one.
     ("is", "modal"): "otag:modal",
 }
 

--- a/api/parsing/tests/test_rewrite.py
+++ b/api/parsing/tests/test_rewrite.py
@@ -65,10 +65,7 @@ EQUIVALENCES = [
     ("is:frenchvanilla", "otag:french-vanilla"),
     ("is:shadowland", "t:land o:/reveal an? (Plains|Island|Swamp|Mountain|Forest)/"),
     ("is:snarl", "t:land o:/reveal an? (Plains|Island|Swamp|Mountain|Forest)/"),
-    (
-        "is:modal",
-        'o:"choose one" or o:"choose two" or o:"choose three" or o:"choose four" or o:"choose up to"',
-    ),
+    ("is:modal", "otag:modal"),
     # composes under negation and inside compounds
     ("-frame:old", "-(frame:1993 or frame:1997)"),
     ("t:goblin frame:modern", "t:goblin frame:2003"),

--- a/client/query_sampler.py
+++ b/client/query_sampler.py
@@ -164,10 +164,10 @@ STATIC_VALUES: dict[str, list[str]] = {
     # _DERIVED_EXPANSIONS; test_query_sampler asserts they agree). Not imported from there because
     # this module ships in the client image, which contains no `api/`.
     #
-    # Anything outside this set parses but falls through to a `card_is_tags` lookup, and that
-    # column only carries the few keys the import writes — `is:reserved` is the one to reach for,
-    # backfilled from the bulk blob's own boolean. Values with no key there match zero cards, as
-    # `is:token` and `is:spell` did in the old load-generator list. All 44 are kept rather
+    # Anything outside this set parses but falls through to a `card_is_tags` lookup, and that column
+    # carries only the two booleans the import syncs from the bulk blob — `is:reserved` is the one to
+    # reach for. Values with no key there still match zero cards, as `is:reprint`, `is:token` and
+    # `is:spell` did in the old load-generator list. All 44 are kept rather
     # than a token few: the family's share of traffic is set by its weight, not by how many values
     # it holds, and each expands to a genuinely different shape — layout lookups, type unions, an
     # oracle-text heuristic, a numeric conjunction.

--- a/client/query_sampler.py
+++ b/client/query_sampler.py
@@ -165,8 +165,9 @@ STATIC_VALUES: dict[str, list[str]] = {
     # this module ships in the client image, which contains no `api/`.
     #
     # Anything outside this set parses but falls through to a `card_is_tags` lookup, and that
-    # column is empty — `is:reprint`, `is:token`, `is:modal` and `is:spell` were in the old
-    # load-generator list and every one of them matched zero cards. All 44 are kept rather
+    # column only carries the few keys the import writes — `is:reserved` is the one to reach for,
+    # backfilled from the bulk blob's own boolean. Values with no key there match zero cards, as
+    # `is:token` and `is:spell` did in the old load-generator list. All 44 are kept rather
     # than a token few: the family's share of traffic is set by its weight, not by how many values
     # it holds, and each expands to a genuinely different shape — layout lookups, type unions, an
     # oracle-text heuristic, a numeric conjunction.


### PR DESCRIPTION
Closes #897.

`is:modal` expanded to a five-way union of oracle-text matches:

```
o:"choose one" or o:"choose two" or o:"choose three" or o:"choose four" or o:"choose up to"
```

The wording is not the definition. Expanding to `otag:modal` instead tracks Scryfall's `is:modal` far more closely, and is cheaper to run.

## Accuracy

Scryfall's own `is:modal` is not the tag either — if it were, the two would agree exactly, and they don't. But the tag correlates with it far better than the wording does. Measured on Scryfall's corpus against their `is:modal` as the reference (800 cards, 2026-08-08), so both candidates are scored against the same ground truth:

| | total | missed | over-caught | wrong |
|---|---|---|---|---|
| `otag:modal` | 797 | 6 | 3 | **9** |
| the wording union | 893 | 52 | 145 | **197** |

The tag is both more sensitive and more specific — it is not simply a tighter or looser cut of the same set. Precision goes 83.8% → 99.6%, recall 93.5% → 99.2%; ~22× fewer disagreements overall.

The failures on our own corpus, by name:

**Text, not modal** — Agonizing Memories, Bamboozle, Barrin's Spite. "Choose two cards from it" is a choice, not a mode header.

**Modal, not text** — every Siege ("As this enters, choose Khans or Dragons"), the Confluences, Catastrophe, Henrika Domnathi.

Locally the tag returns 734 distinct card names against the union's 835, overlapping on 709. The gap to Scryfall's 797 is the usual corpus delta plus tag-snapshot lag.

The old comment claimed a documented `~+50` over-catch under a "trust-the-wording" policy. That framing was wrong for this filter: the delta ran both ways, so the excess was not a broader-but-consistent reading — it was noise in one direction and holes in the other.

## Cost

One JSONB containment replaces five oracle-text substring matches. Counting the predicate alone over the full table on blue, warm, interleaved, 5 runs each:

| | median | spread |
|---|---|---|
| `card_oracle_tags @> '{"modal": true}'` | 82 ms | 80–85 ms |
| the five-way `ilike` union | 141 ms | 136–151 ms |

Both plans scan the table for a bare `count(*)`, so the ~59 ms gap is per-row predicate cost, not an index difference. In a real search the predicate combines with others, so treat this as the direction and rough size of the effect rather than an end-to-end promise.

## Also in this PR

`client/query_sampler.py` carried a stale note that the `card_is_tags` fall-through column "is empty", listing `is:reprint`, `is:token`, `is:modal` and `is:spell` as values that matched zero cards. The column is no longer empty: #888 backfills the two booleans Scryfall ships on every bulk card object, `reserved` (1,069 rows) and `gamechanger` (428). Those are the only two — `CUSTOM_IS_TAGS` is a lazy per-tag sweep, not part of a normal import.

The note now points at `is:reserved` as the fall-through that actually works, and keeps `is:reprint` / `is:token` / `is:spell` as the zero-match cases they still are. `is:modal` drops off that list because it no longer falls through.

## Testing

1,741 tests pass (`api/parsing/tests` + `client/tests`), ruff clean. The `test_query_sampler` tripwire asserting the sampler's `is:` list matches `_DERIVED_EXPANSIONS` stays green — the value name is unchanged, only its expansion.
