### PR TITLE
Tags: Resolve the Alias and Spaced Spellings Scryfall Accepts for Tag Values

### DIFF
--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -273,6 +273,24 @@ def get_keywords_comparison_object(val: str) -> dict[str, bool]:
     return {normalized_keyword: True}
 
 
+def slugify_tag(val: str) -> str:
+    """Normalize a written tag spelling to the slug form oracle and art tags are stored under.
+
+    Every slug in both tag dumps matches `[a-z0-9]+(-[a-z0-9]+)*`, so folding runs of
+    non-alphanumerics to a single hyphen can only turn a miss into the hit the searcher meant.
+    Scryfall accepts the spaced spelling of a slug the same way -- `art:"right facing"` and
+    `art:right-facing` both find the `right-facing` tag -- and this is also what makes aliases
+    written with spaces reachable, since tag_import stores those slugified too.
+
+    Args:
+        val: Tag string as the searcher wrote it.
+
+    Returns:
+        The slugified tag, e.g. "Open Mouth" -> "open-mouth".
+    """
+    return re.sub(r"[^a-z0-9]+", "-", val.strip().lower()).strip("-")
+
+
 def get_oracle_tags_comparison_object(val: str) -> dict[str, bool]:
     """Convert oracle tag string to comparison object for database queries.
 
@@ -282,9 +300,7 @@ def get_oracle_tags_comparison_object(val: str) -> dict[str, bool]:
     Returns:
         Dictionary mapping normalized oracle tag to True.
     """
-    # Oracle tags are stored in lowercase
-    normalized_tag = val.strip().lower()
-    return {normalized_tag: True}
+    return {slugify_tag(val): True}
 
 
 def get_art_tags_comparison_object(val: str) -> dict[str, bool]:
@@ -296,8 +312,7 @@ def get_art_tags_comparison_object(val: str) -> dict[str, bool]:
     Returns:
         Dictionary mapping normalized art tag to True.
     """
-    normalized_tag = val.strip().lower()
-    return {normalized_tag: True}
+    return {slugify_tag(val): True}
 
 
 def get_is_tags_comparison_object(val: str) -> dict[str, bool]:

--- a/api/parsing/tests/test_tag_value_spellings.py
+++ b/api/parsing/tests/test_tag_value_spellings.py
@@ -1,0 +1,64 @@
+"""Scryfall's alternate spellings for a tag *value*, as opposed to the field name.
+
+Oracle and art tag slugs are hyphenated (`right-facing`, `removal-creature`), and Scryfall accepts
+the spaced spelling of one interchangeably — verified live with `unique=art`:
+`art:right-facing`, `art:"right facing"` and `art:"looks right"` all return 2633, and
+`otag:removal-creature` / `otag:"creature removal"` / `otag:creature-removal` all return 7806.
+Only the exact hyphenated spelling matched here, so a searcher writing the tag the way it reads —
+or forwarding a Scryfall query verbatim — got zero results.
+
+Slugifying the search term is safe because every slug in both tag dumps matches
+`[a-z0-9]+(-[a-z0-9]+)*` (checked against the 11,517 art and 4,522 oracle tags), so the
+normalization can only turn a miss into a hit. It is also what makes the space-spelled aliases
+tag_import stores (`open mouth` -> `open-mouth`) reachable.
+"""
+
+import pytest
+
+from api.parsing import generate_sql_query, parse_scryfall_query
+from api.parsing.card_query_nodes import slugify_tag
+from api.parsing.pyparsing_based import parse_search_query
+
+# (spelling as written, the hyphenated spelling it must match)
+TAG_VALUE_CASES = [
+    ('art:"right facing"', "art:right-facing"),
+    ('art:"open mouth"', "art:open-mouth"),
+    ("art:Flames", "art:flames"),
+    ('otag:"creature removal"', "otag:creature-removal"),
+    ("otag:Removal-Creature", "otag:removal-creature"),
+    ('t:creature art:"three figures"', "t:creature art:three-figures"),
+]
+
+
+@pytest.mark.parametrize(
+    argnames=["written_query", "slug_query"],
+    argvalues=TAG_VALUE_CASES,
+    ids=[q for q, _ in TAG_VALUE_CASES],
+)
+def test_written_tag_values_match_the_slug_spelling(written_query: str, slug_query: str) -> None:
+    """A tag value written with spaces or capitals produces identical SQL to its slug, in both parsers."""
+    assert generate_sql_query(parse_scryfall_query(written_query)) == generate_sql_query(parse_scryfall_query(slug_query))
+    assert generate_sql_query(parse_search_query(written_query)) == generate_sql_query(parse_search_query(slug_query))
+
+
+SLUGIFY_CASES = [
+    ("open mouth", "open-mouth"),
+    ("Open Mouth", "open-mouth"),
+    ("  flames  ", "flames"),
+    ("already-a-slug", "already-a-slug"),
+    ("3 people", "3-people"),
+    ("avacyn's collar", "avacyn-s-collar"),
+    ("8-ball (marvel)", "8-ball-marvel"),
+    ("107.3f x card", "107-3f-x-card"),
+    ("", ""),
+]
+
+
+@pytest.mark.parametrize(
+    argnames=["written", "expected"],
+    argvalues=SLUGIFY_CASES,
+    ids=[written or "empty" for written, _ in SLUGIFY_CASES],
+)
+def test_slugify_tag(written: str, expected: str) -> None:
+    """Runs of non-alphanumerics collapse to a single hyphen, with no leading or trailing one."""
+    assert slugify_tag(written) == expected

--- a/api/tag_import.py
+++ b/api/tag_import.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections
 import itertools
 import logging
 import time
@@ -10,6 +11,7 @@ from typing import TYPE_CHECKING
 from psycopg import sql
 from psycopg.types.json import Jsonb
 
+from api.parsing.card_query_nodes import slugify_tag
 from api.scryfall_bulk_data_fetcher import BulkDataKey, ScryfallBulkDataFetcher
 
 if TYPE_CHECKING:
@@ -54,6 +56,59 @@ def _build_all_ancestors(tags: list[dict], uuid_to_slug: dict[str, str]) -> dict
         result[slug] = frozenset(ancestors)
 
     return result
+
+
+def _build_slug_to_aliases(tags: list[dict]) -> dict[str, frozenset[str]]:
+    """Return a map from each tag slug to the alias spellings that stand for it.
+
+    Aliases are alternate spellings Scryfall's tagger resolves to the tag before matching, which is
+    why `art:flames` finds the `fire` tag on Scryfall. They are slugified here so that both written
+    forms reach the same stored key -- half the art aliases are spelled with spaces ("open mouth",
+    an alias of `loose-lips`), and `slugify_tag` normalizes the search term the same way.
+
+    An alias that lands on a real tag slug, or that two tags both claim, is ambiguous, so it is
+    dropped rather than guessed at: the slug always wins. Neither dump contains one today (checked
+    against both), so this is a guard against upstream data changing, not a live case.
+    """
+    slugs = {tag["slug"] for tag in tags}
+    claimants: dict[str, set[str]] = collections.defaultdict(set)
+    for tag in tags:
+        for alias in tag.get("aliases") or []:
+            slugified = slugify_tag(alias)
+            if slugified:
+                claimants[slugified].add(tag["slug"])
+
+    slug_to_aliases: dict[str, set[str]] = collections.defaultdict(set)
+    dropped = []
+    for alias, claiming_slugs in claimants.items():
+        if alias in slugs or len(claiming_slugs) > 1:
+            dropped.append(alias)
+            continue
+        slug_to_aliases[next(iter(claiming_slugs))].add(alias)
+
+    if dropped:
+        logger.warning("Dropping %d ambiguous tag aliases: %s", len(dropped), sorted(dropped))
+
+    return {slug: frozenset(aliases) for slug, aliases in slug_to_aliases.items()}
+
+
+def _build_tag_keys(tags: list[dict], uuid_to_slug: dict[str, str]) -> dict[str, frozenset[str]]:
+    """Return every key a card tagged with a given slug should carry in its tag column.
+
+    That is the slug itself, all of its ancestors (see _build_all_ancestors), and the aliases of
+    each of those. Aliases have to ride along on the ancestors too, because Scryfall resolves an
+    alias to its tag *before* expanding the hierarchy: `art:flames` returns exactly what `art:fire`
+    does, descendants included, not just the artworks tagged `fire` directly.
+    """
+    all_ancestors = _build_all_ancestors(tags, uuid_to_slug)
+    slug_to_aliases = _build_slug_to_aliases(tags)
+
+    tag_keys: dict[str, frozenset[str]] = {}
+    for slug, ancestors in all_ancestors.items():
+        keys = {slug, *ancestors}
+        tag_keys[slug] = frozenset(keys.union(*(slug_to_aliases.get(key, frozenset()) for key in keys)))
+
+    return tag_keys
 
 
 def _sync_hierarchy(
@@ -150,18 +205,17 @@ def import_oracle_tags(
     logger.info("Downloading oracle tags bulk data")
     tags = list(bulk_data_fetcher.stream_data_for_key(BulkDataKey.ORACLE_TAGS))
     uuid_to_slug = _build_uuid_to_slug(tags)
-    all_ancestors = _build_all_ancestors(tags, uuid_to_slug)
+    tag_keys = _build_tag_keys(tags, uuid_to_slug)
 
     oracle_id_to_tags: dict[str, dict[str, bool]] = {}
     for tag in tags:
-        slug = tag["slug"]
+        keys = tag_keys.get(tag["slug"], frozenset({tag["slug"]}))
         for tagging in tag.get("taggings", []):
             oid = tagging.get("oracle_id")
             if oid:
                 card_tags = oracle_id_to_tags.setdefault(oid, {})
-                card_tags[slug] = True
-                for ancestor in all_ancestors.get(slug, frozenset()):
-                    card_tags[ancestor] = True
+                for key in keys:
+                    card_tags[key] = True
 
     logger.info("Syncing %d oracle tags covering %d cards", len(tags), len(oracle_id_to_tags))
     with conn_pool.connection() as conn:
@@ -188,18 +242,17 @@ def import_art_tags(
     logger.info("Downloading art tags bulk data")
     tags = list(bulk_data_fetcher.stream_data_for_key(BulkDataKey.ART_TAGS))
     uuid_to_slug = _build_uuid_to_slug(tags)
-    all_ancestors = _build_all_ancestors(tags, uuid_to_slug)
+    tag_keys = _build_tag_keys(tags, uuid_to_slug)
 
     illustration_id_to_tags: dict[str, dict[str, bool]] = {}
     for tag in tags:
-        slug = tag["slug"]
+        keys = tag_keys.get(tag["slug"], frozenset({tag["slug"]}))
         for tagging in tag.get("taggings", []):
             iid = tagging.get("illustration_id")
             if iid:
                 card_tags = illustration_id_to_tags.setdefault(iid, {})
-                card_tags[slug] = True
-                for ancestor in all_ancestors.get(slug, frozenset()):
-                    card_tags[ancestor] = True
+                for key in keys:
+                    card_tags[key] = True
 
     logger.info("Syncing %d art tags covering %d illustrations", len(tags), len(illustration_id_to_tags))
     with conn_pool.connection() as conn:

--- a/api/tests/test_tagging.py
+++ b/api/tests/test_tagging.py
@@ -1,7 +1,7 @@
 """Tests for tag import module."""
 
 from api.api_resource import APIResource
-from api.tag_import import _build_all_ancestors, _build_uuid_to_slug
+from api.tag_import import _build_all_ancestors, _build_slug_to_aliases, _build_tag_keys, _build_uuid_to_slug
 
 
 class TestBuildAllAncestors:
@@ -56,6 +56,61 @@ class TestBuildUuidToSlug:
 
     def test_empty_list(self) -> None:
         assert _build_uuid_to_slug([]) == {}
+
+
+class TestBuildSlugToAliases:
+    def test_aliases_are_slugified(self) -> None:
+        # The real shape: `loose-lips` carries a spaced alias Scryfall resolves for art:"open mouth".
+        tags = [{"id": "u1", "slug": "loose-lips", "aliases": ["open mouth", "mouth open"]}]
+        assert _build_slug_to_aliases(tags) == {"loose-lips": frozenset({"open-mouth", "mouth-open"})}
+
+    def test_tags_without_aliases_are_absent(self) -> None:
+        tags = [{"id": "u1", "slug": "fire"}, {"id": "u2", "slug": "flying", "aliases": []}]
+        assert _build_slug_to_aliases(tags) == {}
+
+    def test_alias_colliding_with_a_slug_is_dropped(self) -> None:
+        # An alias that is also a real tag's slug would silently merge two tags; the slug wins.
+        tags = [
+            {"id": "u1", "slug": "fire", "aliases": ["flying"]},
+            {"id": "u2", "slug": "flying", "aliases": []},
+        ]
+        assert _build_slug_to_aliases(tags) == {}
+
+    def test_alias_claimed_by_two_tags_is_dropped(self) -> None:
+        tags = [
+            {"id": "u1", "slug": "fire", "aliases": ["open flame"]},
+            {"id": "u2", "slug": "campfire", "aliases": ["open-flame"]},
+        ]
+        assert _build_slug_to_aliases(tags) == {}
+
+    def test_alias_repeated_by_one_tag_is_kept(self) -> None:
+        # Two spellings of one alias collapse to the same slug -- not a conflict.
+        tags = [{"id": "u1", "slug": "loose-lips", "aliases": ["open mouth", "Open Mouth"]}]
+        assert _build_slug_to_aliases(tags) == {"loose-lips": frozenset({"open-mouth"})}
+
+
+class TestBuildTagKeys:
+    def test_slug_ancestors_and_their_aliases(self) -> None:
+        # `flames` is an alias of `fire`, which has `campfire` under it. Scryfall resolves the
+        # alias before expanding the hierarchy, so art:flames must reach the descendant too.
+        tags = [
+            {"id": "u1", "slug": "fire", "parent_ids": [], "aliases": ["flames"]},
+            {"id": "u2", "slug": "campfire", "parent_ids": ["u1"], "aliases": ["camp fire"]},
+        ]
+        uuid_to_slug = {"u1": "fire", "u2": "campfire"}
+        result = _build_tag_keys(tags, uuid_to_slug)
+        assert result["fire"] == frozenset({"fire", "flames"})
+        assert result["campfire"] == frozenset({"campfire", "camp-fire", "fire", "flames"})
+
+    def test_no_aliases_is_slug_plus_ancestors(self) -> None:
+        tags = [
+            {"id": "u1", "slug": "permanent", "parent_ids": []},
+            {"id": "u2", "slug": "land-type", "parent_ids": ["u1"]},
+        ]
+        uuid_to_slug = {"u1": "permanent", "u2": "land-type"}
+        result = _build_tag_keys(tags, uuid_to_slug)
+        assert result["land-type"] == frozenset({"land-type", "permanent"})
+        assert result["permanent"] == frozenset({"permanent"})
 
 
 class TestAPIResourceEndpoints:

--- a/api/tests/test_tagging_integration.py
+++ b/api/tests/test_tagging_integration.py
@@ -155,6 +155,93 @@ class TestAncestorPropagation:
         assert captured["id_to_tags"]["card-b"] == {"flying": True}
 
 
+class TestAliasPropagation:
+    """Alias spellings must be written alongside the slug at import time.
+
+    Scryfall's tagger resolves an alias to its tag before matching, so art:flames returns the same
+    3564 artworks art:fire does. The dumps carry those spellings in an `aliases` field that was
+    previously skipped, so every alias spelling matched nothing here.
+    """
+
+    def test_card_carries_the_alias_spellings(self) -> None:
+        fixture = [
+            {
+                "id": "uuid-loose-lips",
+                "slug": "loose-lips",
+                "parent_ids": [],
+                "child_ids": [],
+                "aliases": ["open mouth", "mouth open"],
+                "taggings": [{"illustration_id": "illus-x", "weight": "strong"}],
+            },
+        ]
+        pool, _ = _make_mock_conn_pool()
+        fetcher = MagicMock()
+        fetcher.stream_data_for_key.return_value = iter(fixture)
+
+        captured: dict = {}
+
+        def capture(conn, id_column, tag_column, id_to_tags) -> tuple[int, int]:
+            captured["id_to_tags"] = id_to_tags
+            return (0, 0)
+
+        with patch("api.tag_import._sync_card_tags", side_effect=capture), patch("api.tag_import._sync_hierarchy"):
+            import_art_tags(pool, fetcher)
+
+        # "open mouth" is stored slugified, which is the form slugify_tag() turns the query into.
+        assert captured["id_to_tags"]["illus-x"] == {"loose-lips": True, "open-mouth": True, "mouth-open": True}
+
+    def test_descendant_carries_an_ancestors_alias(self) -> None:
+        # A card tagged only `campfire` must answer art:flames, since Scryfall resolves flames ->
+        # fire first and then expands the hierarchy.
+        fixture = [
+            {
+                "id": "uuid-fire",
+                "slug": "fire",
+                "parent_ids": [],
+                "child_ids": ["uuid-campfire"],
+                "aliases": ["flames"],
+                "taggings": [],
+            },
+            {
+                "id": "uuid-campfire",
+                "slug": "campfire",
+                "parent_ids": ["uuid-fire"],
+                "child_ids": [],
+                "taggings": [{"illustration_id": "illus-y", "weight": "strong"}],
+            },
+        ]
+        pool, _ = _make_mock_conn_pool()
+        fetcher = MagicMock()
+        fetcher.stream_data_for_key.return_value = iter(fixture)
+
+        captured: dict = {}
+
+        def capture(conn, id_column, tag_column, id_to_tags) -> tuple[int, int]:
+            captured["id_to_tags"] = id_to_tags
+            return (0, 0)
+
+        with patch("api.tag_import._sync_card_tags", side_effect=capture), patch("api.tag_import._sync_hierarchy"):
+            import_art_tags(pool, fetcher)
+
+        assert captured["id_to_tags"]["illus-y"] == {"campfire": True, "fire": True, "flames": True}
+
+    def test_tagging_without_aliases_is_unchanged(self) -> None:
+        pool, _ = _make_mock_conn_pool()
+        fetcher = MagicMock()
+        fetcher.stream_data_for_key.return_value = iter(ART_TAGS_FIXTURE)
+
+        captured: dict = {}
+
+        def capture(conn, id_column, tag_column, id_to_tags) -> tuple[int, int]:
+            captured["id_to_tags"] = id_to_tags
+            return (0, 0)
+
+        with patch("api.tag_import._sync_card_tags", side_effect=capture), patch("api.tag_import._sync_hierarchy"):
+            import_art_tags(pool, fetcher)
+
+        assert captured["id_to_tags"]["illus-x"] == {"dragon": True}
+
+
 class TestImportArtTags:
     def test_calls_stream_for_art_tags(self) -> None:
         pool, _ = _make_mock_conn_pool()

--- a/docs/issues/done/local-tag-alias-spellings.md
+++ b/docs/issues/done/local-tag-alias-spellings.md
@@ -1,0 +1,96 @@
+# Tag alias spellings: `art:flames` finds nothing, `art:fire` finds 3564
+
+## Problem
+
+Scryfall's tagger stores alternate spellings for a tag in an `aliases` field and resolves them to
+the tag before matching. `art:flames` and `art:fire` both return 3564 artworks there. Here,
+`art:fire` worked and `art:flames` returned nothing, because the import read only `slug` and
+dropped `aliases` on the floor.
+
+Probing Scryfall live (`/cards/search?unique=art`) pins down the exact semantics:
+
+```
+art:fire 3564   art:flames 3564   art:flame 3564
+art:loose-lips 6807   art:"open mouth" 6807   art:open-mouth 6807   art:"mouth open" 6807
+art:right-facing 2633   art:"looks right" 2633   art:looks-right 2633
+art:"right facing" 2633   art:"three figures" 1411
+otag:removal-creature 7806   otag:"creature removal" 7806   otag:creature-removal 7806
+```
+
+Two things fall out of that.
+
+1. **An alias behaves exactly like the slug it stands for, descendants included.** `fire` has
+   18 child tags and only 2,225 direct taggings, but `art:flames` returns the same 3,564 as
+   `art:fire` — so the alias resolves to the tag *before* the hierarchy expands, not after.
+2. **A hyphenated slug is also accepted spelled with spaces.** `art:"right facing"` matches
+   `right-facing`, and no alias is involved. That is a second, independent gap: every multi-word
+   tag was reachable only in its hyphenated form.
+
+## What the dumps actually contain
+
+Audited against both dumps (2026-08-09):
+
+| | art_tags | oracle_tags |
+|---|---|---|
+| tags | 11,517 | 4,522 |
+| tags with aliases | 1,024 | 719 |
+| aliases | 1,332 | 819 |
+| alias equal to some tag's slug | 0 | 0 |
+| alias claimed by two tags | 0 | 0 |
+| same two checks after slugifying the alias | 0 / 0 | 0 / 0 |
+| aliases not already slug-shaped | 690 (52%) | 229 (28%) |
+
+Aliases occupy a namespace disjoint from the slugs, with no duplicates — so resolution is
+unambiguous. Every slug in both dumps matches `[a-z0-9]+(-[a-z0-9]+)*`, which is what makes
+normalizing the search term safe: it can only turn a miss into a hit.
+
+## Approach
+
+Aliases are resolved at **import** time, by writing them as additional keys in `card_art_tags` /
+`card_oracle_tags` alongside the slug. Search-term normalization is the **query**-side half, in
+the one helper both backends share.
+
+This follows the decision the ancestor propagation already made — resolve tag semantics once at
+import, keep query time a dumb exact key match — and it is the reason the fix needs no engine
+change: the SQL path (`card_art_tags @> {...}`) and the Rust engine (interned `coll_vocab` ids)
+both read the same column, and both take their search term from
+[card_query_nodes.py](../../../api/parsing/card_query_nodes.py).
+
+Aliases have to be stamped onto the ancestors' taggings too, not just the tag's own, since an
+alias must reach descendants (point 1 above).
+
+### Cost
+
+Measured over the dumps, counting keys written per tagging:
+
+- **art:** +536,636 keys on a 1,024,627-key baseline (**+52.4%**), touching 51% of 472,398 taggings
+- **oracle:** +143,913 on 471,738 (**+30.5%**), touching 39.5% of 229,289 taggings
+
+Relative growth looks steep, absolute is roughly 10MB of JSONB plus a comparable GIN increment and
+about 1MB of extra `u16` postings in the engine. Most of it comes from aliases on popular ancestors
+(`dominaria-origin`, with its 257 descendants) reaching every descendant tagging. Engine
+`coll_vocab` grows by ~2,150 strings, from ~17k, against a `u16` ceiling of 65,536.
+
+### Rejected: a query-time alias table
+
+The alternative was persisting `alias -> slug` (`magic.art_tag_aliases`, `magic.oracle_tag_aliases`)
+and resolving on the way in: a `COALESCE` scalar subquery on the SQL path, and the map pushed into
+the engine at reload so `bind` could fall back to it when a value misses `coll_vocab`. That keeps
+stored data canonical — no alias keys in a `fields=card_art_tags` projection — and costs no space.
+
+It was rejected as the wrong trade for ~10MB: it touches schema, import, SQL generation and Rust
+instead of one import loop, and it introduces a second copy of the tag vocabulary whose refresh has
+to be kept in step with the engine's. Worth revisiting if the JSONB growth ever bites, or if
+canonical output starts to matter.
+
+## Behavior changes
+
+- Every alias spelling now resolves: `art:flames`, `art:open-mouth`, `art:"open mouth"`.
+- Multi-word tags are reachable spelled with spaces: `art:"right facing"`, `otag:"creature removal"`.
+- Tag searches are now case-insensitive in the same normalization step (`art:Flames`).
+- A `fields=card_art_tags` projection now lists alias keys next to the slug. Art tags are not a
+  Scryfall card-JSON field and the frontend never requests them, so nothing else surfaces this.
+- The query half takes effect on deploy; the data half only after the next tag import re-stamps
+  `card_art_tags` / `card_oracle_tags` and the engine reloads.
+- An alias that ever does collide with a slug, or that two tags claim, is dropped with a warning
+  rather than guessed at — the slug wins. Neither dump contains one today.

--- a/docs/issues/done/local-tag-alias-spellings.md
+++ b/docs/issues/done/local-tag-alias-spellings.md
@@ -66,10 +66,35 @@ Measured over the dumps, counting keys written per tagging:
 - **art:** +536,636 keys on a 1,024,627-key baseline (**+52.4%**), touching 51% of 472,398 taggings
 - **oracle:** +143,913 on 471,738 (**+30.5%**), touching 39.5% of 229,289 taggings
 
-Relative growth looks steep, absolute is roughly 10MB of JSONB plus a comparable GIN increment and
-about 1MB of extra `u16` postings in the engine. Most of it comes from aliases on popular ancestors
-(`dominaria-origin`, with its 257 descendants) reaching every descendant tagging. Engine
-`coll_vocab` grows by ~2,150 strings, from ~17k, against a `u16` ceiling of 65,536.
+Relative growth looks steep, absolute is roughly 10MB of JSONB plus a comparable GIN increment.
+Most of it comes from aliases on popular ancestors (`dominaria-origin`, with its 257 descendants)
+reaching every descendant tagging. Engine `coll_vocab` grows by ~2,150 strings, from ~17k, against
+a `u16` ceiling of 65,536.
+
+**The engine figure above was originally given as ~1MB. That was wrong by 6x — it is 6.25MB.**
+Corrected 2026-08-10, measured rather than derived, by building the rkyv archive twice from the
+same dumps with alias stamping on and off:
+
+| | bytes |
+|---|---|
+| archive, aliases stamped | 81,068,608 |
+| archive, aliases not stamped | 74,815,728 |
+| **alias keys** | **6,252,880** |
+
+The original estimate counted only the forward field — `card_oracle_tags: Vec<u16>` on `Card`,
+`card_art_tags: Vec<u16>` on `Printing` — at 2 bytes per entry. But every collection entry is
+stored *twice*: `CardIndexes` carries `oracle_tags: TagIndex` and `art_tags: TagIndex`, and
+`type TagIndex = HashMap<String, Vec<u32>>` is an inverted index whose posting is a 4-byte id. So
+an entry costs 2 bytes forward plus 4 bytes inverted, and the measured marginal cost is 6.11 bytes
+over 1,024,204 alias entries — 6.40 B/entry in card space (117,499 entries), 6.07 in printing space
+(906,705). Isolating the two dumps in separate builds is additive to within 8 bytes, so this is a
+uniform per-entry cost and not a struct-padding artifact.
+
+Note the denominator differs from the per-tagging counts above: those count keys written per
+*tagging record* in the dump, while these count entries per stored *row*. Printings sharing an
+illustration each carry their own copy, which is why the archive-side art figure (906,705) exceeds
+the per-tagging one (536,636) by roughly the printings-per-illustration ratio. The same
+multiplication presumably applies to the JSONB estimate, which was not re-measured.
 
 ### Rejected: a query-time alias table
 
@@ -82,6 +107,31 @@ It was rejected as the wrong trade for ~10MB: it touches schema, import, SQL gen
 instead of one import loop, and it introduces a second copy of the tag vocabulary whose refresh has
 to be kept in step with the engine's. Worth revisiting if the JSONB growth ever bites, or if
 canonical output starts to matter.
+
+**That condition has now fired once, downstream, and the rejection still stands here.** The
+Cloudflare port of this project (`daveycodez/sylvan-librarian-cloudflare`) distributes the rkyv
+archive as Workers KV values under a 25MiB cap and loads them with one sequential read per chunk.
+Its archive went 73.2MB to 81.1MB over the same release, of which 6.25MB is these alias keys and
+0.78MB is an unrelated pair of `Printing` rank fields. That crossed a chunk boundary: chunks are
+cut at 25,000,000 bytes, so the store went from 3 to 4, adding a fourth serialized read to every
+cold load. Removing the alias keys alone lands it at 74,815,728 — back under the boundary, which
+is what makes this section's 6.25MB the deciding figure rather than the total.
+
+Median cold store load over that release went 337ms (n=9) to 691ms (n=10), sampled from production
+logs. Read that as directional: the newer store also has a fresh key, so its chunks had not yet
+warmed the per-colo caches the reads hit, and that confound decays. The extra serialized read does
+not.
+
+That is a real cost, but it is *that deployment's* cost, and the fix belongs there rather than
+here. Postgres does not care about 10MB of JSONB, and this repo's parser has no seam to resolve an
+alias through: `db_info.py` is static schema metadata with no DB access or cache, and the
+`get_*_tags_comparison_object` helpers are pure `str -> dict`. Threading a map of 2,150 aliases —
+import-derived and versioned with the dumps — into them means building that seam, which is
+precisely the second tag vocabulary this section rejected. The port can resolve at parse time
+against a generated map without touching any of that, because its builder and parser are both
+port-local code.
+
+So: the number was wrong and is corrected, the trade it fed into is unchanged for this repo.
 
 ## Behavior changes
 


### PR DESCRIPTION
## What

Scryfall's tagger stores alternate spellings for a tag in an `aliases` field and resolves them to
the tag before matching, so `art:fire` and `art:flames` both return the same artworks
there. The tag import reads `slug`, `parent_ids` and `taggings` out of the dumps, and `aliases` was
one of the fields it passed over — so every alias spelling matched nothing here.

Probing Scryfall live (`/cards/search?unique=art`) pins down two behaviors:

```
art:fire 3564   art:flames 3564   art:flame 3564
art:right-facing 2633   art:"looks right" 2633   art:looks-right 2633
art:"right facing" 2633   art:"three figures" 1411
art:loose-lips 6807   art:"open mouth" 6807   art:open-mouth 6807   art:"mouth open" 6807
otag:removal-creature 7806   otag:"creature removal" 7806   otag:creature-removal 7806
```

1. **An alias behaves exactly like the slug it stands for, descendants included.** `fire` has
   18 child tags and 2,225 direct taggings, but `art:flames` returns the same 3,564 as
   `art:fire` — the alias resolves to the tag *before* the hierarchy expands.
2. **A hyphenated slug is also accepted spelled with spaces.** `art:"right facing"` matches
   `right-facing` with no alias involved. That is an independent gap: multi-word tags were
   reachable only in hyphenated form.

## How

Aliases are resolved at **import**, written as extra keys alongside the slug and every ancestor
slug. That is the decision ancestor propagation already made — resolve tag semantics once at
import, keep query time a dumb exact key match — and it is why neither backend needs a change: the
SQL path (`card_art_tags @> {...}`) and the engine (interned `coll_vocab` ids) read the same
column. Aliases ride along on the ancestors as well, because of point 1 above.

The search term is slugified in the two `get_*_tags_comparison_object` helpers, the single place
both the SQL path and `_rhs_to_json` funnel through. Every slug in both dumps matches
`[a-z0-9]+(-[a-z0-9]+)*`, so normalizing the term can only turn a miss into a hit, and it is also
what makes the space-spelled aliases (`open mouth`) reachable as written.

## Evidence

Audited against both dumps (2026-08-09):

| | art_tags | oracle_tags |
|---|---|---|
| tags | 11,517 | 4,522 |
| tags with aliases | 1,024 | 719 |
| aliases | 1,332 | 819 |
| alias equal to some tag's slug | 0 | 0 |
| alias claimed by two tags | 0 | 0 |
| same two checks after slugifying | 0 / 0 | 0 / 0 |
| aliases not already slug-shaped | 690 (52%) | 229 (28%) |

Aliases occupy a namespace disjoint from the slugs, so resolution is unambiguous. Either case is
dropped with a warning if upstream data ever introduces one — the slug wins.

## Cost

Counting keys written per tagging: art +536,636 on a 1,024,627 baseline (+52.4%), oracle +143,913
on 471,738 (+30.5%). Absolute is roughly 10MB of JSONB plus a comparable GIN increment;
`coll_vocab` grows by ~2,150 strings from ~17k, against a u16 ceiling of 65,536. Most of it is
aliases on popular ancestors reaching every descendant tagging.

**Corrected 2026-08-10:** the engine side was given here as ~1MB. It is **6.25MB** — measured by
building the rkyv archive twice from the same dumps, alias stamping on and off (81,068,608 vs
74,815,728 bytes). The estimate counted only the forward field (`card_oracle_tags: Vec<u16>` on
`Card`, `card_art_tags: Vec<u16>` on `Printing`) at 2 bytes an entry, but every collection entry is
stored twice: `CardIndexes` carries `oracle_tags`/`art_tags` as `TagIndex`, and
`type TagIndex = HashMap<String, Vec<u32>>` is an inverted index whose posting is a 4-byte id.
Measured marginal cost is 6.11 B/entry over 1,024,204 alias entries, additive to within 8 bytes
when the two dumps are isolated in separate builds.

This does not change the design here — see the updated *Rejected: a query-time alias table* section
in the design doc. It does record that "worth revisiting if the JSONB growth ever bites" has fired
once downstream: in the Cloudflare port the archive ships as Workers KV values under a 25MiB cap,
and this 6.25MB crossed a chunk boundary (3 to 4), adding a serialized read to every cold load.
That port can resolve at parse time against a generated map without the seam this repo would need,
so the fix belongs there.

The alternative — persisting `alias -> slug` and resolving at query time, with a `COALESCE`
subquery on the SQL path and the map pushed into the engine at reload — keeps stored data canonical
and costs no space, but touches schema, import, SQL generation and Rust, and adds a second copy of
the tag vocabulary to keep in step with the engine. Written up as the rejected alternative in
`docs/issues/done/local-tag-alias-spellings.md`, worth revisiting if the growth ever bites.

## Notes for deploy

The query half takes effect on deploy; the alias half only after the next tag import re-stamps
`card_art_tags` / `card_oracle_tags` and the engine reloads.

A `fields=card_art_tags` projection now lists alias keys next to the slug. Art tags are not a
Scryfall card-JSON field and the frontend never requests them, so nothing else surfaces this.

## Tests

25 added: alias-map construction with its two ambiguity guards, key expansion over slug +
ancestors + both sets of aliases, end-to-end assertions on what the importer writes for
`loose-lips`/`open mouth`/`mouth open` and for a descendant carrying an ancestor's alias, and the
written-vs-slug spelling equivalences through both parsers.

`2513 passed, 19 xfailed` in the unit tier, `22 passed` under testcontainers, ruff clean.

