### PR TITLE
Parsing: The Remaining Scryfall Alias Spellings — ci, atag/arttag, oracletag/function

### DIFF
--- a/api/parsing/db_info.py
+++ b/api/parsing/db_info.py
@@ -76,7 +76,7 @@ DB_COLUMNS = [
     FieldInfo(
         db_column_name="card_color_identity",
         field_type=FieldType.JSONB_OBJECT,
-        search_aliases=["color_identity", "coloridentity", "id", "identity"],
+        search_aliases=["color_identity", "coloridentity", "id", "identity", "ci"],
         parser_class=ParserClass.COLOR,
     ),
     FieldInfo(
@@ -196,13 +196,13 @@ DB_COLUMNS = [
     FieldInfo(
         db_column_name="card_oracle_tags",
         field_type=FieldType.JSONB_OBJECT,
-        search_aliases=["oracle_tags", "otag"],
+        search_aliases=["oracle_tags", "otag", "oracletag", "function"],
         parser_class=ParserClass.TEXT,
     ),
     FieldInfo(
         db_column_name="card_art_tags",
         field_type=FieldType.JSONB_OBJECT,
-        search_aliases=["art_tags", "art"],
+        search_aliases=["art_tags", "art", "atag", "arttag"],
         parser_class=ParserClass.TEXT,
     ),
     FieldInfo(

--- a/api/parsing/tests/test_alias_spellings.py
+++ b/api/parsing/tests/test_alias_spellings.py
@@ -1,0 +1,53 @@
+"""Scryfall's alternate spellings for color identity and the two tag families.
+
+Scryfall accepts three spellings per tag family — `art`/`atag`/`arttag` and
+`otag`/`oracletag`/`function` — each returning identical results (verified live:
+196/196/196 and 6427/6427/6427), and `ci` as a color-identity alias
+(`ci<=bg` == `id<=bg`). Only one spelling per family was recognized here, so a
+client forwarding Scryfall-shaped query strings verbatim hit a parse error on
+the rest. Each added spelling must resolve to the same field as its canonical
+form, in both parsers.
+"""
+
+import pytest
+
+from api.parsing import generate_sql_query, parse_scryfall_query
+from api.parsing.pyparsing_based import parse_search_query
+
+# (alias spelling, the already-supported spelling it must match)
+TAG_ALIAS_CASES = [
+    ("atag:squirrel", "art:squirrel"),
+    ("arttag:squirrel", "art:squirrel"),
+    ("oracletag:removal", "otag:removal"),
+    ("function:removal", "otag:removal"),
+]
+
+
+@pytest.mark.parametrize(
+    argnames=["alias_query", "canonical_query"],
+    argvalues=TAG_ALIAS_CASES,
+    ids=[q for q, _ in TAG_ALIAS_CASES],
+)
+def test_tag_aliases_match_canonical(alias_query: str, canonical_query: str) -> None:
+    """Each Scryfall tag-alias spelling produces identical SQL to its canonical form, in both parsers."""
+    assert generate_sql_query(parse_scryfall_query(alias_query)) == generate_sql_query(parse_scryfall_query(canonical_query))
+    assert generate_sql_query(parse_search_query(alias_query)) == generate_sql_query(parse_search_query(canonical_query))
+
+
+CI_CASES = [
+    ("ci<=bg", "id<=bg"),
+    ("ci:wu", "id:wu"),
+    ("ci>=rg", "identity>=rg"),
+    ("t:land ci<=bg", "t:land id<=bg"),
+]
+
+
+@pytest.mark.parametrize(
+    argnames=["ci_query", "id_query"],
+    argvalues=CI_CASES,
+    ids=[q for q, _ in CI_CASES],
+)
+def test_ci_is_an_identity_alias(ci_query: str, id_query: str) -> None:
+    """`ci` produces identical SQL to the established identity aliases, in both parsers."""
+    assert generate_sql_query(parse_scryfall_query(ci_query)) == generate_sql_query(parse_scryfall_query(id_query))
+    assert generate_sql_query(parse_search_query(ci_query)) == generate_sql_query(parse_search_query(id_query))


### PR DESCRIPTION
## What

Split out of #872 (@daveycodez's work, commit authored to them) so the alias half can merge on its own and #872 is left holding only the result-shape directives.

Scryfall accepts three spellings per tag family — `art`/`atag`/`arttag` and `otag`/`oracletag`/`function` — each returning identical results (verified live against api.scryfall.com: 196/196/196 and 6427/6427/6427), plus `ci` as a color-identity alias (`ci<=bg` == `id<=bg`). Only one spelling per family was recognized here, so a client forwarding Scryfall-shaped query strings verbatim hit a parse error on the rest.

Both parsers read their alias table from `db_info.py`, so this is five list entries plus tests.

## Validation

- `api/parsing/tests/`: 1632 passed, including the new `test_alias_spellings.py` (each new spelling ≡ its canonical form, in both parsers)
- `ruff check` and `ruff format --check` clean on the touched files