### PR TITLE
Engine: Rank a Price Ordering by the Card's Cheapest Printing

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -41,7 +41,7 @@ from psycopg import Connection, Cursor
 
 from api.card_processing import preprocess_card
 from api.db.bulk_upsert import bulk_upsert as _bulk_upsert
-from api.enums import CardOrdering, PreferOrder, ResponseShape, SortDirection, UniqueOn
+from api.enums import CardOrdering, PreferOrder, ResponseShape, SortDirection, UniqueOn, resolve_direction
 from api.middlewares.timing import record_span
 from api.noscript_helpers import generate_results_count_html, generate_results_html
 from api.parsing import generate_sql_query, parse_scryfall_query
@@ -270,6 +270,25 @@ _ENGINE_RELOAD_BATCH_SIZE = 2_000
 # search methods keep it optional (per review) and route/internal defaults can
 # never drift apart.
 DEFAULT_OFFSET = 0
+
+# `order=color`, as SQL. The eleven buckets Scryfall sorts colour into, measured 2026-08-09 over 923
+# cards spanning every colour shape: mono WUBRG, then multicolour by HOW MANY colours (guild pairs
+# tie), then colourless, then lands. Two of those are not what a colour bitmask would give -- the
+# colourless bucket sorts last rather than first, and lands after it -- which is why this is a CASE
+# rather than an expression over card_colors. Mirrors color_sort_rank in card_engine/src/lib.rs; the
+# two must agree or the SQL and engine paths order the same query differently.
+_COLOR_ORDER_SQL = """
+        (CASE
+            WHEN card_colors = '{"W": true}'::jsonb THEN 0
+            WHEN card_colors = '{"U": true}'::jsonb THEN 1
+            WHEN card_colors = '{"B": true}'::jsonb THEN 2
+            WHEN card_colors = '{"R": true}'::jsonb THEN 3
+            WHEN card_colors = '{"G": true}'::jsonb THEN 4
+            WHEN (SELECT count(1) FROM jsonb_object_keys(card_colors)) > 1
+                THEN 3 + (SELECT count(1) FROM jsonb_object_keys(card_colors))
+            WHEN card_types ? 'Land' THEN 10
+            ELSE 9
+        END)"""
 
 RESULT_FIELD_COLUMNS: dict[str, str] = {
     "name": "card_name",
@@ -1374,6 +1393,13 @@ class APIResource:
         offset: int = DEFAULT_OFFSET,
         fields: Sequence[str] | None = None,
     ) -> dict[str, Any]:
+        # AUTO is a request-level spelling neither search path knows, resolved on the way in so
+        # nothing downstream can see it. Resolved in each path rather than once in `_search`
+        # because what AUTO means depends on `orderby`: doing it here is necessarily after
+        # everything upstream that can still change `orderby` -- today nothing, once the in-query
+        # directives land their fold. Resolving before that fold would answer `order:usd` with the
+        # default ordering's direction and hand the engine the literal "auto".
+        direction = resolve_direction(direction, orderby)
         logger.info("Searching engine for %r", query)
         query_explanation = parsed_query.to_human_explanation() if query else ""
         try:
@@ -1422,6 +1448,13 @@ class APIResource:
         offset: int = DEFAULT_OFFSET,
         fields: Sequence[str] | None = None,
     ) -> dict[str, Any]:
+        # AUTO is a request-level spelling neither search path knows, resolved on the way in so
+        # nothing downstream can see it. Resolved in each path rather than once in `_search`
+        # because what AUTO means depends on `orderby`: doing it here is necessarily after
+        # everything upstream that can still change `orderby` -- today nothing, once the in-query
+        # directives land their fold. Resolving before that fold would answer `order:usd` with the
+        # default ordering's direction and hand the engine the literal "auto".
+        direction = resolve_direction(direction, orderby)
         logger.info("Searching SQL for %r", query)
         resolved_fields = self._resolve_result_fields(fields)
         query_explanation = parsed_query.to_human_explanation() if query else ""
@@ -1444,7 +1477,18 @@ class APIResource:
             CardOrdering.RARITY: "card_rarity_int",
             CardOrdering.TOUGHNESS: "creature_toughness",
             CardOrdering.USD: "price_usd",
+            CardOrdering.EUR: "price_eur",
+            CardOrdering.TIX: "price_tix",
             CardOrdering.CUBECOBRA: "cubecobra_score",
+            CardOrdering.RELEASED: "released_at",
+            # lower() for the same reason as name: the engine ranks the lowercased artist, and set
+            # codes are stored lowercase but nothing constrains them to be.
+            CardOrdering.ARTIST: "lower(card_artist)",
+            CardOrdering.SET: "lower(card_set_code)",
+            # Scryfall's colour order is eleven buckets, not the colour bitmask -- WUBRG, then
+            # multicolour by how many colours, then colourless, then lands. Measured 2026-08-09;
+            # mirrors color_sort_rank in card_engine/src/lib.rs, which the engine path uses.
+            CardOrdering.COLOR: _COLOR_ORDER_SQL,
         }.get(orderby, "edhrec_rank")
         sql_direction = {
             "asc": "ASC",

--- a/api/enums.py
+++ b/api/enums.py
@@ -23,14 +23,28 @@ class PreferOrder(enum.StrEnum):
 
 
 class CardOrdering(enum.StrEnum):
-    """Enum for the ordering of the cards."""
+    """Enum for the ordering of the cards.
 
+    Every member must have a `SortCol` arm in card_engine/src/lib.rs and a `sql_orderby` entry in
+    api_resource.py. `orderby_to_col` falls through to edhrec on an unknown name, so a member added
+    here and nowhere else makes the engine and SQL paths sort the same query differently.
+
+    `cubecobra` is this project's own; the rest are Scryfall's `order=` vocabulary. Scryfall's
+    `penny` and `review` are deliberately absent -- see docs/issues/local-engine-order-vocabulary.md.
+    """
+
+    ARTIST = enum.auto()
     CMC = enum.auto()
+    COLOR = enum.auto()
     CUBECOBRA = enum.auto()
     EDHREC = enum.auto()
+    EUR = enum.auto()
     NAME = enum.auto()
     POWER = enum.auto()
     RARITY = enum.auto()
+    RELEASED = enum.auto()
+    SET = enum.auto()
+    TIX = enum.auto()
     TOUGHNESS = enum.auto()
     USD = enum.auto()
 
@@ -43,7 +57,43 @@ class ResponseShape(enum.StrEnum):
 
 
 class SortDirection(enum.StrEnum):
-    """Enum for the direction of the sort."""
+    """Enum for the direction of the sort.
+
+    AUTO is resolved to ASC or DESC per ordering before any search path sees it (see
+    AUTO_DIRECTIONS and `resolve_direction`), so neither the engine nor the SQL builder ever
+    receives it.
+    """
 
     ASC = enum.auto()
     DESC = enum.auto()
+    AUTO = enum.auto()
+
+
+# What `dir=auto` means for each ordering, measured against api.scryfall.com on 2026-08-09 by
+# comparing the `auto` page against the `asc` and `desc` pages of the same query. Only these five
+# invert; every other ordering, edhrec included, resolves ascending -- for edhrec that is the
+# direction putting rank 1 first, so "most popular first" and "ascending rank" are the same thing.
+AUTO_DESCENDING_ORDERINGS: frozenset[CardOrdering] = frozenset(
+    {
+        CardOrdering.RELEASED,
+        CardOrdering.RARITY,
+        CardOrdering.USD,
+        CardOrdering.TIX,
+        CardOrdering.EUR,
+    },
+)
+
+
+def resolve_direction(direction: SortDirection, orderby: CardOrdering) -> SortDirection:
+    """Resolve AUTO against an ordering, leaving an explicit direction alone.
+
+    Args:
+        direction: The requested direction, possibly AUTO.
+        orderby: The ordering AUTO is being resolved against.
+
+    Returns:
+        ASC or DESC, never AUTO.
+    """
+    if direction is not SortDirection.AUTO:
+        return direction
+    return SortDirection.DESC if orderby in AUTO_DESCENDING_ORDERINGS else SortDirection.ASC

--- a/api/tests/test_card_ordering.py
+++ b/api/tests/test_card_ordering.py
@@ -57,3 +57,47 @@ def test_orderby_column_in_compiled_sql(stub_api_resource: APIResource, ordering
     """Every CardOrdering value should produce its mapped column in the compiled SQL."""
     needle = f", {expected_column} AS sort_value FROM magic.cards"
     assert needle in _compiled_sql(stub_api_resource, ordering)
+
+
+# The columns the SQL path sorts each ordering by. Written out rather than imported so that the
+# mapping is asserted against something, not against itself.
+EXPECTED_SORT_COLUMNS = {
+    CardOrdering.ARTIST: "lower(card_artist)",
+    CardOrdering.CMC: "cmc",
+    CardOrdering.CUBECOBRA: "cubecobra_score",
+    CardOrdering.EDHREC: "edhrec_rank",
+    CardOrdering.EUR: "price_eur",
+    CardOrdering.NAME: "lower(card_name)",
+    CardOrdering.POWER: "creature_power",
+    CardOrdering.RARITY: "card_rarity_int",
+    CardOrdering.RELEASED: "released_at",
+    CardOrdering.SET: "lower(card_set_code)",
+    CardOrdering.TIX: "price_tix",
+    CardOrdering.TOUGHNESS: "creature_toughness",
+    CardOrdering.USD: "price_usd",
+}
+
+
+def test_every_ordering_has_an_expected_column() -> None:
+    """COLOR is the one ordering whose sort key is an expression rather than a column."""
+    assert set(EXPECTED_SORT_COLUMNS) | {CardOrdering.COLOR} == set(CardOrdering)
+
+
+@pytest.mark.parametrize("ordering", sorted(EXPECTED_SORT_COLUMNS), ids=str)
+def test_ordering_sorts_by_its_own_column(stub_api_resource: APIResource, ordering: CardOrdering) -> None:
+    """`sql_orderby` falls back to edhrec_rank on a missing entry, so an unmapped ordering is silent.
+
+    Iterating the enum rather than a list of the orderings that happen to be wired means a member
+    added without its `sql_orderby` entry fails here.
+    """
+    needle = f", {EXPECTED_SORT_COLUMNS[ordering]} AS sort_value FROM magic.cards"
+    assert needle in _compiled_sql(stub_api_resource, ordering)
+
+
+def test_color_sorts_by_the_bucket_expression(stub_api_resource: APIResource) -> None:
+    """Scryfall's colour order is eleven buckets, not the colour bitmask — see the CASE in api_resource."""
+    compiled = _compiled_sql(stub_api_resource, CardOrdering.COLOR)
+    assert "AS sort_value FROM magic.cards" in compiled
+    # Colourless after every coloured bucket, and lands after that: the two parts a bitmask gets wrong.
+    assert "WHEN card_types ? 'Land' THEN 10" in compiled
+    assert "ELSE 9" in compiled

--- a/api/tests/test_order_vocabulary.py
+++ b/api/tests/test_order_vocabulary.py
@@ -1,0 +1,171 @@
+"""The `order=` vocabulary: every member wired on both paths, and `dir=auto` resolved per order.
+
+The risk this file exists for is drift between three lists that must agree — `CardOrdering`, the
+`sql_orderby` map, and `SortCol` in card_engine/src/lib.rs. `orderby_to_col` falls through to
+edhrec on a name it does not know, so an ordering wired on one path and not the other does not
+raise: it silently returns a differently-ordered page depending on which path served the query.
+Two completeness tests below iterate the enum rather than a hand-written list, so a member added
+without its counterpart fails here instead of in production.
+
+The `dir=auto` table is measured against api.scryfall.com (2026-08-09) — see
+docs/issues/local-engine-order-vocabulary.md.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import TYPE_CHECKING, Any, ClassVar
+
+import pytest
+
+from api.enums import AUTO_DESCENDING_ORDERINGS, CardOrdering, SortDirection, resolve_direction
+from api.parsing import parse_scryfall_query
+from card_engine import QueryEngine
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+class TestAutoDirection:
+    """`auto` is per-ordering, and resolved before either search path sees it."""
+
+    # Measured against api.scryfall.com on 2026-08-09 over `q=t:creature s:dom`, by comparing the
+    # `auto` page against the `asc` and `desc` pages of the same query.
+    MEASURED: ClassVar[dict[CardOrdering, SortDirection]] = {
+        CardOrdering.RELEASED: SortDirection.DESC,
+        CardOrdering.RARITY: SortDirection.DESC,
+        CardOrdering.USD: SortDirection.DESC,
+        CardOrdering.TIX: SortDirection.DESC,
+        CardOrdering.EUR: SortDirection.DESC,
+        CardOrdering.NAME: SortDirection.ASC,
+        CardOrdering.SET: SortDirection.ASC,
+        CardOrdering.COLOR: SortDirection.ASC,
+        CardOrdering.CMC: SortDirection.ASC,
+        CardOrdering.POWER: SortDirection.ASC,
+        CardOrdering.TOUGHNESS: SortDirection.ASC,
+        CardOrdering.EDHREC: SortDirection.ASC,
+        CardOrdering.ARTIST: SortDirection.ASC,
+    }
+
+    @pytest.mark.parametrize("ordering", sorted(MEASURED), ids=str)
+    def test_auto_matches_what_scryfall_does(self, ordering: CardOrdering) -> None:
+        assert resolve_direction(SortDirection.AUTO, ordering) == self.MEASURED[ordering]
+
+    def test_edhrec_auto_is_ascending(self) -> None:
+        """Ascending rank is most-popular-first; descending would surface the least-played cards.
+
+        Called out on its own because "descending popularity" and "ascending rank" are the same
+        direction here, and reading it the other way inverts the site's default sort.
+        """
+        assert resolve_direction(SortDirection.AUTO, CardOrdering.EDHREC) == SortDirection.ASC
+
+    @pytest.mark.parametrize("ordering", sorted(CardOrdering), ids=str)
+    def test_auto_always_resolves_to_a_concrete_direction(self, ordering: CardOrdering) -> None:
+        """No ordering may leave AUTO in place — neither search path knows the value."""
+        assert resolve_direction(SortDirection.AUTO, ordering) in (SortDirection.ASC, SortDirection.DESC)
+
+    @pytest.mark.parametrize("explicit", [SortDirection.ASC, SortDirection.DESC], ids=str)
+    @pytest.mark.parametrize("ordering", sorted(AUTO_DESCENDING_ORDERINGS), ids=str)
+    def test_an_explicit_direction_is_never_overridden(self, ordering: CardOrdering, explicit: SortDirection) -> None:
+        """Including on the orderings whose auto is desc — `dir=asc` there must stay ascending."""
+        assert resolve_direction(explicit, ordering) == explicit
+
+
+def _ordered_ids(engine: QueryEngine, orderby: CardOrdering, direction: SortDirection) -> list[str]:
+    _total, cards = engine.query(
+        filters=parse_scryfall_query("cmc>=0"),
+        unique="printing",
+        prefer="default",
+        orderby=str(orderby),
+        direction=str(direction),
+        limit=1_000,
+        offset=0,
+        fields=["scryfall_id"],
+    )
+    return [str(c["scryfall_id"]) for c in cards]
+
+
+class TestEngineKnowsEveryOrdering:
+    """Every CardOrdering member has its own `SortCol` arm, not the edhrec fallthrough.
+
+    `orderby_to_col` cannot be inspected from Python, so this is behavioural: an ordering that fell
+    through would produce the exact page edhrec produces. The corpus is built so that no two
+    orderings agree by accident — each card is deliberately distinct on every sortable column.
+    """
+
+    @pytest.fixture(scope="class", name="engine")
+    def engine_fixture(self, tmp_path_factory: pytest.TempPathFactory) -> Generator[QueryEngine]:
+        rng = random.Random(20260809)
+        cards: list[dict[str, Any]] = []
+        colors = [{}, {"W": True}, {"U": True}, {"B": True}, {"R": True}, {"G": True}, {"W": True, "U": True}]
+        for i in range(40):
+            cid = f"{i:08x}-0000-4000-8000-{i:012x}"
+            cards.append(
+                {
+                    "scryfall_id": cid,
+                    "oracle_id": f"{i:08x}-1111-4111-8111-{i:012x}",
+                    "illustration_id": f"{i:08x}-2222-4222-8222-{i:012x}",
+                    "card_name": f"Card {i:03d}",
+                    "card_name_lower": f"card {i:03d}",
+                    "card_name_folded": f"card {i:03d}",
+                    # Every sortable column gets a different permutation of the same 40 cards, so
+                    # two orderings returning the same page means one of them was not applied.
+                    "cmc": i % 13,
+                    "edhrec_rank": (i * 7) % 40,
+                    "cubecobra_score": float((i * 29) % 40),
+                    "creature_power": (i * 3) % 11,
+                    "creature_toughness": (i * 5) % 11,
+                    "card_rarity_int": i % 4,
+                    "price_usd": (i * 11) % 97,
+                    "price_eur": (i * 13) % 89,
+                    "price_tix": (i * 17) % 83,
+                    "released_at": f"20{10 + (i % 15):02d}-{1 + (i % 12):02d}-{1 + (i % 28):02d}",
+                    "card_set_code": f"s{(i * 19) % 40:02d}",
+                    "card_artist": f"Artist {(i * 23) % 40:03d}",
+                    "card_colors": colors[i % len(colors)],
+                    "type_line": "Land" if i % 9 == 0 else "Creature — Test",
+                    "oracle_text": f"text {i}",
+                    "prefer_score": float(rng.randrange(100)),
+                }
+            )
+        engine = QueryEngine(str(tmp_path_factory.mktemp("orders") / "orders.store"))
+        assert engine.reload_begin()
+        engine.add_batch(cards)
+        engine.reload_commit()
+        return engine
+
+    def test_the_corpus_loaded(self, engine: QueryEngine) -> None:
+        assert engine.size() == 40
+
+    @pytest.mark.parametrize(
+        "ordering",
+        [o for o in sorted(CardOrdering) if o is not CardOrdering.EDHREC],
+        ids=str,
+    )
+    def test_ordering_is_not_the_edhrec_fallthrough(self, engine: QueryEngine, ordering: CardOrdering) -> None:
+        """The failure this catches is silent: an unmapped name sorts by edhrec and still 200s."""
+        by_edhrec = _ordered_ids(engine, CardOrdering.EDHREC, SortDirection.ASC)
+        assert _ordered_ids(engine, ordering, SortDirection.ASC) != by_edhrec
+
+    @pytest.mark.parametrize("ordering", sorted(CardOrdering), ids=str)
+    def test_every_ordering_returns_the_whole_corpus(self, engine: QueryEngine, ordering: CardOrdering) -> None:
+        """A sort key must reorder rows, never drop them — an absent value sorts last, not out."""
+        assert len(_ordered_ids(engine, ordering, SortDirection.ASC)) == 40
+
+    @pytest.mark.parametrize("ordering", sorted(CardOrdering), ids=str)
+    def test_descending_is_the_reverse_ordering(self, engine: QueryEngine, ordering: CardOrdering) -> None:
+        """Not element-wise reversed — ties break the same way in both directions by design."""
+        ascending = _ordered_ids(engine, ordering, SortDirection.ASC)
+        descending = _ordered_ids(engine, ordering, SortDirection.DESC)
+        assert set(ascending) == set(descending)
+        assert ascending != descending
+
+    def test_released_orders_by_date_not_by_a_truncated_key(self, engine: QueryEngine) -> None:
+        """A raw yyyymmdd exceeds the f32 sort key's exact range, collapsing adjacent dates.
+
+        Forty distinct dates must give forty distinct positions; a truncating key ties some of them
+        and lets the secondary sort decide, which reads as "nearly sorted" rather than as a failure.
+        """
+        ids = _ordered_ids(engine, CardOrdering.RELEASED, SortDirection.ASC)
+        assert ids != _ordered_ids(engine, CardOrdering.RELEASED, SortDirection.DESC)
+        assert len(set(ids)) == 40

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5303,8 +5303,11 @@ fn narrow_rec(
 
 // ─── Sort / select / limit ────────────────────────────────────────────────────
 
+/// `EurLow`/`TixLow` have no `prefer=` spelling — they are not user-selectable, and
+/// `prefer_from_str` cannot produce them. They exist only so `prefer_for_sort` can
+/// express "cheapest printing" for the two price columns that have no `usd_low` twin.
 #[derive(Clone, Copy)]
-enum Prefer { Oldest, Newest, UsdLow, UsdHigh, Promo, Default }
+enum Prefer { Oldest, Newest, UsdLow, UsdHigh, EurLow, TixLow, Promo, Default }
 
 fn prefer_from_str(s: &str) -> Prefer {
     match s {
@@ -5314,6 +5317,39 @@ fn prefer_from_str(s: &str) -> Prefer {
         "usd_high" => Prefer::UsdHigh,
         "promo"    => Prefer::Promo,
         _          => Prefer::Default,
+    }
+}
+
+/// A price ordering ranks each card by its CHEAPEST printing, and the row it returns is
+/// that printing — so under `unique=card`/`unique=artwork` the group's representative has
+/// to be chosen by the price being ordered on, not by `prefer_score`.
+///
+/// Measured against api.scryfall.com on 2026-08-11, `unique=cards`, both directions:
+///
+/// ```text
+/// Birds of Paradise  order=usd -> msc #170 $9.60   (min; the dearest is leb #187 $1000)
+/// Counterspell       order=usd -> brb #15  $2.30   (min; the dearest is leb #55  $919.92)
+/// Gandalf the White  order=usd -> ltr #19  $10.22  (min; the dearest is ltr #299 $2999.99)
+/// Gandalf the White  order=tix -> ltr #470 0.02    (min; ltr #19 at 0.03 is NOT chosen)
+/// Juzám Djinn        order=usd -> arn #29  $1827   (its only priced printing)
+/// ```
+///
+/// Direction does not enter into it: `dir=asc` and `dir=desc` return the same printing and
+/// only reverse the list. Nor is the choice `prefer_score`-shaped — the cheapest printing is
+/// systematically the *least* canonical one (world-championship decks, bulk reprints), so no
+/// amount of `prefer_score` tuning reaches this answer. Left on `Prefer::Default` the engine
+/// instead ranks each card by whatever its most canonical printing costs, which drops cards
+/// whose canonical printing is unpriced (Juzám Djinn's oversized promo) and floats cards
+/// whose canonical printing is a premium variant (Gandalf's $2999.99 serialized ltr #299).
+///
+/// An explicit `prefer=` still wins: it is the caller saying which printing they want, and
+/// `usd_low` already IS this rule spelled out by hand.
+fn prefer_for_sort(prefer: Prefer, sort_col: SortCol) -> Prefer {
+    match (prefer, sort_col) {
+        (Prefer::Default, SortCol::PriceUsd) => Prefer::UsdLow,
+        (Prefer::Default, SortCol::PriceEur) => Prefer::EurLow,
+        (Prefer::Default, SortCol::PriceTix) => Prefer::TixLow,
+        _ => prefer,
     }
 }
 
@@ -5337,8 +5373,13 @@ fn prefer_score(card: &AOracleCard, p: &APrinting, prefer: Prefer) -> f64 {
     match prefer {
         Prefer::Oldest  => -(p.released_at_int.as_ref().map(|v| u32::from(*v)).unwrap_or(99_999_999) as f64),
         Prefer::Newest  => p.released_at_int.as_ref().map(|v| u32::from(*v)).unwrap_or(0) as f64,
+        // The `*Low` arms negate, so a MISSING price scores -inf and loses to every priced
+        // printing — a group with any priced printing is represented by one, and a group with
+        // none keeps its first-in-store-order (highest `prefer_score`) printing.
         Prefer::UsdLow  => -p.price_usd.as_ref().map(|v| f64::from(u32::from(*v)) / 100.0).unwrap_or(f64::INFINITY),
         Prefer::UsdHigh => p.price_usd.as_ref().map(|v| f64::from(u32::from(*v)) / 100.0).unwrap_or(0.0),
+        Prefer::EurLow  => -p.price_eur.as_ref().map(|v| f64::from(u32::from(*v)) / 100.0).unwrap_or(f64::INFINITY),
+        Prefer::TixLow  => -p.price_tix.as_ref().map(|v| f64::from(u32::from(*v)) / 100.0).unwrap_or(f64::INFINITY),
         // Card-level (edhrec is oracle-scoped): every printing ties, so the
         // first printing in store order is chosen — same as before the split.
         Prefer::Promo   => -(card.edhrec_rank.as_ref().map(|r| u32::from(*r) as f64).unwrap_or(f64::INFINITY)),
@@ -5677,10 +5718,14 @@ impl QueryParams {
     /// `orderby_to_col`/`== "desc"`/`prefer_from_str`/`mode_from_unique` block
     /// each used to repeat.
     fn from_strs(unique: &str, prefer: &str, orderby: &str, direction: &str, limit: usize, page_offset: usize) -> Self {
+        // `prefer` depends on `sort_col`, so bind the column first — see `prefer_for_sort`.
+        // This is the only `QueryParams` constructor, which is what makes one call here enough
+        // to cover `run_query`, `run_query_with_plan`, `explain_analyze` and `explain`.
+        let sort_col = orderby_to_col(orderby);
         QueryParams {
             mode: mode_from_unique(unique),
-            prefer: prefer_from_str(prefer),
-            sort_col: orderby_to_col(orderby),
+            prefer: prefer_for_sort(prefer_from_str(prefer), sort_col),
+            sort_col,
             descending: direction == "desc",
             limit,
             page_offset,

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -305,6 +305,13 @@ struct Printing {
     // strings live on the printing.
     card_artist_vid: u16,
     card_set_code: InlineStr<8>,
+    // Dense ranks of card_set_code and the artist name in byte order, assigned post-load by
+    // assign_set_ranks / assign_artist_ranks; the sort keys for SortCol::Set and SortCol::Artist.
+    // Neither can be derived at sort time: a set code is a string, and card_artist_vid is intern
+    // order (first seen), not alphabetical. Equal values share a rank so the sort secondaries break
+    // their ties, and both stay far below 2^24 so the f32 sort-key conversion is exact.
+    set_rank: u32,
+    artist_rank: u32,
     card_border_id: u32,
     card_watermark_id: u32,
     collector_number_id: u32,
@@ -2050,9 +2057,12 @@ struct SortPermutations {
 }
 
 impl ArchivedSortPermutations {
-    /// The permutation for a streamable column/direction; None for the
-    /// printing-keyed columns (rarity, usd), whose sort key depends on the
-    /// prefer-chosen printing and cannot be precomputed.
+    /// The permutation for a streamable column/direction; None for the columns that have none.
+    ///
+    /// Those are the printing-keyed ones -- rarity, the three prices, released, set and artist --
+    /// whose sort key depends on the prefer-chosen printing and so cannot be precomputed per card.
+    /// Colour is card-level and could have one; it does not yet, and returning None here costs only
+    /// the streaming fast path, not correctness.
     fn get(&self, col: SortCol, descending: bool) -> Option<&Archived<Vec<u32>>> {
         let pair = match col {
             SortCol::EdhrecRank => &self.edhrec,
@@ -2061,7 +2071,14 @@ impl ArchivedSortPermutations {
             SortCol::Power      => &self.power,
             SortCol::Toughness  => &self.toughness,
             SortCol::Name       => &self.name,
-            SortCol::Rarity | SortCol::PriceUsd => return None,
+            SortCol::Rarity
+            | SortCol::PriceUsd
+            | SortCol::PriceEur
+            | SortCol::PriceTix
+            | SortCol::Released
+            | SortCol::Color
+            | SortCol::Set
+            | SortCol::Artist => return None,
         };
         Some(&pair[descending as usize])
     }
@@ -2075,7 +2092,14 @@ impl ArchivedSortPermutations {
             SortCol::Power      => &self.power_inv,
             SortCol::Toughness  => &self.toughness_inv,
             SortCol::Name       => &self.name_inv,
-            SortCol::Rarity | SortCol::PriceUsd => return None,
+            SortCol::Rarity
+            | SortCol::PriceUsd
+            | SortCol::PriceEur
+            | SortCol::PriceTix
+            | SortCol::Released
+            | SortCol::Color
+            | SortCol::Set
+            | SortCol::Artist => return None,
         };
         Some(&pair[descending as usize])
     }
@@ -2121,6 +2145,44 @@ fn assign_name_ranks(cards: &mut [OracleCard]) {
         }
         cards[ids[i] as usize].name_rank = rank;
     }
+}
+
+/// Dense-rank every printing by a key derived from it, writing the rank back through `set`.
+///
+/// The shape `assign_name_ranks` uses, lifted out because set code and artist need the same thing:
+/// sort an index permutation by the key, then walk it assigning a rank that advances only when the
+/// key changes, so equal keys tie and the sort secondaries decide between them.
+fn assign_printing_ranks<K: Ord>(
+    printings: &mut [Printing],
+    key: impl Fn(&Printing) -> K,
+    set: impl Fn(&mut Printing, u32),
+) {
+    let mut ids: Vec<u32> = (0..printings.len() as u32).collect();
+    ids.sort_unstable_by(|&a, &b| key(&printings[a as usize]).cmp(&key(&printings[b as usize])));
+    let mut rank = 0u32;
+    for i in 0..ids.len() {
+        if i > 0 && key(&printings[ids[i - 1] as usize]) != key(&printings[ids[i] as usize]) {
+            rank += 1;
+        }
+        set(&mut printings[ids[i] as usize], rank);
+    }
+}
+
+/// Rank printings by set code, the sort key for `order=set`.
+fn assign_set_ranks(printings: &mut [Printing]) {
+    assign_printing_ranks(printings, |p| p.card_set_code.as_str().to_owned(), |p, r| p.set_rank = r);
+}
+
+/// Rank printings by artist name, the sort key for `order=artist`.
+///
+/// Resolved through the vocab rather than sorting on `card_artist_vid`, which is intern order.
+/// A printing with no artist ranks last, matching how the absent side of every other order sorts.
+fn assign_artist_ranks(printings: &mut [Printing], artist_vocab: &[String]) {
+    let name_of = |p: &Printing| match p.card_artist_vid {
+        ARTIST_NONE => None,
+        vid => artist_vocab.get(vid as usize).cloned(),
+    };
+    assign_printing_ranks(printings, |p| (name_of(p).is_none(), name_of(p)), |p, r| p.artist_rank = r);
 }
 
 /// `inv[perm[i]] == i` — the position of each card within the permutation.
@@ -2224,8 +2286,8 @@ fn perm_primary_key(value: Option<f32>, descending: bool) -> u32 {
 }
 
 /// The sort column's value for one archived card, in the same units `build_sort_permutations` sorted
-/// on. Card-level columns only: `Rarity`/`PriceUsd` have no permutation (they depend on the
-/// prefer-chosen printing), which is why `ArchivedSortPermutations::get` returns `None` for them.
+/// on. Card-level columns only: every column `ArchivedSortPermutations::get` returns `None` for is
+/// unreachable here, because nothing walks a permutation that does not exist.
 fn sort_col_card_value(card: &AOracleCard, sort_col: SortCol) -> Option<f32> {
     match sort_col {
         SortCol::EdhrecRank => card.edhrec_rank.as_ref().map(|v| u32::from(*v) as f32),
@@ -2235,7 +2297,15 @@ fn sort_col_card_value(card: &AOracleCard, sort_col: SortCol) -> Option<f32> {
         SortCol::Power      => card.creature_power.as_ref().map(|v| f32::from(*v)),
         SortCol::Toughness  => card.creature_toughness.as_ref().map(|v| f32::from(*v)),
         SortCol::Name       => Some(u32::from(card.name_rank) as f32),
-        SortCol::Rarity | SortCol::PriceUsd => None,
+        // Unreachable: these have no permutation, so nothing walks them (see `get`).
+        SortCol::Rarity
+        | SortCol::PriceUsd
+        | SortCol::PriceEur
+        | SortCol::PriceTix
+        | SortCol::Released
+        | SortCol::Color
+        | SortCol::Set
+        | SortCol::Artist => None,
     }
 }
 
@@ -5277,8 +5347,14 @@ fn prefer_score(card: &AOracleCard, p: &APrinting, prefer: Prefer) -> f64 {
 }
 
 #[derive(Clone, Copy)]
-enum SortCol { Cmc, Power, Toughness, Rarity, PriceUsd, Cubecobra, EdhrecRank, Name }
+enum SortCol {
+    Cmc, Power, Toughness, Rarity, PriceUsd, PriceEur, PriceTix,
+    Cubecobra, EdhrecRank, Name, Released, Color, Set, Artist,
+}
 
+/// Every arm here must have a `CardOrdering` member in api/enums.py and a `sql_orderby` entry in
+/// api_resource.py. The fallthrough is why: an order name the API knows and this does not sorts by
+/// edhrec here while SQL sorts by the real column, so the two paths disagree on identical input.
 fn orderby_to_col(orderby: &str) -> SortCol {
     match orderby {
         "cmc"       => SortCol::Cmc,
@@ -5286,9 +5362,47 @@ fn orderby_to_col(orderby: &str) -> SortCol {
         "rarity"    => SortCol::Rarity,
         "toughness" => SortCol::Toughness,
         "usd"       => SortCol::PriceUsd,
+        "eur"       => SortCol::PriceEur,
+        "tix"       => SortCol::PriceTix,
         "cubecobra" => SortCol::Cubecobra,
         "name"      => SortCol::Name,
+        "released"  => SortCol::Released,
+        "color"     => SortCol::Color,
+        "set"       => SortCol::Set,
+        "artist"    => SortCol::Artist,
         _           => SortCol::EdhrecRank,
+    }
+}
+
+/// Pack a `yyyymmdd` date into a small order-preserving integer.
+///
+/// The sort key rounds its primary through f32, which is exact only below 2^24 (see `name_rank`).
+/// A raw `yyyymmdd` is ~20,260,809 -- past that, so two dates a day apart can collide. This keeps
+/// the ordering and drops the magnitude: distinct years are 372 apart, which exceeds the largest
+/// in-year offset (11*31 + 30 = 371), so the packing is strictly monotonic for valid dates and
+/// tops out near 755,000 for 2030. `released_at_int` itself stays `yyyymmdd`, which is what the
+/// date and year filters compare against.
+fn released_sort_ord(yyyymmdd: u32) -> u32 {
+    let (y, m, d) = (yyyymmdd / 10_000, (yyyymmdd / 100) % 100, yyyymmdd % 100);
+    y * 372 + m.saturating_sub(1) * 31 + d.saturating_sub(1)
+}
+
+/// Scryfall's `order=color` bucketing, measured 2026-08-09 over 923 cards spanning every colour
+/// shape: `W U B R G`, then multicolour by HOW MANY colours (not which -- guild pairs tie and fall
+/// to the secondary sort), then colourless, then lands. Two parts of that are not what a popcount
+/// would give: colourless sorts last rather than first, and lands sort after it.
+fn color_sort_rank(colors: u8, type_bits: u16) -> u32 {
+    // WUBRG in Scryfall's order; the bit values are color_to_bit's. The C bit is masked off rather
+    // than counted: a colourless card ranks by being colourless, and C alongside a real colour
+    // would otherwise read as an extra colour.
+    const MONO_ORDER: [u8; 5] = [1, 2, 4, 8, 16];
+    const WUBRG: u8 = 1 | 2 | 4 | 8 | 16;
+    let colors = colors & WUBRG;
+    match colors.count_ones() {
+        0 if type_bits & TYPE_LAND != 0 => 10,
+        0 => 9,
+        1 => MONO_ORDER.iter().position(|&bit| colors == bit).unwrap_or(0) as u32,
+        n => 3 + n, // 2 colours -> 5, 3 -> 6, 4 -> 7, 5 -> 8
     }
 }
 
@@ -5315,9 +5429,18 @@ fn sort_key_bits(card: &AOracleCard, p: &APrinting, sort_col: SortCol, descendin
         // exposed value), and cents fit exactly in f32 (max real price 514,202 cents, f32
         // represents any integer up to 2^24 exactly), so skip the /100.0 dollars conversion.
         SortCol::PriceUsd   => p.price_usd.as_ref().map(|v| u32::from(*v) as f32),
+        SortCol::PriceEur   => p.price_eur.as_ref().map(|v| u32::from(*v) as f32),
+        SortCol::PriceTix   => p.price_tix.as_ref().map(|v| u32::from(*v) as f32),
         SortCol::Cubecobra  => card.cubecobra_score.as_ref().map(|v| f32::from(*v)),
         SortCol::EdhrecRank => card.edhrec_rank.as_ref().map(|v| u32::from(*v) as f32),
         SortCol::Name       => Some(u32::from(card.name_rank) as f32),
+        // Packed rather than raw: yyyymmdd exceeds the exact-f32 range (see released_sort_ord).
+        SortCol::Released   => p.released_at_int.as_ref().map(|v| released_sort_ord(u32::from(*v)) as f32),
+        SortCol::Color      => Some(color_sort_rank(card.card_colors, u16::from(card.card_types)) as f32),
+        // Dense ranks assigned post-load; the stored code and artist id do not sort alphabetically
+        // on their own (see assign_set_ranks / assign_artist_ranks).
+        SortCol::Set        => Some(u32::from(p.set_rank) as f32),
+        SortCol::Artist     => Some(u32::from(p.artist_rank) as f32),
     };
     let pk = primary.map_or(u32::MAX, |v| f32_sort_bits(if descending { -v } else { v }));
     let e = card.edhrec_rank.as_ref().map(|v| u32::from(*v)).unwrap_or(u32::MAX);
@@ -11531,7 +11654,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 // `NameUnigramIndex` (#858) is a new archived type, so a store built before it must fail the header
 // check and be rebuilt rather than be read as garbage. Dated 2026-08-06, patch 01; the check is
 // EQUALITY, so the invariant is only that a value is never reused for a different layout.
-const ARCHIVE_FORMAT_VERSION: u32 = 2026080601;
+const ARCHIVE_FORMAT_VERSION: u32 = 2026080901;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -12008,6 +12131,10 @@ impl QueryEngine {
                 flavor_text_lower_id: row.flavor_text_lower_id,
                 card_artist_vid: row.card_artist_vid,
                 card_set_code: row.card_set_code,
+                // Both assigned once the whole printing list exists, by assign_set_ranks /
+                // assign_artist_ranks -- a dense rank cannot be known one row at a time.
+                set_rank: 0,
+                artist_rank: 0,
                 card_border_id: row.card_border_id,
                 card_watermark_id: row.card_watermark_id,
                 collector_number_id: row.collector_number_id,
@@ -12038,6 +12165,10 @@ impl QueryEngine {
         drop(vocab.map);
         let artist_vocab = artists.strings;
         drop(artists.map);
+        // After the vocab is final, before the printings are archived: both ranks are stored on the
+        // printing and must be in place when it is written out.
+        assign_set_ranks(&mut printings);
+        assign_artist_ranks(&mut printings, &artist_vocab);
         let mana_vocab = mana.strings;
         drop(mana.map);
         // String-sorted permutation of the vocab ids; VocabInterner caps the

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -11355,3 +11355,104 @@ fn arith_tuple_key_budget_catches_a_blown_domain() {
 /// Above `ARITH_TUPLE_GUARD_MIN_CARDS`, and large enough that an all-distinct key space
 /// clears `10*sqrt(n)+32` by a wide margin.
 const ARITH_TUPLE_BLOWUP_CARDS: usize = 6_000;
+
+// ─── Price orderings pick the group's cheapest printing ───────────────────────
+//
+// See `prefer_for_sort`. Scryfall ranks a card by its CHEAPEST printing in the ordered
+// currency and returns that printing, so under `unique=card`/`unique=artwork` the
+// representative has to be chosen by the ordered price rather than by `prefer_score`.
+
+/// One card whose three printings disagree about which is cheapest in each currency,
+/// plus a `prefer_score` order that agrees with none of them. `store_of` stores printings
+/// prefer-descending, so scryfall_id 1 is the default-preferred one.
+fn priced_store(prices: &[(Option<u32>, Option<u32>, Option<u32>)]) -> CardData {
+    let mut vocab = VocabInterner::new();
+    let card = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
+    let mut data = store_of(vec![card], &[prices.len()], vocab);
+    for (p, &(usd, eur, tix)) in data.printings.iter_mut().zip(prices) {
+        p.price_usd = usd;
+        p.price_eur = eur;
+        p.price_tix = tix;
+    }
+    // Built, not left at their empty defaults: an empty index makes `walk_value_orderby_page`
+    // decline and fall back to the gather, which would leave the walk's `rep == pid` emission
+    // test — the one place the representative choice and the page order have to agree —
+    // silently uncovered.
+    data.indexes.price_usd = build_printing_value_index(&data.printings, &data.cards, &data.offsets, |p| p.price_usd);
+    data.indexes.price_eur = build_printing_value_index(&data.printings, &data.cards, &data.offsets, |p| p.price_eur);
+    data.indexes.price_tix = build_printing_value_index(&data.printings, &data.cards, &data.offsets, |p| p.price_tix);
+    data
+}
+
+/// The representative `unique=card` returns for `orderby`/`direction`, as a scryfall_id.
+fn representative(data: &CardData, prefer: &str, orderby: &str, direction: &str) -> u128 {
+    let bytes = rkyv::to_bytes::<Error>(data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let mut filter = FilterExpr::True;
+    let (total, page) = run_query(&QueryCtx::from(archived), &mut filter, None, "card", prefer, orderby, direction, 100, 0);
+    assert_eq!(total, 1, "unique=card collapses the fixture to one row");
+    u128::from(page[0].1.scryfall_id)
+}
+
+#[test]
+fn price_orderby_represents_the_card_by_its_cheapest_printing() {
+    // id 1 is prefer-best; the cheapest is a different printing in each currency.
+    let data = priced_store(&[
+        (Some(9_00), Some(1_00), Some(9_00)), // id 1 — cheapest in EUR
+        (Some(5_00), Some(5_00), Some(0_50)), // id 2 — cheapest in TIX
+        (Some(1_00), Some(3_00), Some(3_00)), // id 3 — cheapest in USD
+    ]);
+    // The non-price ordering is untouched: it still gets the prefer_score pick.
+    assert_eq!(representative(&data, "default", "edhrec", "asc"), 1);
+    assert_eq!(representative(&data, "default", "name", "desc"), 1);
+    // Each price ordering gets that currency's cheapest printing...
+    assert_eq!(representative(&data, "default", "usd", "desc"), 3);
+    assert_eq!(representative(&data, "default", "eur", "desc"), 1);
+    assert_eq!(representative(&data, "default", "tix", "desc"), 2);
+    // ...in BOTH directions. Direction reverses the page; it does not re-pick the printing.
+    assert_eq!(representative(&data, "default", "usd", "asc"), 3);
+    assert_eq!(representative(&data, "default", "eur", "asc"), 1);
+    assert_eq!(representative(&data, "default", "tix", "asc"), 2);
+}
+
+/// The Juzám Djinn shape: the prefer-best printing is an unpriced oversized promo, so
+/// leaving the pick to `prefer_score` gave the card no USD price at all and dropped it out
+/// of a price sort entirely. A missing price must lose to any real one.
+#[test]
+fn price_orderby_skips_a_printing_with_no_price_in_that_currency() {
+    let data = priced_store(&[
+        (None, None, Some(1_00)),          // id 1 — prefer-best, but unpriced in USD and EUR
+        (Some(1827_00), Some(1775_40), None), // id 2 — the only printing with a USD/EUR price
+    ]);
+    assert_eq!(representative(&data, "default", "edhrec", "asc"), 1);
+    assert_eq!(representative(&data, "default", "usd", "desc"), 2);
+    assert_eq!(representative(&data, "default", "eur", "desc"), 2);
+    // TIX is the mirror image: only the prefer-best printing has one.
+    assert_eq!(representative(&data, "default", "tix", "desc"), 1);
+}
+
+/// When NOTHING is priced there is no cheaper printing to prefer, so the card keeps its
+/// ordinary representative rather than silently changing which printing it shows.
+#[test]
+fn price_orderby_keeps_the_default_representative_when_no_printing_is_priced() {
+    let data = priced_store(&[(None, None, None), (None, None, None)]);
+    assert_eq!(representative(&data, "default", "usd", "desc"), 1);
+    assert_eq!(representative(&data, "default", "eur", "asc"), 1);
+    assert_eq!(representative(&data, "default", "tix", "desc"), 1);
+}
+
+/// An explicit `prefer=` is the caller naming the printing they want, and it still wins —
+/// `prefer_for_sort` only fills in a pick for callers that did not make one.
+#[test]
+fn an_explicit_prefer_still_beats_the_price_orderby() {
+    let data = priced_store(&[
+        (Some(9_00), Some(1_00), Some(9_00)), // id 1 — prefer-best, dearest in USD
+        (Some(5_00), Some(5_00), Some(0_50)),
+        (Some(1_00), Some(3_00), Some(3_00)), // id 3 — cheapest in USD
+    ]);
+    assert_eq!(representative(&data, "usd_high", "usd", "desc"), 1);
+    assert_eq!(representative(&data, "usd_low", "usd", "desc"), 3);
+    // `oldest`/`newest` are price-blind: store_of makes the LAST printing the oldest.
+    assert_eq!(representative(&data, "oldest", "usd", "desc"), 3);
+    assert_eq!(representative(&data, "newest", "usd", "desc"), 1);
+}

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -229,6 +229,8 @@ fn stub_printing(scryfall_id: u128, illustration_id: u128, prefer_score: Option<
         flavor_text_lower_id: NONE_STR,
         card_artist_vid: ARTIST_NONE,
         card_set_code: InlineStr::from_str(""),
+        set_rank: 0,
+        artist_rank: 0,
         card_border_id: NONE_STR,
         card_watermark_id: NONE_STR,
         collector_number_id: NONE_STR,

--- a/client/query_sampler.py
+++ b/client/query_sampler.py
@@ -136,16 +136,42 @@ REALISTIC_UNIQUE_WEIGHTS: dict[str, float] = {"card": 75, "printing": 20, "artwo
 # ships in the client image, which contains no `api/`. Anything outside this set is accepted by the
 # engine and silently sorted by edhrec, so callers mapping external orderbys should fall back
 # explicitly rather than pass an unknown value through and mislabel the result.
-ENGINE_ORDERBYS = frozenset({"cmc", "cubecobra", "edhrec", "name", "power", "rarity", "toughness", "usd"})
+ENGINE_ORDERBYS = frozenset(
+    {
+        "artist",
+        "cmc",
+        "color",
+        "cubecobra",
+        "edhrec",
+        "eur",
+        "name",
+        "power",
+        "rarity",
+        "released",
+        "set",
+        "tix",
+        "toughness",
+        "usd",
+    },
+)
 REALISTIC_ORDERBY_WEIGHTS: dict[str, float] = {
     "edhrec": 40,
     "name": 15,
     "cmc": 10,
-    "usd": 10,
-    "rarity": 8,
-    "power": 6,
-    "toughness": 5,
-    "cubecobra": 6,
+    "usd": 8,
+    "rarity": 7,
+    "power": 5,
+    "toughness": 4,
+    "cubecobra": 5,
+    # The orders added with the Scryfall vocabulary. Weighted low because they are new rather than
+    # because they are known to be rare -- and non-zero because none of them has a precomputed sort
+    # permutation, so they exercise the general sort path the streaming plans skip.
+    "released": 2,
+    "set": 1,
+    "color": 1,
+    "artist": 1,
+    "eur": 0.5,
+    "tix": 0.5,
 }
 # Non-default result parameters skew hard to their defaults but are sampled so the paths that only
 # run off-default stay on the radar.

--- a/docs/changelog/2026-08-09-order-vocabulary.md
+++ b/docs/changelog/2026-08-09-order-vocabulary.md
@@ -1,0 +1,44 @@
+# Six more `order=` values, and `dir=auto`
+
+## What this adds
+
+`order=` accepted `cmc`, `edhrec`, `name`, `power`, `rarity`, `toughness`, `usd` and `cubecobra`.
+It now also accepts `released`, `set`, `artist`, `color`, `eur` and `tix` — Scryfall's vocabulary
+minus `penny` and `review`.
+
+`dir=auto` is new. It is not a constant: measured against api.scryfall.com, `auto` means descending
+for `released`, `rarity`, `usd`, `tix` and `eur`, and ascending for everything else. Two of those
+are orderings that already existed, so `rarity` and `usd` were previously sorting the wrong way for
+any caller that asked for `auto`.
+
+All of it lands on `/search`, on `/cards/search`, and on the in-query `order:` / `sort:` /
+`direction:` / `dir:` directives at once, because every route resolves to `CardOrdering` and
+`SortDirection` before reaching a search path.
+
+## How
+
+The blocker was `orderby_to_col` in the engine, whose catch-all arm sorts by edhrec. An ordering
+added to the API and not to `SortCol` does not raise — it makes the engine and the SQL builder
+return differently-ordered pages for identical input. So each new ordering is an engine change
+first: a `SortCol` variant and a `sort_key_bits` arm, plus
+
+- **`released`** packs `yyyymmdd` down to `y*372 + (m-1)*31 + (d-1)` before the sort key. The key
+  rounds through f32, exact only below 2^24; a raw `20260809` is past that and collides dates a day
+  or two apart. `released_at_int` itself is unchanged, since the date and year filters read it.
+- **`color`** is eleven buckets — `W U B R G`, multicolour by how many colours, colourless, land.
+  Measured, because two parts are not what a colour bitmask gives: colourless sorts last rather
+  than first, and lands after it.
+- **`set` and `artist`** get dense ranks on the printing, assigned post-load like `name_rank`
+  already is. Neither sorts from what the key can reach: a set code is a string, and
+  `card_artist_vid` is intern order. `ARCHIVE_FORMAT_VERSION` bumps so an existing store rebuilds.
+
+`AUTO` resolves in `_search`, before either path sees it, so the engine and SQL always receive the
+same concrete direction and the cache keys on what actually ran.
+
+## Not covered
+
+`penny` needs `penny_rank` lifted out of `raw_card_blob` into a column; `review` is Scryfall-internal
+and not reproducible. Both keep falling back to `name`, which is what Scryfall does with an order it
+does not recognize — measured: it falls back silently rather than erroring.
+
+Full design and measurements: [docs/issues/local-engine-order-vocabulary.md](../issues/local-engine-order-vocabulary.md).

--- a/docs/issues/local-engine-order-vocabulary.md
+++ b/docs/issues/local-engine-order-vocabulary.md
@@ -1,0 +1,113 @@
+# The Six Missing `order` Values, and `dir=auto`
+
+Scryfall sorts by fifteen things. This engine sorts by eight, and `dir=auto` is not implemented at
+all. Closing that gap lands in three places at once — the `order=` parameter, the in-query `order:`
+directive (#893 builds its vocabulary from the `CardOrdering` enum), and the Scryfall-compatible
+`/cards/search` (#912) — because all three resolve to the same enum before reaching a search path.
+
+Everything below marked *measured* was taken from api.scryfall.com on 2026-08-09.
+
+## What blocks it
+
+`orderby_to_col` (`card_engine/src/lib.rs`) maps an order name to `SortCol`, with a catch-all:
+
+```rust
+_ => SortCol::EdhrecRank,
+```
+
+So adding a `CardOrdering` member and a `sql_orderby` entry without extending `SortCol` makes the
+SQL path sort by the new column while the engine silently sorts by edhrec. The two paths would
+disagree on identical input, which is the failure `RESULT_FIELD_COLUMNS` already warns about for
+result fields. **Every order below is an engine change first and an API change second.**
+
+## `dir=auto` — measured
+
+Scryfall's `auto` is per-order, not a constant. Taken over `q=t:creature s:dom` by comparing the
+`auto` page against the `asc` and `desc` pages:
+
+| resolves to `desc` | resolves to `asc` |
+| --- | --- |
+| `released`, `rarity`, `usd`, `tix`, `eur` | `name`, `set`, `color`, `cmc`, `power`, `toughness`, `edhrec`, `penny`, `artist`, `review` |
+
+Two of these are orders this engine already supports, so **`rarity` and `usd` are wrong today** for
+any caller that passes `auto` — they sort ascending where Scryfall sorts descending.
+
+`edhrec` resolves to **ascending**, which is the direction that puts rank 1 (Llanowar Elves, on that
+query) first. Rank-descending would surface the least-played cards, so "descending popularity" and
+"ascending rank" are the same thing here and the enum wants the latter.
+
+`auto` folds to a concrete direction *before* either search path sees it, so it belongs in `_search`
+next to the directive folding, not in the engine. That also means `/search` and `/cards/search` get
+it from one place, and `direction:auto` / `dir:auto` come free.
+
+## The six orders
+
+| order | data on the printing | work |
+| --- | --- | --- |
+| `eur` | `price_eur: Option<u32>` (cents) | one arm each in `orderby_to_col` and `sort_key_bits`, identical to `usd` |
+| `tix` | `price_tix: Option<u32>` (cents) | same |
+| `released` | `released_at_int: Option<u32>` | see the f32 trap below |
+| `color` | `card_colors: u8` bitmask + `TYPE_LAND` | rank function, see below |
+| `set` | `card_set_code: InlineStr<8>` | needs a dense rank; string, so nothing to sort on directly |
+| `artist` | `card_artist_vid: u16` | needs a dense rank; vid is intern order, not alphabetical |
+
+### The f32 trap on `released`
+
+`sort_key_bits` packs the primary into 32 bits via `f32_sort_bits`, and the comment on `name_rank`
+already records the constraint: *"Ranks stay below 2^24 so the f32 sort-key conversion is exact."*
+
+`released_at_int` is `yyyymmdd`, so 20260809 — three orders of magnitude past 2^24 = 16,777,216.
+Fed in raw it silently loses roughly a day or two of resolution, which is invisible in every test
+that does not compare two adjacent release dates.
+
+`released_at_int` must stay `yyyymmdd` (date and year filters read it), so the sort key packs it
+down instead: `y * 372 + (m - 1) * 31 + (d - 1)`, which is strictly order-preserving for valid dates
+and tops out near 755,000 for year 2030. Computed inline in `sort_key_bits` — it runs once per
+matching row while building the `Match` tuple, not once per comparison.
+
+### The colour ranking — measured
+
+Scryfall's `order=color` is eleven buckets, taken over 923 legendary creatures and lands spanning
+every colour shape:
+
+```
+W → U → B → R → G → 2-colour → 3-colour → 4-colour → 5-colour → colourless → land
+```
+
+Two things worth noting, because neither is what a reader would guess. Multicolour is bucketed by
+**how many** colours, not by which — within 2-colour the order is whatever the secondary sort gives,
+so all guild pairs tie. And colourless sorts *after* every coloured bucket rather than before,
+with lands after that; a naive popcount would put colourless first.
+
+The rank is `0..=10`, computable from the bitmask's popcount, its single set bit for the mono cases,
+and a `TYPE_LAND` check. Trivially inside the exact-f32 range.
+
+### `set` and `artist` need a stored rank
+
+Neither can be ordered from what the sort key can reach: a set code is a string, and
+`card_artist_vid` is assigned in first-seen order by the interner, not alphabetically. Both follow
+the existing `assign_name_ranks` shape — a post-load dense-rank pass writing a `u32` onto the
+printing — which means two new fields on `Printing`, inherited by `APrinting` through the rkyv
+derive, and a bump of `ARCHIVE_FORMAT_VERSION` so an existing store rebuilds rather than
+misreading. Cost is 8 bytes per printing, ~4 MB against the build's ~305 MB floor.
+
+## Deliberately not done
+
+- **`penny`** — `penny_rank` lives only inside `raw_card_blob`. Needs a migration, a column, an
+  import change and an engine field: a much larger change for the least-used order in the list.
+- **`review`** — Scryfall-internal ordering with no public input. Not reproducible at any cost, and
+  the one value on the list that should stay unsupported permanently.
+
+Both keep falling back to `name`, which is what Scryfall itself does with an order it does not
+recognize — *measured*: `order=bogus` returns the same page as no `order` at all, silently, with no
+error. The only divergence is the `warnings` entry this API adds saying so.
+
+## Order of work
+
+1. `eur`, `tix` — near-free, and they prove the seam.
+2. `released`, `color` — computed ranks, no store change.
+3. `set`, `artist` — the two stored ranks and the format bump.
+4. `SortDirection.AUTO` and the table above, folded in `_search`.
+
+Steps 1, 2 and 4 touch no archived layout, so they can ship without a store rebuild; step 3 forces
+one on next boot.


### PR DESCRIPTION
**Stacked on #913** (`engine-order-vocabulary`), which is where `order=eur` and `order=tix` come from — the diff below shows `5f01742` as well as this branch's own commit. Merge after #913; the fix itself is one function plus two `prefer_score` arms.

## The bug

`order=usd|eur|tix` under `unique=card` ranked each card by whatever its `prefer_score`-preferred printing happened to cost. That is not what the ordering means, and it is not what Scryfall returns.

Measured against api.scryfall.com on 2026-08-11, `unique=cards`:

```
Birds of Paradise  order=usd -> msc #170 $9.60   (min; the dearest is leb #187 $1000)
Counterspell       order=usd -> brb #15  $2.30   (min; the dearest is leb #55  $919.92)
Gandalf the White  order=usd -> ltr #19  $10.22  (min; the dearest is ltr #299 $2999.99)
Gandalf the White  order=tix -> ltr #470 0.02    (min; ltr #19 at 0.03 is NOT chosen)
Juzám Djinn        order=usd -> arn #29  $1827   (its only priced printing)
```

Scryfall ranks a card by its **cheapest** printing in the ordered currency and returns *that* printing. `dir=asc` and `dir=desc` return the same printing and only reverse the list, so this is a property of the ordering, not of the direction.

Two failure shapes fell out of the old behaviour, both reproducible:

- **Juzám Djinn** — its preferred printing is the oversized 90s promo (`o90p`), which has no USD price at all, so the card carried no price into the sort and **vanished from `order=usd` entirely**. Scryfall ranks it first at $1827.
- **Gandalf the White** — its preferred printing is the serialized `ltr #299` at $2999.99, which floated it to **rank 1** of `t:creature order=usd dir=desc`. Scryfall ranks it by its $10.22 printing, nowhere near the top.

## Why this is not a `prefer_score` tuning problem

The cheapest printing is systematically the *least* canonical one — world-championship decks, bulk reprints — so no weighting reaches this answer. Measured on a 97,803-printing corpus, the `prefer_score`-best printing is never the cheapest:

```
Birds of Paradise  prefer-best rvr #133    $15.46 | cheapest wc01 #jt231   $4.98
Counterspell       prefer-best cmr #632    $3.15  | cheapest wc00 #tvdl61b $1.29
Lightning Bolt     prefer-best plst#E01-54 $1.12  | cheapest msc #806      $0.73
```

For the record, Juzám Djinn's promo outscores its Arabian Nights printing by exactly the **+15 of the `frame` component** (`1997` vs `1993`) and is component-for-component identical otherwise — so even correcting that would not select the cheap printing a price ordering has to return. (Whether an oversized `memorabilia` promo should be the *default* representative at all is a separate question; `backfill_prefer_scores.sql` has no set-type term, and set type only filters the `illustration_count` numerator. Happy to open that separately if it's of interest.)

## The change

`prefer_for_sort` fills in the representative from the ordered column when the caller named no `prefer` of their own. `Prefer::UsdLow` already spelled this rule out by hand, so `usd` reuses it; `EurLow`/`TixLow` join it for the two columns that had no equivalent. They are internal-only — `prefer_from_str` cannot produce them, so no new `prefer=` value becomes reachable.

- An explicit `prefer=` is the caller naming the printing they want and **still wins**.
- A missing price loses to any real one (the `*Low` arms negate, so an absent price scores `-inf`).
- A card with **nothing** priced keeps its ordinary representative rather than silently changing which printing it shows.

`QueryParams::from_strs` is the only `QueryParams` constructor, which is what makes one call there enough to cover `run_query`, `run_query_with_plan`, `explain_analyze` and `explain`.

## Blast radius

Confined to representative selection. No stored value, archive layout or sort key changes, so **no reimport and no `ARCHIVE_FORMAT_VERSION` bump**. The three price columns already have no sort permutation — `SortPermutations::get` returns `None` for them precisely because "their sort key depends on the prefer-chosen printing" — so they were already on the gathered / `walk_value_orderby_page` paths this affects, and `walk_value_orderby_page`'s `rep == pid` emission test is prefer-generic and stays correct.

Cost: price-ordered queries now score a card's whole printing span (~3.1 printings) instead of early-breaking on the first (~1.01). The cost model already reads `prefer` for exactly this (`scan_units` under `PlanePopcountOrder`), so the estimate follows the change rather than going stale.

## Tests

Four new tests in `card_engine/src/tests.rs`, driving the real `run_query` string surface:

- `price_orderby_represents_the_card_by_its_cheapest_printing` — one card whose three printings disagree about which is cheapest per currency; asserts `edhrec`/`name` still get the `prefer_score` pick, each price ordering gets that currency's cheapest, and **both directions agree**.
- `price_orderby_skips_a_printing_with_no_price_in_that_currency` — the Juzám Djinn shape.
- `price_orderby_keeps_the_default_representative_when_no_printing_is_priced`.
- `an_explicit_prefer_still_beats_the_price_orderby` — `usd_high`/`usd_low`/`oldest`/`newest`.

They build the price value indexes rather than leaving them at their empty defaults, so `walk_value_orderby_page` is exercised instead of silently declining to the gather. Two of the four fail without the fix; the other two are invariants that must hold either way.

`cargo test -p card_engine`: 182 passed, 0 failed.

## Verified end to end

Against a live 31,724-card / 97,803-printing store, `t:creature order=usd dir=desc` now matches Scryfall's first page **printing for printing** through rank 12 (Juzám Djinn `arn` $1827, Guardian Beast `arn` $615, Zodiac Dragon `ptk` $544, Ali from Cairo `arn` $409.99, Sliver Queen `sth` $295.68, Phyrexian Dreadnought `mir` $279.96, …).