### PR TITLE
Parsing: Accept Negative Literals as Comparison Values

### DIFF
--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -448,7 +448,7 @@ class Parser:
         # ── dual-class alias (cn / number): dispatch on value shape ──
         if wl in _DUAL_NUM_TEXT and next_tok.type == TT.OP:
             op = self.consume().value
-            if self.peek().type == TT.NUMBER:
+            if self._value_starts_number():
                 return CardBinaryOperatorNode(CardAttributeNode(wl, ParserClass.NUMERIC), op, self.parse_num_expr_value())
             return CardBinaryOperatorNode(CardAttributeNode(wl, ParserClass.TEXT), op, self.parse_text_value(wl))
 
@@ -546,9 +546,29 @@ class Parser:
         msg = f"Expected numeric term, got {tok.value!r} at position {tok.pos}"
         raise ParseError(msg)
 
+    def _value_starts_number(self) -> bool:
+        """Return True if the value about to be parsed opens with a numeric literal, signed or not."""
+        if self.peek().type == TT.NUMBER:
+            return True
+        return self.peek().type == TT.MINUS and self.peek(1).type == TT.NUMBER
+
+    def parse_signed_num_term(self) -> QueryNode:
+        """Parse a numeric term that may carry a leading '-' sign (the -1 in 'power>-1').
+
+        Only the leading term of a value expression may be signed. A '-' there has no competing
+        reading — filter negation and binary subtraction both require a preceding operand, and a
+        comparison operator has just consumed that position — so no spacing rule is needed to
+        disambiguate it, unlike the '-' handling in _spaced_arith_tail.
+        """
+        if self.peek().type == TT.MINUS and self.peek(1).type == TT.NUMBER:
+            self.consume()  # MINUS
+            tok = self.consume()  # NUMBER
+            return NumericValueNode(-tok.value)
+        return self.parse_num_term()
+
     def parse_num_expr_value(self) -> QueryNode:
         """Numeric expression in value context (spaces around arith ops are OK)."""
-        lhs = self.parse_num_term()
+        lhs = self.parse_signed_num_term()
         while self.peek().type in _ARITH_OPS and self._num_term_start(self.peek(1)):
             tok = self.peek()
             if tok.type == TT.MINUS and tok.space_before and not self.peek(1).space_before:

--- a/api/parsing/pyparsing_based.py
+++ b/api/parsing/pyparsing_based.py
@@ -230,6 +230,11 @@ def create_basic_parsers() -> dict[str, ParserElement]:
     word = Regex(r"[^\W\d][\w-]*\w|[^\W\d]").set_parse_action(make_word)
 
     literal_number = float_number | integer
+    # Signed literals are wired into the right-hand side of a numeric comparison only (see
+    # numeric_comparison_rhs): everywhere else a leading '-' is filter negation or subtraction.
+    negative_float = Regex(r"-\d+\.\d*").set_parse_action(lambda t: float(t[0]))
+    negative_integer = Regex(r"-\d+\b").set_parse_action(lambda t: int(t[0]))
+    signed_literal_number = negative_float | negative_integer | literal_number
     string_value_word = Regex(r"\w[\w.-]*")
 
     return {
@@ -246,6 +251,7 @@ def create_basic_parsers() -> dict[str, ParserElement]:
         "regex_pattern": regex_pattern,
         "word": word,
         "literal_number": literal_number,
+        "signed_literal_number": signed_literal_number,
         "string_value_word": string_value_word,
     }
 
@@ -301,6 +307,7 @@ def create_all_condition_parsers(basic_parsers: dict, mana_parsers: dict, color_
     quoted_string = basic_parsers["quoted_string"]
     string_value_word = basic_parsers["string_value_word"]
     literal_number = basic_parsers["literal_number"]
+    signed_literal_number = basic_parsers["signed_literal_number"]
     arithmetic_op = basic_parsers["arithmetic_op"]
     lparen = basic_parsers["lparen"]
     rparen = basic_parsers["rparen"]
@@ -324,8 +331,14 @@ def create_all_condition_parsers(basic_parsers: dict, mana_parsers: dict, color_
     arithmetic_expr <<= arithmetic_term + arithmetic_op + arithmetic_term + ZeroOrMore(arithmetic_op + arithmetic_term)
     arithmetic_expr.set_parse_action(make_chained_arithmetic)
 
+    # Only the leading term of the RHS may be signed — 'power>-1+cmc' is (-1)+cmc, while
+    # 'power>cmc+-1' stays a parse error, matching parse_signed_num_term in the hand parser.
+    signed_arithmetic_expr = signed_literal_number + arithmetic_op + arithmetic_term + ZeroOrMore(arithmetic_op + arithmetic_term)
+    signed_arithmetic_expr.set_parse_action(make_chained_arithmetic)
+
     numeric_comparison_lhs = arithmetic_expr | paren_expr_term | numeric_attr_word | literal_number
-    unified_numeric_comparison = numeric_comparison_lhs + DEFAULT_OPERATORS + numeric_comparison_lhs
+    numeric_comparison_rhs = arithmetic_expr | signed_arithmetic_expr | paren_expr_term | numeric_attr_word | signed_literal_number
+    unified_numeric_comparison = numeric_comparison_lhs + DEFAULT_OPERATORS + numeric_comparison_rhs
     unified_numeric_comparison.set_parse_action(make_binary_operator_node)
 
     mana_value_or_string = mana_value | quoted_string | string_value_word

--- a/api/parsing/tests/implicit_and_cases.py
+++ b/api/parsing/tests/implicit_and_cases.py
@@ -106,6 +106,13 @@ TESTCASES = [
     {"query": "power>2 -toughness>0", "expected": "power>2 AND -toughness>0", "id": "cmp_then_neg_toughness"},
     {"query": "power>2 -(cmc-1)>0", "expected": "power>2 AND -(cmc-1)>0", "id": "cmp_then_neg_paren"},
     {"query": "power>2 cmc<3", "expected": "power>2 AND cmc<3", "id": "two_comparisons_and"},
+    # Negative literal as a comparison value (#891): the '-' is a sign, so no AND is inserted
+    {"query": "power>-1", "expected": "power>-1", "id": "cmp_negative_literal"},
+    {"query": "power > -1", "expected": "power>-1", "id": "cmp_negative_literal_spaces"},
+    {"query": "power>-1.5", "expected": "power>-1.5", "id": "cmp_negative_float_literal"},
+    {"query": "t:creature power>-1", "expected": "t:creature AND power>-1", "id": "attr_then_cmp_negative_literal"},
+    {"query": "power>-1 t:creature", "expected": "power>-1 AND t:creature", "id": "cmp_negative_literal_then_attr"},
+    {"query": "power>-1+2", "expected": "power>-1+2", "id": "cmp_negative_literal_arith_tail"},
     # Arithmetic within comparison (not after comparison RHS): must not insert AND
     {"query": "power*2 - 1 > 0", "expected": "power*2-1>0", "id": "arith_mul_sub_lit"},
     # Multi-term arithmetic chains (compact / no spaces): tokenizer absorbs as single tokens

--- a/api/parsing/tests/test_negative_literals.py
+++ b/api/parsing/tests/test_negative_literals.py
@@ -1,0 +1,74 @@
+"""Tests for negative numeric literals in value position, e.g. 'power>-1' (#891)."""
+
+import pytest
+
+from api.parsing.card_query_nodes import CardAttributeNode
+from api.parsing.nodes import BinaryOperatorNode, NotNode, NumericValueNode
+
+testcases = {
+    "greater_than": {"query": "power>-1", "column": "creature_power", "operator": ">", "value": -1},
+    "greater_or_equal": {"query": "power>=-1", "column": "creature_power", "operator": ">=", "value": -1},
+    "less_than": {"query": "toughness<-2", "column": "creature_toughness", "operator": "<", "value": -2},
+    "equals": {"query": "power=-1", "column": "creature_power", "operator": "=", "value": -1},
+    "not_equals": {"query": "power!=-1", "column": "creature_power", "operator": "!=", "value": -1},
+    # ':' on a numeric attribute is Scryfall's spelling of '='; it stays ':' in the AST and
+    # becomes '=' at SQL generation.
+    "colon_operator": {"query": "power:-1", "column": "creature_power", "operator": ":", "value": -1},
+    "float_literal": {"query": "power>-1.5", "column": "creature_power", "operator": ">", "value": -1.5},
+    "cmc": {"query": "cmc>-1", "column": "cmc", "operator": ">", "value": -1},
+    "loyalty": {"query": "loyalty>-1", "column": "planeswalker_loyalty", "operator": ">", "value": -1},
+    # The '-' need not hug the operator: nothing else can start a value here.
+    "spaces_around_operator": {"query": "power > -1", "column": "creature_power", "operator": ">", "value": -1},
+    # cn/number are dual numeric/text aliases — a signed literal picks the numeric branch,
+    # the same as a bare one does.
+    "dual_class_alias": {"query": "cn>-1", "column": "collector_number_int", "operator": ">", "value": -1},
+}
+
+
+@pytest.mark.parametrize(
+    argnames=sorted(next(iter(testcases.values()))),
+    argvalues=[[v for k, v in sorted(testcases[testname].items())] for testname in sorted(testcases)],
+    ids=sorted(testcases),
+)
+def test_negative_literal_parses(parse_query, column: str, operator: str, query: str, value: float) -> None:
+    """A negative literal on the right of a comparison parses to a negative NumericValueNode."""
+    root = parse_query(query).root
+    assert isinstance(root, BinaryOperatorNode), f"{query!r} did not parse to a comparison: {root}"
+    assert isinstance(root.lhs, CardAttributeNode)
+    assert root.lhs.attribute_name == column
+    assert root.operator == operator
+    assert root.rhs == NumericValueNode(value)
+
+
+def test_signed_literal_leads_arithmetic_value(parse_query) -> None:
+    """Only the leading term of a value may be signed, and it may still start an arithmetic tail."""
+    rhs = parse_query("power>-1+2").root.rhs
+    assert isinstance(rhs, BinaryOperatorNode)
+    assert rhs.lhs == NumericValueNode(-1)
+    assert rhs.operator == "+"
+    assert rhs.rhs == NumericValueNode(2)
+
+
+@pytest.mark.parametrize(
+    argnames=["query"],
+    argvalues=[
+        ("power>-cmc",),  # negating an attribute is not supported, only literals carry a sign
+        ("power>cmc+-1",),  # a sign is only valid on the leading term of a value
+        ("power>cmc--1",),
+    ],
+    ids=["negated_attribute", "sign_after_arithmetic_op", "sign_after_subtraction"],
+)
+def test_unsupported_signs_rejected(parse_query, query: str) -> None:
+    """Signs outside the leading term of a value remain parse errors."""
+    with pytest.raises(ValueError, match="Failed to parse query"):
+        parse_query(query)
+
+
+def test_leading_minus_is_still_negation(parse_query) -> None:
+    """A '-' that opens a factor is filter negation, not a sign — '-1<power' is NOT (1<power)."""
+    root = parse_query("-1<power").root
+    assert isinstance(root, NotNode)
+    assert isinstance(root.operand, BinaryOperatorNode)
+    assert root.operand.lhs == NumericValueNode(1)
+    assert root.operand.operator == "<"
+    assert root.operand.rhs.attribute_name == "creature_power"

--- a/docs/issues/00901-leading-negative-literal-sign-or-negation.md
+++ b/docs/issues/00901-leading-negative-literal-sign-or-negation.md
@@ -1,0 +1,86 @@
+# Leading negative literal: sign or negation?
+
+[#901](https://github.com/jbylund/sylvan_librarian/issues/901). Follow-on to
+[#891](https://github.com/jbylund/sylvan_librarian/issues/891), which made `power>-1` parse.
+
+After #891 the same number written two ways means two different things:
+
+```
+power>-1  →  creature_power > -1
+-1<power  →  NOT (1 < creature_power)      i.e. power <= 1
+```
+
+## Why they diverge
+
+#891 established one rule with no lookahead:
+
+- `-` where a **filter** can start → negation
+- `-` where a **value** must appear → sign
+
+The value case is unambiguous by construction: filter negation and binary subtraction both need a
+preceding operand, and the comparison operator has just consumed that position. That is why
+[`parse_signed_num_term`](../../api/parsing/hand_parser.py) needs no spacing rule, unlike
+`_spaced_arith_tail`.
+
+Leading position is the opposite: what follows a leading `-` becomes a boolean, so negation is the
+natural reading, and `-t:creature` is core Scryfall syntax. The divergence above is the price of
+that rule, not an oversight in it.
+
+## Proposal
+
+Let the sign win over negation **only when the `-` is followed by a numeric literal**.
+
+| query | today | proposed |
+|---|---|---|
+| `-1<power` | `NOT (1 < power)` → power <= 1 | `(-1) < power` → power > -1 |
+| `-1+power>2` | `NOT ((1 + power) > 2)` → power <= 1 | `((-1) + power) > 2` → power > 3 |
+| `-power>0` | `NOT (power > 0)` | unchanged |
+| `-cmc+5>1` | `NOT ((cmc + 5) > 1)` | unchanged |
+| `-(cmc-1)>0` | `NOT ((cmc - 1) > 0)` | unchanged |
+| `-t:creature` | `NOT (t:creature)` | unchanged |
+
+Keying on the *literal* is what keeps the last four rows fixed. The rejected variant is below.
+
+## The cost
+
+`-1<power`, `-2>=cmc` and `-1+power>2` parse today and emit valid, meaningful SQL. The change
+**silently flips working queries** — the failure mode with no error message and no deprecation path.
+Only the non-comparison forms are currently unusable:
+
+```
+-1              →  NOT (1)                 datatype mismatch at PostgreSQL
+-1 t:creature   →  NOT (1) AND t:creature  datatype mismatch at PostgreSQL
+```
+
+The mitigating argument: the affected shape is a comparison with a bare literal on the **left** and
+the attribute on the right, which is rare because `-1<power` is a roundabout spelling of `power>1`
+— and `power>1` is exactly the reading the proposal removes. So the queries that break are the ones
+whose author was relying on the current rule deliberately.
+
+## Rejected: sign binds to the first term of any arithmetic expression
+
+The broader version — a leading `-` signs the next *term* whatever it is, with `-(expr)` reserved
+for negation — was considered and rejected. It turns `-power>3` into `(-power) > 3`, which matches
+almost nothing, and it makes parentheses mandatory to negate any numeric comparison. That is a
+capability loss on syntax users import from Scryfall, and a silent one.
+
+The parser already encodes the opposing intent: `-(cmc-1)` alone raises *"Cannot negate an
+arithmetic expression"*. Negation applies to booleans; a sign has no home outside value position.
+
+## Scope
+
+Both parsers change together, plus the preprocessor that decides AND-insertion around a leading `-`:
+
+- [`api/parsing/hand_parser.py`](../../api/parsing/hand_parser.py) — `parse_factor`
+- [`api/parsing/pyparsing_based.py`](../../api/parsing/pyparsing_based.py) — `handle_negation`,
+  `preprocess_implicit_and`
+- `test_parser_parity.py` holds the two in lockstep over
+  [`implicit_and_cases.py`](../../api/parsing/tests/implicit_and_cases.py); the corpus needs the
+  flipped cases added, since several of them (`cmp_then_arith_leading_minus`,
+  `leading_arith_minus_cmc`) pin the current reading.
+
+## Open question
+
+Whether to do it at all. The divergence is real but affects a rare query shape, and the fix trades a
+silent flip for it. Worth deciding deliberately — the alternative is documenting the rule
+("a leading `-` always negates") and leaving the asymmetry in place.


### PR DESCRIPTION
Closes #891.

## What

`power>-1` failed to parse in **both** parsers. A numeric value had to start with a digit, so the leading `-` had no valid reading and the whole query was rejected — as were `cmc>-1`, `power>=-1`, `toughness<-2`, `power>-1.5` and every other signed comparison.

The fix allows a sign on the **leading term of a value**. That position is unambiguous by construction: filter negation and binary subtraction both require a preceding operand, and the comparison operator has just consumed it. So unlike the `-` handling in `_spaced_arith_tail`, no spacing rule is needed to tell the readings apart — `power>-1`, `power > -1` and `power>- 1` all work, which also matches the pyparsing side, whose preprocessor discards spacing entirely.

Scope is deliberately tight — only the leading term, and only a literal carries a sign:

```
power>-1      →  creature_power > -1
power>-1+2    →  (-1) + 2                  sign leads, arithmetic tail still applies
power>-cmc    →  parse error               negating an attribute is a separate feature
power>cmc+-1  →  parse error               a sign is only valid on the leading term
-1<power      →  NOT (1 < power)           unchanged: a `-` opening a factor still negates
```

`cn`/`number` are dual numeric/text aliases whose branch is chosen by the shape of the value; a signed literal now picks the numeric branch, as a bare one already did. Without that, the two parsers disagreed on `cn>-1`.

No engine change needed — `filter.rs` reads `NumericValueNode` via `as_f64()`, which handles negative JSON numbers already.

## Validation

- New `api/parsing/tests/test_negative_literals.py` — runs against **both** parsers via the existing `parse_query` fixture: 11 signed-comparison shapes, the arithmetic-tail case, the three rejected sign positions, and a regression guard that `-1<power` is still a negation
- 6 cases added to `implicit_and_cases.py`, the shared corpus behind `test_parser_parity.py` and `test_pyparsing_preprocess.py`, so the preprocessor is pinned to not insert an implicit AND before a signed literal
- 28 hand-checked queries emit **byte-identical SQL** from both parsers, including the previously divergent `cn>-1`
- `api/parsing/tests/`: 1676 passed
- `ruff check` and `ruff format --check` clean

## Follow-up

The fix leaves an asymmetry — `power>-1` is a comparison but `-1<power` is a negation — because a leading `-` is Scryfall's NOT. Filed as #901 with the option analysis; the design doc rides along in this PR as `docs/issues/00901-leading-negative-literal-sign-or-negation.md`.