### PR TITLE
Tests: Pin the 15 Known Parser Parity Divergences as Strict xfails

### DIFF
--- a/api/parsing/tests/test_parser_parity.py
+++ b/api/parsing/tests/test_parser_parity.py
@@ -7,13 +7,8 @@ from api.parsing.pyparsing_based import parse_search_query
 from api.parsing.tests.implicit_and_cases import TESTCASES
 
 
-@pytest.mark.parametrize(
-    argnames=["query"],
-    argvalues=[[c["query"]] for c in TESTCASES if c["query"].strip()],
-    ids=[c["id"] for c in TESTCASES if c["query"].strip()],
-)
-def test_both_parsers_agree(query: str) -> None:
-    """Both parsers must produce identical SQL for every query in TESTCASES."""
+def assert_parsers_agree(query: str) -> None:
+    """Assert both parsers accept or reject *query* alike, and emit identical SQL when they accept."""
     hand_exc: Exception | None = None
     pyp_exc: Exception | None = None
     hand_result: tuple | None = None
@@ -38,3 +33,80 @@ def test_both_parsers_agree(query: str) -> None:
         assert hand_result == pyp_result, (
             f"Parsers produce different SQL for {query!r}:\n  hand_rolled: {hand_result}\n  pyparsing:   {pyp_result}"
         )
+
+
+@pytest.mark.parametrize(
+    argnames=["query"],
+    argvalues=[[c["query"]] for c in TESTCASES if c["query"].strip()],
+    ids=[c["id"] for c in TESTCASES if c["query"].strip()],
+)
+def test_both_parsers_agree(query: str) -> None:
+    """Both parsers must produce identical SQL for every query in TESTCASES."""
+    assert_parsers_agree(query)
+
+
+# Real queries from benchmarks/wild-queries/wild-corpus.jsonl on which the two parsers disagree
+# today, grouped by the root cause in #903. Sweeping that 14k-query corpus found exactly these.
+#
+# Each is xfail(strict=True): fixing one turns it into an XPASS and fails the suite, so the fix
+# cannot land without deleting its entry here. Keep the minimal repro alongside the wild query —
+# it is what a fixer works from, and it fails for the same reason.
+KNOWN_DIVERGENCES: dict[str, tuple[str, list[str]]] = {
+    # pyparsing's preprocess_implicit_and misreads the '-' as subtraction and inserts no AND,
+    # because _rhs_introduces_comparison only counts comparison operators at depth 0 — the ones
+    # inside the group are invisible to it. Numeric LHS yields `int - boolean` (invalid SQL);
+    # a year LHS yields a parse error.
+    "a_minus_before_group_after_numeric": (
+        "#903 A: comparison nested in the group is invisible to _rhs_introduces_comparison",
+        [
+            "cmc>1 -(t:elf)",
+            "pow=3 -(name:force or type:elf)",
+            "usd>50 -(format:modern or format:commander)",
+            "year:2019 -(t:elf)",
+            "year:2019 -(oracle:exile or type:enchantment)",
+            "year:2022 -(id:rg or usd<0.25)",
+            "year:2022 -(id:ub or artist:avon)",
+            "year:2022 -(set:mid or color:ubr)",
+            "year:2022 -(tou=4 or set:mom)",
+            "year:2023 -(id:rg or name:dark)",
+            "year:2023 -(year:2020 or set:mom)",
+            "year:2024 -(name:co or set:khm)",
+        ],
+    ),
+    # The implicit-AND tokenizer matches CaselessKeyword("AND"/"OR") before it knows it is in
+    # value position, so 'o:or' preprocesses to 'o: OR' and the value is gone. Only on the slow
+    # path — a query with none of ()"'/{+* takes the fast path and is unaffected.
+    "b_reserved_word_as_value": (
+        "#903 B: and/or in value position consumed as a boolean operator by the tokenizer",
+        [
+            "o:and power+toughness>10",
+            "(o:or o:more) t:land",
+            "(oracle:two oracle:or oracle:more oracle:opponents) type:land",
+        ],
+    ),
+    # Scryfall's exact-color operator is implemented by neither parser. pyparsing rejects it;
+    # the hand parser silently reads it as an implicit name plus an exact name, so 'c!w' becomes
+    # name LIKE %c% AND name = "w" and quietly matches nothing.
+    "c_exact_color_operator": (
+        "#903 C: c!/id! exact-color unsupported — pyparsing rejects, hand parser mis-parses",
+        [
+            "c!w",
+            "c!ubg cmc>=6 f:standard",
+            "en-kor c!w",
+            "o:destroy o:creature o:with o:flying c!g",
+        ],
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    argnames=["query"],
+    argvalues=[
+        pytest.param(query, marks=pytest.mark.xfail(strict=True, reason=reason), id=f"{cause}-{index}")
+        for cause, (reason, queries) in KNOWN_DIVERGENCES.items()
+        for index, query in enumerate(queries)
+    ],
+)
+def test_known_parser_divergences(query: str) -> None:
+    """Queries the parsers disagree on today (#903) — remove an entry when its cause is fixed."""
+    assert_parsers_agree(query)

--- a/api/parsing/tests/test_parser_parity.py
+++ b/api/parsing/tests/test_parser_parity.py
@@ -84,11 +84,12 @@ KNOWN_DIVERGENCES: dict[str, tuple[str, list[str]]] = {
             "(oracle:two oracle:or oracle:more oracle:opponents) type:land",
         ],
     ),
-    # Scryfall's exact-color operator is implemented by neither parser. pyparsing rejects it;
-    # the hand parser silently reads it as an implicit name plus an exact name, so 'c!w' becomes
+    # On Scryfall '!' is an alias for '=' on color/mana/numeric/rarity/year/date fields, and not an
+    # operator at all on text fields. Neither parser implements the alias: pyparsing rejects the
+    # shape, and the hand parser applies the text-field fallback everywhere, so 'c!w' becomes
     # name LIKE %c% AND name = "w" and quietly matches nothing.
-    "c_exact_color_operator": (
-        "#903 C: c!/id! exact-color unsupported — pyparsing rejects, hand parser mis-parses",
+    "c_bang_equals_alias": (
+        "#903 C: '!' as an '=' alias unimplemented — pyparsing rejects, hand parser mis-parses",
         [
             "c!w",
             "c!ubg cmc>=6 f:standard",

--- a/docs/issues/00903-parser-parity-divergences.md
+++ b/docs/issues/00903-parser-parity-divergences.md
@@ -71,27 +71,54 @@ the following `OR` token as the string `"OR"` — coincidentally what the user m
 is a comparison operator. The hand parser gets this right for free by parsing values in context
 rather than pre-tokenizing.
 
-## C. `c!` exact-color is unsupported, and one parser hides it — 3 of 15
+## C. `!` is Scryfall's `=` alias, unimplemented here — 3 of 15
 
-Scryfall's `c!ubg` ("colors are exactly UBG") is implemented by neither parser. pyparsing rejects
-it. The hand parser silently splits it into an implicit name and an exact name:
+`c!ubg` is not a distinct "exact color" operator. On Scryfall `!` is simply an alias for `=`.
+Verified live against api.scryfall.com, 2026-08-08 — `total_cards` for each spelling:
 
-```
-c!w  ->  name:"c" AND !w  ->  name LIKE %c% AND name = "w"
-```
+| query | with `!` | with `=` |
+|---|---|---|
+| `c!g` | 4,904 | 4,904 |
+| `c!ubg` | 57 | 57 |
+| `id!rg` | 471 | 471 |
+| `cmc!3` | 8,077 | 8,077 |
+| `pow!3` | 4,079 | 4,079 |
+| `usd!5` | 39 | 39 |
+| `r!rare` | 11,766 | 11,766 |
+| `mana!2G` | 1,014 | 1,014 |
+| `devotion!gg` | 1,090 | 1,090 |
+| `year!2020` | 3,886 | 3,886 |
+| `date!2020-01-01` | 17 | 17 |
 
-Zero rows, no error. The divergence is a symptom; the gap is that `c!`/`id!` is not implemented.
+The alias is **not** universal. For text-valued fields Scryfall does not treat `!` as an operator
+at all — it falls back to reading the `!` as its exact-name prefix, which is precisely what our
+hand parser does:
+
+| query | Scryfall | vs `=` spelling |
+|---|---|---|
+| `t!creature` | 0 | `t=creature` → 18,751 |
+| `o!flying` | 0 | `o=flying` → 4,574 |
+| `s!khm` | 0 | `s=khm` → 323 |
+| `f!modern` | 2 | `f=modern` → 22,450 |
+
+So the hand parser's `c!w` → `name:"c" AND !w` is the **correct** reading for TEXT and LEGALITY
+fields, and wrong only for the classes where `!` really is an operator. pyparsing rejects the shape
+outright, which is wrong in both directions.
+
 Affected: `c!ubg cmc>=6 f:standard`, `en-kor c!w`, `o:destroy o:creature o:with o:flying c!g`.
 
-This is a feature request wearing a bug's clothes, and splitting it out is reasonable — but the
-hand parser's silent mis-parse is worth fixing either way, independently of whether `c!` is ever
-implemented.
+**Fix sketch:** accept `!` as an `=` alias for `ParserClass` COLOR, MANA, NUMERIC, RARITY, YEAR and
+DATE; keep the existing implicit-name fallback for TEXT and LEGALITY. The wrinkle is tokenization:
+`!=` must keep winning over `!` (longest match), and the hand lexer emits `BANG` rather than `OP`,
+so `parse_word_primary` has to accept a `BANG` after an alias of a supporting class. That is a
+smaller and better-specified change than "implement exact-color matching" — the comparison
+semantics already exist, only the spelling is missing.
 
 ## Suggested order
 
 **A** first: it produces invalid SQL from a query shape users write, and the fix is one function.
-**C** is the worst user-visible behaviour (silent zero rows) but is a missing feature rather than a
-defect in an implemented one. **B** is the narrowest.
+**C** is a missing operator spelling rather than missing semantics, so it is cheap and it removes a
+silent-zero-rows case. **B** is the narrowest.
 
 ## What shipped so far
 

--- a/docs/issues/00903-parser-parity-divergences.md
+++ b/docs/issues/00903-parser-parity-divergences.md
@@ -1,0 +1,103 @@
+# The two parsers disagree on 15 real queries
+
+[#903](https://github.com/jbylund/sylvan_librarian/issues/903).
+
+`test_parser_parity.py` asserts the hand-rolled and pyparsing parsers emit identical SQL, but it
+runs over [`implicit_and_cases.py`](../../api/parsing/tests/implicit_and_cases.py) — a corpus they
+both pass. Sweeping the 14,473-query [`benchmarks/wild-queries/wild-corpus.jsonl`](../../benchmarks/wild-queries/)
+through both found **15 divergent queries**, from **three** root causes.
+
+Found while measuring the blast radius of [#891](https://github.com/jbylund/sylvan_librarian/issues/891).
+Pre-existing on `main` and unrelated to it: 15 before that change, the same 15 after.
+
+## How they were found
+
+Generate SQL + bound params for every distinct corpus query under both parsers, compare. The same
+harness answers "did this change alter any real query" and is worth rerunning after parser work —
+the 17,881-query sweep takes seconds. Repro is a ~20-line script: import both entry points, diff
+`generate_sql_query(...)` output per query.
+
+## A. `is_arithmetic_minus` ignores comparisons nested in a group — 10 of 15
+
+[`preprocess_implicit_and`](../../api/parsing/pyparsing_based.py) decides whether a `-` is binary
+subtraction or filter negation. Its `_rhs_introduces_comparison` guard scans forward for a
+comparison operator, but counts them **only at `depth == 0`**:
+
+```python
+elif t in _COMPARISON_OPERATORS and depth == 0:
+    return True
+```
+
+For `cmc>1 -(t:elf)` the `(` pushes depth to 1 before the `:` is seen, so the guard returns False,
+`is_arithmetic_minus` wins, and no implicit AND is inserted:
+
+| | result |
+|---|---|
+| hand | `(cmc > 1) AND NOT (card_subtypes @> [Elf])` |
+| pyparsing | `cmc > (1 - (card_subtypes @> [Elf]))` |
+
+The pyparsing SQL is not just different, it is **invalid** — PostgreSQL has no `integer - boolean`,
+so it is a runtime 500 rather than wrong rows. Two flavors:
+
+- **numeric LHS → bad SQL**: `pow=3 -(name:force or type:elf)`, `usd>50 -(format:modern or format:commander)`
+- **year LHS → parse error**: 8 queries shaped like `year:2019 -(oracle:exile or type:enchantment)`
+
+The trigger is only the token *before* the `-` being numeric. `t:elf -(t:goblin or t:orc)` is fine,
+and so is `year:2019 -t:elf` without the parens.
+
+**Fix sketch:** track depth in `_rhs_introduces_comparison` so a comparison anywhere inside the
+group counts. Worth checking whether the depth-0 restriction was load-bearing for some other case
+before changing it — `git log -S_rhs_introduces_comparison` for the original intent.
+
+## B. `and`/`or` in value position eaten by the tokenizer — 2 of 15
+
+`_get_implicit_and_tokenizer` matches `CaselessKeyword("AND"/"OR")` before anything knows it is in
+value position, so the value disappears and becomes a boolean operator:
+
+```
+o:and power+toughness>10   ->  o: AND power+toughness>10
+(o:or o:more) t:land       ->  (o: OR o:more) AND t:land
+```
+
+Only on the slow path. `preprocess_implicit_and` short-circuits queries containing none of
+`()"'/{+*`, so `o:and power>10` is fine while `o:and power+toughness>10` is not — the `+` is what
+disqualifies it. That makes the bug look intermittent.
+
+It sometimes recovers with the right answer, which is worse than failing:
+`(oracle:two oracle:or) type:land` preprocesses to a dangling `oracle:` whose value then matches
+the following `OR` token as the string `"OR"` — coincidentally what the user meant.
+
+**Fix sketch:** the tokenizer needs to not treat a keyword as an operator when the previous token
+is a comparison operator. The hand parser gets this right for free by parsing values in context
+rather than pre-tokenizing.
+
+## C. `c!` exact-color is unsupported, and one parser hides it — 3 of 15
+
+Scryfall's `c!ubg` ("colors are exactly UBG") is implemented by neither parser. pyparsing rejects
+it. The hand parser silently splits it into an implicit name and an exact name:
+
+```
+c!w  ->  name:"c" AND !w  ->  name LIKE %c% AND name = "w"
+```
+
+Zero rows, no error. The divergence is a symptom; the gap is that `c!`/`id!` is not implemented.
+Affected: `c!ubg cmc>=6 f:standard`, `en-kor c!w`, `o:destroy o:creature o:with o:flying c!g`.
+
+This is a feature request wearing a bug's clothes, and splitting it out is reasonable — but the
+hand parser's silent mis-parse is worth fixing either way, independently of whether `c!` is ever
+implemented.
+
+## Suggested order
+
+**A** first: it produces invalid SQL from a query shape users write, and the fix is one function.
+**C** is the worst user-visible behaviour (silent zero rows) but is a missing feature rather than a
+defect in an implemented one. **B** is the narrowest.
+
+## What shipped so far
+
+No fixes — only the pin. [`test_parser_parity.py`](../../api/parsing/tests/test_parser_parity.py)
+gains `test_known_parser_divergences`, parameterized over all 15 wild queries plus 4 minimal repros,
+each `xfail(strict=True)`. Fixing any cause turns its entries into `XPASS(strict)` failures, so a
+fix cannot land without deleting the entries it resolves — the list can only shrink.
+
+The shared assertion moved into `assert_parsers_agree()` so both parity tests use one comparison.


### PR DESCRIPTION
Refs #903. No behaviour change — this pins a known-bad state so it cannot get worse silently.

## What

`test_parser_parity.py` asserts the two parsers emit identical SQL, but it runs over `implicit_and_cases.py` — a corpus they both already pass. Sweeping the 14,473-query `benchmarks/wild-queries/wild-corpus.jsonl` through both found **15 real queries where they disagree**, from three root causes:

| | cause | count | symptom |
|---|---|---|---|
| **A** | `_rhs_introduces_comparison` counts comparison operators only at `depth == 0`, so the `:` inside `cmc>1 -(t:elf)` is invisible and the `-` is read as subtraction | 10 | pyparsing emits `cmc > (1 - <boolean>)` — PostgreSQL has no `integer - boolean`, so a runtime 500; with a `year:` LHS it is a parse error instead |
| **B** | the implicit-AND tokenizer matches `CaselessKeyword("AND"/"OR")` before knowing it is in value position, so `o:or` preprocesses to `o: OR` | 2 | value silently lost; only on the slow path, so `o:and power>10` works and `o:and power+toughness>10` does not |
| **C** | `!` is Scryfall's alias for `=` (`c!g` ≡ `c=g`, 4,904 both — verified live) and neither parser implements it | 3 | pyparsing rejects the shape; the hand parser applies the text-field fallback everywhere, so `c!w` → `name LIKE %c% AND name = "w"`, matching nothing with no error |

Full analysis, minimal repros and fix sketches: `docs/issues/00903-parser-parity-divergences.md`.

These are pre-existing on `main` and unrelated to #891/#902 — 15 divergences before that change, the same 15 after.

## Why xfail rather than a fix

The three causes want three different fixes, and C turned out to be an operator spelling rather than missing semantics (`!` is an `=` alias on color/mana/numeric/rarity/year/date fields, and correctly *not* an operator on text fields — so the hand parser's fallback is right for TEXT, wrong elsewhere). Pinning them first means the list can only shrink: each case is `xfail(strict=True)`, so fixing a cause turns its entries into `XPASS(strict)` **failures** and the fix cannot land without deleting the entries it resolves.

Verified that guard actually guards, rather than trusting the marker — a stand-in query that the parsers agree on, marked the same way, fails the run:

```
________________________ test_xpass_is_a_failure[t:elf] ________________________
[XPASS(strict)] pretend-fixed
```

## Also

- the shared comparison moves into `assert_parsers_agree()`, so both parity tests use one implementation instead of two copies
- 4 minimal repros sit alongside the 15 wild queries — they fail for the same reason and are what a fixer actually works from

## Validation

- `api/parsing/tests/`: 1632 passed, 19 xfailed — no test that passed before now fails
- `ruff check` and `ruff format --check` clean
