### PR TITLE
Import: Skip the Memorabilia Sets Scryfall Hides, and Add is:oversized

### DIFF
--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -125,6 +125,11 @@ BOOLEAN_IS_TAGS: dict[str, str] = {
     "league": "cards.raw_card_blob->'promo_types' @> '\"league\"'",
     "masterpiece": "cards.raw_card_blob->>'set_type' = 'masterpiece'",
     "media_insert": "cards.raw_card_blob->'promo_types' @> '\"mediainsert\"'",
+    # Low cardinality -- memorabilia and the oversized promo sets, ~2.7% of printings -- so it
+    # does not carry the foil/promo/reprint concern in the header above. It is also one of the
+    # filters that turns OFF default visibility (see _unhides_extras), which is only expressible
+    # at all once the tag exists.
+    "oversized": "cards.raw_card_blob->'oversized' = 'true'::jsonb",
     # "Partner with <name>" cards carry a plain "Partner" keyword alongside it (verified
     # against the corpus), so checking for "Partner" alone already covers both.
     "partner": "cards.raw_card_blob->'keywords' @> '\"Partner\"'",

--- a/api/card_processing.py
+++ b/api/card_processing.py
@@ -20,6 +20,11 @@ if TYPE_CHECKING:
 # for any card with no type in this set. Title-cased to match parse_type_line().
 PERMANENT_CARD_TYPES = {"Artifact", "Battle", "Creature", "Enchantment", "Land", "Planeswalker"}
 
+# Scryfall's set_type for the products that are collectible objects rather than tournament-legal
+# printings: World Championship decks, Collectors' Edition, 30th Anniversary, the oversized promo
+# sets -- 30a, ced, cei, ovnt, ptc, o90p, olep, wc97..wc04, 99 sets in all.
+MEMORABILIA_SET_TYPE = "memorabilia"
+
 
 def parse_type_line(type_line: str) -> tuple[list[str], list[str]]:
     """Parse the type line of a card."""
@@ -126,6 +131,26 @@ def preprocess_card(card: dict[str, Any]) -> list[dict[str, Any]]:  # noqa: PLR0
     if "paper" not in card.get("games", []):
         return []
     if card.get("set_type") == "funny":
+        return []
+    # Memorabilia, for the same reason one line up: a product that is a collectible object rather
+    # than a tournament-legal printing. Scryfall hides these from any search that does not name
+    # their set -- measured 2026-08-11, `!"Ancestral Recall"` returns 9 of its 18 printings and
+    # `!"Birds of Paradise"` 42 of 43 -- so importing them makes ordinary queries disagree with it.
+    # Concretely they supplied the CHEAPEST printing for 184 cards, which is exactly the printing a
+    # price ordering is defined to return.
+    #
+    # Dropped at import rather than filtered at query time, and that is the load-bearing decision.
+    # To be correct a query-time predicate has to sit in the filter TREE -- the representative walk
+    # picks among printings that pass the residual, so a flag outside it would let a hidden
+    # printing stand for its card -- and a conjunct present on every query breaks four of the six
+    # physical plans, which gate on the filter being literally `True` or on a range being bare:
+    # PlanePopcountOrder, CardRangePopcount, PrintingRangeScan, and `all_match_known`'s
+    # constant-count arms. Measured at +59..115us per query on a 112,932-printing store.
+    #
+    # What this gives up instead: `set:cei` and its 98 siblings return nothing, where Scryfall
+    # returns them. No CARD is lost -- measured, 0 of 31,724 cards are printed only in memorabilia
+    # sets -- so it changes which printing represents a card, never whether the card is findable.
+    if card.get("set_type") == MEMORABILIA_SET_TYPE:
         return []
 
     # Filter out unplayable cards: Cards and Tokens

--- a/api/tests/test_card_processing.py
+++ b/api/tests/test_card_processing.py
@@ -7,7 +7,7 @@ import pathlib
 import uuid
 from typing import Any
 
-from api.card_processing import extract_frame_data_from_raw_card, preprocess_card
+from api.card_processing import MEMORABILIA_SET_TYPE, extract_frame_data_from_raw_card, preprocess_card
 
 # Project root directory for accessing sample data
 _PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent
@@ -208,6 +208,27 @@ class TestCardProcessing:
 
         result = preprocess_card(invalid_card)
         assert result == []
+
+    def test_preprocess_card_filters_memorabilia_sets(self) -> None:
+        """Memorabilia printings are not imported.
+
+        Scryfall hides them from any search that does not name their set, so importing them makes
+        ordinary queries disagree with it. Measured 2026-08-11: `!"Ancestral Recall"` returns 9 of its 18 printings on Scryfall, and
+        the 9 it omits are exactly the memorabilia ones (30a, ced, cei, ovnt) plus a digital set.
+        """
+        # The LITERAL, not MEMORABILIA_SET_TYPE: driving both sides off the same constant makes the
+        # test self-referential, and it then passes with the constant set to anything at all.
+        assert preprocess_card(create_test_card(set_type="memorabilia")) == []
+        # Pinned separately, so the constant is still what names the Scryfall set_type.
+        assert MEMORABILIA_SET_TYPE == "memorabilia"
+
+    def test_preprocess_card_keeps_ordinary_sets(self) -> None:
+        """The exclusion is on set_type alone — a normal expansion is untouched.
+
+        Paired with the test above so a predicate that accidentally dropped everything (an `in`
+        against the wrong operand, say) fails here rather than looking like a working filter.
+        """
+        assert len(preprocess_card(create_test_card(set_type="expansion"))) == 1
 
     def test_preprocess_card_filters_card_type(self) -> None:
         """Test preprocess_card filters out cards with Card type."""


### PR DESCRIPTION
Based on `main`, independent of every open PR.

## What Scryfall does

`set_type: memorabilia` printings — World Championship decks, Collectors' Edition, 30th Anniversary, the oversized promos, **99 sets** — are hidden from any search that does not name their set. Measured against api.scryfall.com on 2026-08-11:

```
!"Ancestral Recall"      9 printings returned, 18 exist
!"Birds of Paradise"    42 printings returned, 43 exist

set:cei / e:cei / s:cei  the hidden printing, on its own
-set:lea                 all 17 others — every hidden set reappears
(set:cei or t:instant)   all 18
is:reserved              14  } together exactly 18, so BOTH polarities
-is:reserved              4  } run against the unhidden corpus
is:oversized             the oversized printings

border:black  year<=1994  r:rare  cn:48  number:48  in:cei  st:core
frame:1993  prints>1  lang:en  game:paper  is:promo  is:digital
is:foil  is:nonfoil  is:fullart  is:booster
                         no unhiding — only the 9 visible printings
```

Note `st:memorabilia` matches **nothing** on Scryfall rather than unhiding, so it is not a trigger.

## Why it matters here

Importing them makes ordinary queries disagree. Concretely, they supply the **cheapest printing for 184 cards** — exactly the printing a price ordering is defined to return. `order=usd` was ranking Birds of Paradise by a $4.98 World Championship copy where Scryfall ranks it by a $9.60 one, and Counterspell by a $1.29 `wc00` where Scryfall uses `brb` at $2.30.

## Why at import, not at query time

This is the load-bearing decision, and it was made on measurement — I built the query-time version first and threw it away.

To be **correct**, a query-time predicate has to live in the filter tree. The representative walk picks the `prefer` best among printings that pass the *residual*, so a flag outside the tree lets a hidden printing stand for its card; and `total` is derived five different ways across the plans, so a predicate the filter does not carry has to be reimplemented in each.

But a conjunct present on every query **breaks four of the six physical plans**:

| plan | gate it fails |
|---|---|
| `PlanePopcountOrder` | residual must be literally `FilterExpr::True` |
| `all_match_known` (both match kernels) | same |
| `CardRangePopcount` | range must be BARE |
| `PrintingRangeScan` | same |

None can be taught to look through it. The two range fastpaths emit straight from a value-index slice and report the slice **width** as their total, so looking through would emit hidden printings *and* miscount them in one step. Measured cost of the query-time version: **+59–115 µs per query** on a 112,932-printing store, with `PlanePopcountOrder` — the plan serving the default `unique=card` plane shape — lost on every query.

Import-time exclusion costs none of that, and makes the store smaller rather than larger.

## What it gives up

`set:cei` and its 98 siblings return nothing, where Scryfall returns them.

**No card is lost.** Measured over a 31,724-card corpus: **0** cards are printed *only* in memorabilia sets. So this changes which printing represents a card, never whether the card is findable. 2,672 of 97,803 printings (2.73%) stop being imported.

## `is:oversized`

Joins `BOOLEAN_IS_TAGS` alongside it — it is one of the filters that unhides on Scryfall, and it stays meaningful after this exclusion: of 726 oversized printings, only **253** are memorabilia. The rest are planechase, commander, archenemy, vanguard and promo, which this does not touch. `oversized` is a plain boolean on every bulk card object, same shape as `reserved` and `game_changer`, and its low cardinality means it does not carry the foil/promo/reprint memory concern the existing comment records.

## Tests

`test_preprocess_card_filters_memorabilia_sets` and `test_preprocess_card_keeps_ordinary_sets`, paired so a predicate that dropped *everything* fails rather than looking like a working filter.

The filter test pins the **literal** `set_type` rather than `MEMORABILIA_SET_TYPE`, with the constant asserted separately. Driving both sides off the same constant made it self-referential — it passed with the constant set to anything at all. Caught by flipping the constant and watching it stay green.

`pytest api/tests/test_card_processing.py api/tests/test_parsing_errors.py` → 63 passed. `ruff check api/` clean.