### PR TITLE
Engine+API: A Missing Sort Value Sorts Lowest, Not Last

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -850,7 +850,20 @@ class APIResource:
         )
         _select_cols = "".join(f"\n                    {col}," for col in _cte_columns)
         _result_cols = ",\n                    ".join(f"{RESULT_FIELD_COLUMNS[name]} AS {name}" for name in resolved_fields)
-        _order_by = f"""sort_value {sql_direction} NULLS LAST,
+        # A missing sort value sorts as the LOWEST value, so the direction moves it: FIRST
+        # ascending, LAST descending. Measured against api.scryfall.com on 2026-08-11 --
+        # `set:m10 order=power dir=asc` leads with the null-power cards and `dir=desc` trails with
+        # them, and `t:creature order=usd dir=asc` leads with the unpriced ones.
+        #
+        # The clause has to stay explicit and simply invert: Postgres' DEFAULT is the OPPOSITE of
+        # this (NULLS LAST for ASC, NULLS FIRST for DESC, i.e. nulls treated as the HIGHEST value),
+        # so dropping it would silently restore the behaviour this is fixing.
+        #
+        # The two tiebreaks below keep NULLS LAST unconditionally. `dir` does not apply to them --
+        # they are not the user's sort column, and card_engine's sort key encodes the same
+        # asymmetry (`sort_key_bits` negates only the primary).
+        _sort_value_nulls = "FIRST" if sql_direction == "ASC" else "LAST"
+        _order_by = f"""sort_value {sql_direction} NULLS {_sort_value_nulls},
                     edhrec_rank ASC NULLS LAST,
                     prefer_score DESC NULLS LAST"""
         _count_nulls = ",\n                    ".join(f"null AS {name}" for name in resolved_fields)

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -850,19 +850,41 @@ class APIResource:
         )
         _select_cols = "".join(f"\n                    {col}," for col in _cte_columns)
         _result_cols = ",\n                    ".join(f"{RESULT_FIELD_COLUMNS[name]} AS {name}" for name in resolved_fields)
-        # A missing sort value sorts as the LOWEST value, so the direction moves it: FIRST
-        # ascending, LAST descending. Measured against api.scryfall.com on 2026-08-11 --
-        # `set:m10 order=power dir=asc` leads with the null-power cards and `dir=desc` trails with
-        # them, and `t:creature order=usd dir=asc` leads with the unpriced ones.
+        # WHICH SIDE A MISSING SORT VALUE GOES depends on the COLUMN, and the two families
+        # disagree. Measured against api.scryfall.com, one page-1 request per (column, direction)
+        # over `e:khm unique=prints` on 2026-08-17, re-confirming the 2026-08-11 rows:
         #
-        # The clause has to stay explicit and simply invert: Postgres' DEFAULT is the OPPOSITE of
-        # this (NULLS LAST for ASC, NULLS FIRST for DESC, i.e. nulls treated as the HIGHEST value),
-        # so dropping it would silently restore the behaviour this is fixing.
+        #     power       asc null,null,null…    desc "8","8","8"…     absent LOWEST  (19 nulls)
+        #     toughness   asc null,null,null…    desc "8","8","8"…     absent LOWEST  (20 nulls)
+        #     usd         asc null,null,null…    desc null,"66.82"…    absent LOWEST  (foil note)
+        #     edhrec      asc 199,378,378…       desc null,null,null…  absent HIGHEST (33 nulls)
+        #
+        # A missing MAGNITUDE behaves like a value below every real one; a missing RANK -- "this
+        # card is not ranked" -- behaves like a position after every real one. Both directions move
+        # it either way, so this is a per-column table and not a per-direction constant.
+        #
+        # `edhrec` matters more than its one row suggests: it is the DEFAULT `order=`, so treating
+        # its nulls as lowest puts every unranked card at the head of an unordered search.
+        #
+        # THE `usd` DESC HEAD IS NOT A COUNTEREXAMPLE, and reading only the ascending page would
+        # have recorded it as one: `khm/407` leads `order=usd dir=desc` with a NULL `prices.usd`
+        # because its `usd_foil` is $106.04 and Scryfall's price key coalesces the foil. The rows
+        # that are genuinely price-less (the Arena `A-*` printings) lead ASCENDING, which is the
+        # reading this table records.
+        #
+        # The clause has to stay explicit either way: Postgres' default is NULLS LAST for ASC and
+        # NULLS FIRST for DESC, which happens to be the RANK rule -- so dropping it would leave
+        # `order=edhrec` right and every other column wrong.
         #
         # The two tiebreaks below keep NULLS LAST unconditionally. `dir` does not apply to them --
         # they are not the user's sort column, and card_engine's sort key encodes the same
-        # asymmetry (`sort_key_bits` negates only the primary).
-        _sort_value_nulls = "FIRST" if sql_direction == "ASC" else "LAST"
+        # asymmetry (`sort_key_bits` negates only the primary). The `edhrec_rank` tiebreak has
+        # always read `ASC NULLS LAST`, which is this table's EDHREC row written out by hand.
+        _absent_sorts_highest = orderby == CardOrdering.EDHREC
+        if _absent_sorts_highest:
+            _sort_value_nulls = "LAST" if sql_direction == "ASC" else "FIRST"
+        else:
+            _sort_value_nulls = "FIRST" if sql_direction == "ASC" else "LAST"
         _order_by = f"""sort_value {sql_direction} NULLS {_sort_value_nulls},
                     edhrec_rank ASC NULLS LAST,
                     prefer_score DESC NULLS LAST"""

--- a/api/tests/test_card_ordering.py
+++ b/api/tests/test_card_ordering.py
@@ -15,7 +15,11 @@ if TYPE_CHECKING:
     from api.api_resource import APIResource
 
 
-def _compiled_sql(stub_api_resource: APIResource, ordering: CardOrdering) -> str:
+def _compiled_sql(
+    stub_api_resource: APIResource,
+    ordering: CardOrdering,
+    direction: SortDirection = SortDirection.ASC,
+) -> str:
     """Return the compiled SQL string via the SQL path directly."""
     parsed_query = parse_scryfall_query("cmc=1")
     with (
@@ -34,7 +38,7 @@ def _compiled_sql(stub_api_resource: APIResource, ordering: CardOrdering) -> str
             unique=UniqueOn.CARD,
             prefer=PreferOrder.DEFAULT,
             orderby=ordering,
-            direction=SortDirection.ASC,
+            direction=direction,
             limit=100,
             timer=Timer(),
         )
@@ -57,3 +61,40 @@ def test_orderby_column_in_compiled_sql(stub_api_resource: APIResource, ordering
     """Every CardOrdering value should produce its mapped column in the compiled SQL."""
     needle = f", {expected_column} AS sort_value FROM magic.cards"
     assert needle in _compiled_sql(stub_api_resource, ordering)
+
+
+@pytest.mark.parametrize(
+    argnames=("ordering", "direction", "expected"),
+    argvalues=[
+        # A missing MAGNITUDE sorts below every value, so the direction moves it to the head
+        # ascending and the tail descending.
+        (CardOrdering.POWER, SortDirection.ASC, "sort_value ASC NULLS FIRST"),
+        (CardOrdering.POWER, SortDirection.DESC, "sort_value DESC NULLS LAST"),
+        (CardOrdering.TOUGHNESS, SortDirection.ASC, "sort_value ASC NULLS FIRST"),
+        (CardOrdering.USD, SortDirection.ASC, "sort_value ASC NULLS FIRST"),
+        (CardOrdering.USD, SortDirection.DESC, "sort_value DESC NULLS LAST"),
+        (CardOrdering.CMC, SortDirection.ASC, "sort_value ASC NULLS FIRST"),
+        # A missing RANK sorts AFTER every rank, which is the opposite end in both directions —
+        # and `edhrec` is the default `order=`, so this is what an unordered search gets.
+        (CardOrdering.EDHREC, SortDirection.ASC, "sort_value ASC NULLS LAST"),
+        (CardOrdering.EDHREC, SortDirection.DESC, "sort_value DESC NULLS FIRST"),
+    ],
+)
+def test_the_missing_value_side_is_per_column(
+    stub_api_resource: APIResource,
+    ordering: CardOrdering,
+    direction: SortDirection,
+    expected: str,
+) -> None:
+    """Scryfall puts a missing value on a side that depends on the COLUMN, not just the direction.
+
+    Measured on api.scryfall.com over `e:khm unique=prints`, one page-1 request per (column,
+    direction), 2026-08-17: `power`, `toughness` and `usd` all LEAD ascending with their nulls,
+    while `edhrec` holds none on an ascending page of 175 and LEADS descending with 33 of them.
+
+    Asserted on the compiled SQL rather than through the database because the clause is the whole
+    of the behaviour: Postgres' own default is NULLS LAST for ASC and NULLS FIRST for DESC, which
+    is the EDHREC row — so a regression that simply dropped the clause would leave one column
+    right and every other one wrong, and only a per-column assertion can tell those apart.
+    """
+    assert expected in _compiled_sql(stub_api_resource, ordering, direction)

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -7267,16 +7267,21 @@ fn compose_printing_estimate(
 /// A null-valued printing is ABSENT from the value index by construction, so the walk can only ever
 /// enumerate non-null rows. It handles the leftovers by declining — `seen < want && seen < total` —
 /// and that is a SUFFIX test: it detects "there are rows I could not place, and they sort after
-/// everything I did". With absent sorting LOWEST (see `perm_primary_key`), on ascending the rows it
-/// cannot place sort BEFORE everything it emits, so the test never fires: the walk fills the page
-/// from real values, exits via its `seen == want` break, and returns a confidently wrong page 0.
-/// Not a fallback — a silently wrong answer.
+/// everything I did". In the direction where this column's absent side sorts FIRST (see
+/// `absent_sorts_highest`), the rows it cannot place sort BEFORE everything it emits, so the test
+/// never fires: the walk fills the page from real values, exits via its `seen == want` break, and
+/// returns a confidently wrong page 0. Not a fallback — a silently wrong answer.
 ///
-/// So ascending is only offered when the index covers every printing, i.e. the column has no nulls
-/// anywhere in this store and "nulls first" is vacuous. `len()` is the indexed-printing count, so the
-/// comparison is exact and — this is the part that matters for the router — it is a STORE-level
-/// constant available identically to `compose_paging_with_total`'s prediction and to the fastpath
-/// itself, so the two cannot disagree about which branch will run.
+/// So that direction is only offered when the index covers every printing, i.e. the column has no
+/// nulls anywhere in this store and "nulls first" is vacuous. `len()` is the indexed-printing count,
+/// so the comparison is exact and — this is the part that matters for the router — it is a
+/// STORE-level constant available identically to `compose_paging_with_total`'s prediction and to the
+/// fastpath itself, so the two cannot disagree about which branch will run.
+///
+/// WHICH direction that is now comes from the column, not from a constant. Both walkable columns
+/// (`usd`, `rarity`) are absent-LOWEST, so it is still ascending that needs totality and nothing
+/// about the current behaviour moves; deriving it means a column that ever joins the HIGHEST arm
+/// cannot leave this gate pointing at the safe direction while the keys point at the other one.
 ///
 /// `card_rarity_int` is non-null across the production corpus, so `order=rarity` keeps its walk in
 /// both directions; only `order=usd dir=asc` falls to the gather, which is the direction where most
@@ -7292,7 +7297,10 @@ fn orderby_walk_available(sort_col: SortCol, descending: bool, indexes: &Archive
         _ => return false,
     };
     //  is one entry per printing, so its length IS the corpus printing count.
-    descending || idx.len() == indexes.printing_to_card.len()
+    // The safe direction is the one where the ABSENT rows land after everything the walk can emit,
+    // because the suffix test is the only thing that can see them.
+    let absent_sorts_last = absent_sorts_highest(sort_col) != descending;
+    absent_sorts_last || idx.len() == indexes.printing_to_card.len()
 }
 
 /// The routed path's time, split into DISJOINT phases that cover all of `run_query_routed`.

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2210,23 +2210,73 @@ fn bound_from_cmp(op: CmpOp, v: f64) -> SortBound {
     }
 }
 
+/// Which side a MISSING value sorts on, PER COLUMN — Scryfall does not answer this the same way
+/// for every `order=`, and a single global rule is wrong for one half of the table whichever way it
+/// is written.
+///
+/// # The measurements
+///
+/// One page-1 request per (column, direction) against api.scryfall.com over `e:khm unique=prints`
+/// (425 printings), reading the sorted field off the head and tail of the page, on 2026-08-17 —
+/// re-confirming the 2026-08-11 rows this rule was first written from:
+///
+/// ```text
+/// column      asc head            desc head             absent sorts
+/// power       null,null,null…     "8","8","8"…          LOWEST   (19 nulls, trailing desc)
+/// toughness   null,null,null…     "8","8","8"…          LOWEST   (20 nulls)
+/// usd         null,null,null…     null,"66.82"…         LOWEST   (see the foil note)
+/// edhrec      199,378,378…        null,null,null…       HIGHEST  (33 nulls, none on asc page 1)
+/// ```
+///
+/// So it splits on what the column MEANS: a magnitude (power, a price) that is missing behaves
+/// like a value below every real one, while a RANK that is missing — "this card is not ranked" —
+/// behaves like a position after every real one. Both directions genuinely reflect it; it is
+/// pinned to neither end.
+///
+/// `edhrec` carries more weight than its single row suggests: it is the DEFAULT `order=`, so
+/// treating its nulls as lowest puts every unranked card at the head of an unordered search.
+///
+/// THE `usd` DESC HEAD IS NOT A COUNTEREXAMPLE, and it is why this table is read off both
+/// directions rather than trusted from one. `khm/407` leads `order=usd dir=desc` with
+/// `prices.usd = null` — because its `usd_foil` is $106.04 and Scryfall's price key coalesces the
+/// foil price. The rows that are genuinely price-less (the Arena `A-*` printings, every price
+/// null) lead ASCENDING, which is the reading this table records.
+///
+/// # Unmeasured columns keep the old rule, deliberately
+///
+/// `cubecobra` has no `order=` on api.scryfall.com at all, and `cmc`, `rarity` and `name` had no
+/// null on the probed corpus. Every one of them stays LOWEST, which is what they already did; a
+/// column added to the HIGHEST arm without a measurement behind it is the failure this table
+/// exists to prevent.
+const fn absent_sorts_highest(sort_col: SortCol) -> bool {
+    match sort_col {
+        // The rank family, and the default `order=`.
+        SortCol::EdhrecRank => true,
+        SortCol::Cmc
+        | SortCol::Power
+        | SortCol::Toughness
+        | SortCol::Rarity
+        | SortCol::PriceUsd
+        | SortCol::Cubecobra
+        | SortCol::Name => false,
+    }
+}
+
 /// The permutation's PRIMARY key: the sort column's value, direction folded in by negation, absent
-/// sorting as the LOWEST value. One function because three places must agree on it exactly —
+/// sorting on the side `absent_sorts_highest` gives that column. One function because three places
+/// must agree on it exactly —
 /// `build_sort_permutations` orders by it, `sort_key_bits` builds every gathered plan's key from it,
 /// and `walk_bounds` binary-searches for it to find where a value interval starts and ends in that
 /// order. A divergence between those would not be a slow walk, it would be a walk that starts past
 /// real matches and silently returns the wrong page.
 ///
-/// # Absent sorts lowest, not last
+/// # The absent side is a property of the COLUMN
 ///
-/// Measured against api.scryfall.com on 2026-08-11: `set:m10 order=power dir=asc` leads with the
-/// null-power cards and `dir=desc` trails with them, and `t:creature order=usd dir=asc` leads with
-/// the unpriced Alchemy cards. So a missing value behaves like a value below every real one, and
-/// the direction genuinely moves it — it is not pinned to either end.
-///
-/// This is a change of SHAPE, not of constant. The old sentinel was `u32::MAX` on both directions,
-/// which put absent past every finite key either way precisely BECAUSE it did not participate in
-/// the direction reflection. Now it does.
+/// This is a change of SHAPE, not of constant. The original sentinel was `u32::MAX` on both
+/// directions, which put absent past every finite key either way precisely BECAUSE it did not
+/// participate in the direction reflection. Now it does — and WHICH end it reflects from comes
+/// from `absent_sorts_highest`, because a missing rank and a missing magnitude sit on opposite
+/// sides. The SENTINEL therefore moves with the column, and so does the clamp that reserves it.
 ///
 /// The clamp is belt-and-braces rather than decoration: `f32_sort_bits` maps only a negative NaN
 /// with an all-ones mantissa to `u32::MAX`, and the corpus minimum (`-f32::MAX`) to `0x0080_0000`,
@@ -2238,10 +2288,13 @@ fn bound_from_cmp(op: CmpOp, v: f64) -> SortBound {
 /// a null can never satisfy a comparison against its own column. That is the half of the old
 /// argument still doing the work — `walk_bounds` stays correct because a null-bearing card cannot
 /// match the bound, not because the null sits at a particular end.
-fn perm_primary_key(value: Option<f32>, descending: bool) -> u32 {
+fn perm_primary_key(value: Option<f32>, sort_col: SortCol, descending: bool) -> u32 {
+    // The sentinel end for this (column, direction): absent-highest ascending and absent-lowest
+    // descending both put absent at the TOP of the key space; the other two put it at the bottom.
+    let absent_at_top = absent_sorts_highest(sort_col) != descending;
     match value {
         None => {
-            if descending {
+            if absent_at_top {
                 u32::MAX
             } else {
                 0
@@ -2250,7 +2303,7 @@ fn perm_primary_key(value: Option<f32>, descending: bool) -> u32 {
         Some(v) => {
             let k = f32_sort_bits(if descending { -v } else { v });
             debug_assert!(k != 0 && k != u32::MAX, "a real value collided with the absent sentinel");
-            if descending { k.min(u32::MAX - 1) } else { k.max(1) }
+            if absent_at_top { k.min(u32::MAX - 1) } else { k.max(1) }
         }
     }
 }
@@ -2296,12 +2349,12 @@ fn walk_bounds<'p>(
     // that ordering cannot disagree.
     let key_at = |pos: usize| {
         let cid = u32::from(all[pos]) as usize;
-        perm_primary_key(sort_col_card_value(&cards[cid], sort_col), descending)
+        perm_primary_key(sort_col_card_value(&cards[cid], sort_col), sort_col, descending)
     };
     // Under `desc` the key is negated, so the interval's ends swap roles: the largest VALUE has the
     // smallest key and therefore comes first.
     let (first_v, last_v) = if descending { (bound.hi, bound.lo) } else { (bound.lo, bound.hi) };
-    let key_of = |v: f64| perm_primary_key(Some(v as f32), descending);
+    let key_of = |v: f64| perm_primary_key(Some(v as f32), sort_col, descending);
     // `partition_point` over positions: the first position whose key reaches the interval, and the
     // first position past it. Both sides are inclusive in value, so `start` excludes keys strictly
     // before the interval and `end` includes the whole tie block at its far edge.
@@ -2333,11 +2386,16 @@ fn partition_point(len: usize, pred: impl Fn(usize) -> bool) -> usize {
 fn build_sort_permutations(cards: &[OracleCard]) -> SortPermutations {
     // Purely card-space now: the printings/offsets arguments existed only to read the first stored
     // printing's prefer_score, which is no longer a sort key (see the closure below).
-    let perm = |get: &dyn Fn(&OracleCard) -> Option<f32>, descending: bool| -> Vec<u32> {
+    // `sort_col` is passed rather than inferred from `get`, because the absent side is a property
+    // of the COLUMN now (`absent_sorts_highest`) and this is the one place that BAKES that choice
+    // into the archive. A permutation built for the wrong column would put its nulls at the wrong
+    // end of a stored array, where the gathered plans' keys would still be right — the two halves
+    // disagreeing is what makes it a wrong page rather than a slow one.
+    let perm = |get: &dyn Fn(&OracleCard) -> Option<f32>, sort_col: SortCol, descending: bool| -> Vec<u32> {
         let mut ids: Vec<u32> = (0..cards.len() as u32).collect();
         ids.sort_unstable_by_key(|&i| {
             let c = &cards[i as usize];
-            let pk = perm_primary_key(get(c), descending);
+            let pk = perm_primary_key(get(c), sort_col, descending);
             let e = c.edhrec_rank.unwrap_or(u32::MAX);
             // Canonical secondary: the first (store-preferred) printing's
             // default prefer score, matching sort_key_bits' third component
@@ -2353,18 +2411,18 @@ fn build_sort_permutations(cards: &[OracleCard]) -> SortPermutations {
     // Inverse built per direction, not derived from one another — ties keep
     // fixed relative order in both directions (see the struct doc above), so
     // reversing one inverse would get tied groups' internal order backwards.
-    let both = |get: &dyn Fn(&OracleCard) -> Option<f32>| -> ([Vec<u32>; 2], [Vec<u32>; 2]) {
-        let asc = perm(get, false);
-        let desc = perm(get, true);
+    let both = |get: &dyn Fn(&OracleCard) -> Option<f32>, sort_col: SortCol| -> ([Vec<u32>; 2], [Vec<u32>; 2]) {
+        let asc = perm(get, sort_col, false);
+        let desc = perm(get, sort_col, true);
         let inv = [invert_perm(&asc), invert_perm(&desc)];
         ([asc, desc], inv)
     };
-    let (edhrec, edhrec_inv) = both(&|c| c.edhrec_rank.map(|v| v as f32));
-    let (cubecobra, cubecobra_inv) = both(&|c| c.cubecobra_score);
-    let (cmc, cmc_inv) = both(&|c| c.cmc.map(|v| v as f32));
-    let (power, power_inv) = both(&|c| c.creature_power.map(|v| v as f32));
-    let (toughness, toughness_inv) = both(&|c| c.creature_toughness.map(|v| v as f32));
-    let (name, name_inv) = both(&|c| Some(c.name_rank as f32));
+    let (edhrec, edhrec_inv) = both(&|c| c.edhrec_rank.map(|v| v as f32), SortCol::EdhrecRank);
+    let (cubecobra, cubecobra_inv) = both(&|c| c.cubecobra_score, SortCol::Cubecobra);
+    let (cmc, cmc_inv) = both(&|c| c.cmc.map(|v| v as f32), SortCol::Cmc);
+    let (power, power_inv) = both(&|c| c.creature_power.map(|v| v as f32), SortCol::Power);
+    let (toughness, toughness_inv) = both(&|c| c.creature_toughness.map(|v| v as f32), SortCol::Toughness);
+    let (name, name_inv) = both(&|c| Some(c.name_rank as f32), SortCol::Name);
     SortPermutations {
         edhrec, cubecobra, cmc, power, toughness, name,
         edhrec_inv, cubecobra_inv, cmc_inv, power_inv, toughness_inv, name_inv,
@@ -5309,6 +5367,9 @@ fn prefer_score(card: &AOracleCard, p: &APrinting, prefer: Prefer) -> f64 {
 }
 
 #[derive(Clone, Copy)]
+// `Debug` so a table-driven test can NAME the column it is asserting about — an "absent sorted on
+// the wrong side" failure that cannot say which column is a failure nobody can act on.
+#[derive(Debug)]
 enum SortCol { Cmc, Power, Toughness, Rarity, PriceUsd, Cubecobra, EdhrecRank, Name }
 
 fn orderby_to_col(orderby: &str) -> SortCol {
@@ -5355,7 +5416,7 @@ fn sort_key_bits(card: &AOracleCard, p: &APrinting, sort_col: SortCol, descendin
     // with. It was written out longhand here as a second copy of that one-liner; two copies of a
     // sentinel is exactly the kind of thing that drifts, and a drift between them is not a slow
     // walk but a walk that starts past real matches and silently returns the wrong page.
-    let pk = perm_primary_key(primary, descending);
+    let pk = perm_primary_key(primary, sort_col, descending);
     let e = card.edhrec_rank.as_ref().map(|v| u32::from(*v)).unwrap_or(u32::MAX);
     let sc = p.prefer_score.as_ref().map_or(u32::MAX, |v| f32_sort_bits(-f32::from(*v)));
     ((pk as u128) << 64) | ((e as u128) << 32) | (sc as u128)

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2211,16 +2211,48 @@ fn bound_from_cmp(op: CmpOp, v: f64) -> SortBound {
 }
 
 /// The permutation's PRIMARY key: the sort column's value, direction folded in by negation, absent
-/// sorting last. One function because two places must agree on it exactly — `build_sort_permutations`
-/// orders by it, and `walk_bounds` binary-searches for it to find where a value interval starts and
-/// ends in that order. A divergence between those two would not be a slow walk, it would be a walk
-/// that starts past real matches and silently returns the wrong page.
+/// sorting as the LOWEST value. One function because three places must agree on it exactly —
+/// `build_sort_permutations` orders by it, `sort_key_bits` builds every gathered plan's key from it,
+/// and `walk_bounds` binary-searches for it to find where a value interval starts and ends in that
+/// order. A divergence between those would not be a slow walk, it would be a walk that starts past
+/// real matches and silently returns the wrong page.
 ///
-/// `u32::MAX` for absent is what makes a numeric bound safe to search for: a card with no value in the
-/// column sorts past every finite key in BOTH directions, and `numeric_cmp_tri` answers `Tri::Null` for
-/// it, so it can never be a match of a comparison against that column either.
+/// # Absent sorts lowest, not last
+///
+/// Measured against api.scryfall.com on 2026-08-11: `set:m10 order=power dir=asc` leads with the
+/// null-power cards and `dir=desc` trails with them, and `t:creature order=usd dir=asc` leads with
+/// the unpriced Alchemy cards. So a missing value behaves like a value below every real one, and
+/// the direction genuinely moves it — it is not pinned to either end.
+///
+/// This is a change of SHAPE, not of constant. The old sentinel was `u32::MAX` on both directions,
+/// which put absent past every finite key either way precisely BECAUSE it did not participate in
+/// the direction reflection. Now it does.
+///
+/// The clamp is belt-and-braces rather than decoration: `f32_sort_bits` maps only a negative NaN
+/// with an all-ones mantissa to `u32::MAX`, and the corpus minimum (`-f32::MAX`) to `0x0080_0000`,
+/// so no real value can collide with either sentinel today. The clamp makes that a property of the
+/// function instead of a property of the data, and it is applied identically wherever the key is
+/// computed, so the binary search and the permutation cannot disagree at the boundary.
+///
+/// What this does NOT change: `numeric_cmp_tri` still answers `Tri::Null` for an absent operand, so
+/// a null can never satisfy a comparison against its own column. That is the half of the old
+/// argument still doing the work — `walk_bounds` stays correct because a null-bearing card cannot
+/// match the bound, not because the null sits at a particular end.
 fn perm_primary_key(value: Option<f32>, descending: bool) -> u32 {
-    value.map_or(u32::MAX, |v| f32_sort_bits(if descending { -v } else { v }))
+    match value {
+        None => {
+            if descending {
+                u32::MAX
+            } else {
+                0
+            }
+        }
+        Some(v) => {
+            let k = f32_sort_bits(if descending { -v } else { v });
+            debug_assert!(k != 0 && k != u32::MAX, "a real value collided with the absent sentinel");
+            if descending { k.min(u32::MAX - 1) } else { k.max(1) }
+        }
+    }
 }
 
 /// The sort column's value for one archived card, in the same units `build_sort_permutations` sorted
@@ -5319,7 +5351,11 @@ fn sort_key_bits(card: &AOracleCard, p: &APrinting, sort_col: SortCol, descendin
         SortCol::EdhrecRank => card.edhrec_rank.as_ref().map(|v| u32::from(*v) as f32),
         SortCol::Name       => Some(u32::from(card.name_rank) as f32),
     };
-    let pk = primary.map_or(u32::MAX, |v| f32_sort_bits(if descending { -v } else { v }));
+    // The SAME encoder `build_sort_permutations` orders by and `walk_bounds` binary-searches
+    // with. It was written out longhand here as a second copy of that one-liner; two copies of a
+    // sentinel is exactly the kind of thing that drifts, and a drift between them is not a slow
+    // walk but a walk that starts past real matches and silently returns the wrong page.
+    let pk = perm_primary_key(primary, descending);
     let e = card.edhrec_rank.as_ref().map(|v| u32::from(*v)).unwrap_or(u32::MAX);
     let sc = p.prefer_score.as_ref().map_or(u32::MAX, |v| f32_sort_bits(-f32::from(*v)));
     ((pk as u128) << 64) | ((e as u128) << 32) | (sc as u128)
@@ -7164,8 +7200,38 @@ fn compose_printing_estimate(
 /// The two used to differ in *structure* — a pair vec against planes/postings — and so had a walk
 /// each. They now share one layout and one walk (`walk_value_orderby_page`), which is what makes this
 /// predicate mean exactly "there is a value index to walk".
-fn orderby_walk_available(sort_col: SortCol) -> bool {
-    matches!(sort_col, SortCol::PriceUsd | SortCol::Rarity)
+///
+/// # Why ascending needs the index to be total
+///
+/// A null-valued printing is ABSENT from the value index by construction, so the walk can only ever
+/// enumerate non-null rows. It handles the leftovers by declining — `seen < want && seen < total` —
+/// and that is a SUFFIX test: it detects "there are rows I could not place, and they sort after
+/// everything I did". With absent sorting LOWEST (see `perm_primary_key`), on ascending the rows it
+/// cannot place sort BEFORE everything it emits, so the test never fires: the walk fills the page
+/// from real values, exits via its `seen == want` break, and returns a confidently wrong page 0.
+/// Not a fallback — a silently wrong answer.
+///
+/// So ascending is only offered when the index covers every printing, i.e. the column has no nulls
+/// anywhere in this store and "nulls first" is vacuous. `len()` is the indexed-printing count, so the
+/// comparison is exact and — this is the part that matters for the router — it is a STORE-level
+/// constant available identically to `compose_paging_with_total`'s prediction and to the fastpath
+/// itself, so the two cannot disagree about which branch will run.
+///
+/// `card_rarity_int` is non-null across the production corpus, so `order=rarity` keeps its walk in
+/// both directions; only `order=usd dir=asc` falls to the gather, which is the direction where most
+/// rows are null and the walk would have declined on most pages anyway.
+///
+/// Kept separate from `orderby_walk_beats_gather`, which answers a COST question. A cost heuristic
+/// that is wrong picks a slower plan; a correctness gate that is wrong returns wrong rows. They must
+/// not share a predicate.
+fn orderby_walk_available(sort_col: SortCol, descending: bool, indexes: &Archived<CardIndexes>) -> bool {
+    let idx = match sort_col {
+        SortCol::PriceUsd => &indexes.price_usd,
+        SortCol::Rarity => &indexes.rarity_printing_ordered,
+        _ => return false,
+    };
+    //  is one entry per printing, so its length IS the corpus printing count.
+    descending || idx.len() == indexes.printing_to_card.len()
 }
 
 /// The routed path's time, split into DISJOINT phases that cover all of `run_query_routed`.
@@ -7417,6 +7483,16 @@ fn walk_value_orderby_page<'a>(
 ) -> Option<(Vec<(&'a AOracleCard, &'a APrinting)>, ComposePageWork)> {
     let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
     let QueryParams { mode, prefer, descending, limit, page_offset, .. } = *params;
+    // The walk enumerates only index-resident rows and detects leftovers with a SUFFIX test, so on
+    // ascending it is correct only when the index covers every printing (see
+    // `orderby_walk_available`, which is the gate production routes through). Asserted here as well
+    // because the gate lives at the call site and a future caller reaching the walk directly would
+    // otherwise get silently wrong ascending pages rather than a decline.
+    debug_assert!(
+        descending || idx.len() == indexes.printing_to_card.len(),
+        "walk_value_orderby_page on an ascending page over a column with nulls returns a wrong \
+         page, not a decline — route through orderby_walk_available",
+    );
     let printing_to_card = &indexes.printing_to_card;
     let want = page_offset + limit;
     let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
@@ -7794,7 +7870,7 @@ fn printing_compose_fastpath<'a>(
     // compose that produces it. This one is PERMISSIVE: skip the gather's gates whenever a walk might
     // run at all, since their premise ("broad => not worth composing") is backwards for the walk. The
     // real choice is `walk_col` below, and the gather's gates are honoured again if it says gather.
-    let walk_possible = perm.is_none() && orderby_walk_available(sort_col);
+    let walk_possible = perm.is_none() && orderby_walk_available(sort_col, descending, indexes);
     if !walk_possible && let Some(reason) = gather_declines {
         note_paging_taken(reason);
         return None;
@@ -9796,7 +9872,7 @@ fn compose_paging_with_total(
             return ComposePaging::Decline;
         }
         ComposePaging::Perm
-    } else if orderby_walk_available(sort_col)
+    } else if orderby_walk_available(sort_col, descending, indexes)
         && result_total.is_some_and(|t| orderby_walk_beats_gather(mode, filter, t))
     {
         // The same `orderby_walk_beats_gather` the fastpath applies, on this side's ESTIMATE of the

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -5,7 +5,7 @@ use super::{
     assign_artwork_groups, build_artwork_base_from, build_bit_planes, build_border_printing_planes, build_rarity_printing_planes, build_divergent_ids, build_name_bigram_index, build_name_unigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_printing_value_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
-    perm_primary_key, range_too_broad_to_narrow, run_query, run_query_routed, run_query_with_plan, explain, explain_analyze, AcquireFacts, PlanEstimate, PlanTrial,
+    absent_sorts_highest, perm_primary_key, range_too_broad_to_narrow, run_query, run_query_routed, run_query_with_plan, explain, explain_analyze, AcquireFacts, PlanEstimate, PlanTrial,
     acquire_plan_features, take_phase_stats, PagingTaken, CountSource, NarrowedRepr,
     EXACT_VALUE_TOTALS, RangeCardCounts, narrow_rec, ValueTotals, PairTotals, build_all_value_totals, build_pair_totals, build_range_card_counts, exact_result_total,
     PhysicalPlan, PlanScope, CandidatePlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingValueIndex, NARROW_FLOOR,
@@ -7269,7 +7269,7 @@ fn artwork_group_ids_handle_more_than_64_groups() {
 /// expectation is deliberately unchanged: that is the evidence only the ascending side moved, and
 /// therefore that only the ascending permutations need rebuilding.
 #[test]
-fn sort_permutations_put_nulls_lowest_in_both_directions() {
+fn sort_permutations_put_a_missing_magnitude_lowest() {
     let mut vocab = VocabInterner::new();
     let mut cards = vec![
         stub_card(1, TYPE_CREATURE, &[], &mut vocab),
@@ -7282,22 +7282,69 @@ fn sort_permutations_put_nulls_lowest_in_both_directions() {
     let data = store_of(cards, &[1, 1, 1], vocab);
     let perms = build_sort_permutations(&data.cards);
     assert_eq!(perms.cmc[0], vec![1, 2, 0], "asc: null, 1, 5");
-    assert_eq!(perms.cmc[1], vec![0, 2, 1], "desc: 5, 1, null — unchanged");
+    assert_eq!(perms.cmc[1], vec![0, 2, 1], "desc: 5, 1, null");
 }
 
-/// The definition, pinned directly on the key function rather than through a permutation: for every
-/// nullable column, absent sorts below every real value ascending and above it descending.
+/// And a missing RANK goes where the highest value goes — LAST ascending, FIRST descending, the
+/// exact opposite end, in the same stored array shape.
+///
+/// Measured on api.scryfall.com over `e:khm order=edhrec unique=prints` (425 printings, 33 of them
+/// unranked): ascending page 1 runs 199, 378, 378 … 8068 with not one null in its 175 rows, and
+/// `dir=desc` page 1 LEADS with 33 nulls before 13065, 13021, 13021 …
+///
+/// `edhrec` is the DEFAULT `order=`, so this is the ordering an unordered search gets.
 #[test]
-fn a_missing_primary_sorts_lowest_in_both_directions() {
-    for descending in [false, true] {
-        let absent = perm_primary_key(None, descending);
-        for v in [-1000.0f32, -1.5, 0.0, 1.0, 42.0, 514_202.0, f32::MAX] {
-            let present = perm_primary_key(Some(v), descending);
-            assert_ne!(present, absent, "a real value collided with the sentinel (v={v}, desc={descending})");
-            if descending {
-                assert!(present < absent, "desc: {v} should sort before absent");
-            } else {
-                assert!(present > absent, "asc: {v} should sort after absent");
+fn sort_permutations_put_a_missing_rank_highest() {
+    let mut vocab = VocabInterner::new();
+    let mut cards = vec![
+        stub_card(1, TYPE_CREATURE, &[], &mut vocab),
+        stub_card(2, TYPE_CREATURE, &[], &mut vocab),
+        stub_card(3, TYPE_CREATURE, &[], &mut vocab),
+    ];
+    cards[0].edhrec_rank = Some(500);
+    cards[1].edhrec_rank = None;
+    cards[2].edhrec_rank = Some(12);
+    let data = store_of(cards, &[1, 1, 1], vocab);
+    let perms = build_sort_permutations(&data.cards);
+    assert_eq!(perms.edhrec[0], vec![2, 0, 1], "asc: 12, 500, unranked LAST");
+    assert_eq!(perms.edhrec[1], vec![1, 0, 2], "desc: unranked FIRST, 500, 12");
+    // The inverses are built per direction rather than derived, so they have to move with it.
+    assert_eq!(perms.edhrec_inv[0], vec![1, 2, 0], "asc inverse: card 1 is unranked, so position 2");
+    assert_eq!(perms.edhrec_inv[1], vec![1, 0, 2], "desc inverse: card 1 is unranked, so position 0");
+}
+
+/// The definition, pinned directly on the key function rather than through a permutation, for every
+/// column: absent sits on the side `absent_sorts_highest` names, and the direction reflects it.
+///
+/// Table-driven off the enum so a column ADDED to `SortCol` cannot silently inherit an
+/// unconsidered answer — the match in `absent_sorts_highest` has no wildcard arm.
+#[test]
+fn a_missing_primary_sorts_on_its_column_side() {
+    let columns = [
+        (SortCol::Cmc, false),
+        (SortCol::Power, false),
+        (SortCol::Toughness, false),
+        (SortCol::Rarity, false),
+        (SortCol::PriceUsd, false),
+        (SortCol::Cubecobra, false),
+        (SortCol::Name, false),
+        (SortCol::EdhrecRank, true),
+    ];
+    for (sort_col, highest) in columns {
+        assert_eq!(absent_sorts_highest(sort_col), highest, "the measured table moved for {sort_col:?}");
+        for descending in [false, true] {
+            let absent = perm_primary_key(None, sort_col, descending);
+            for v in [-1000.0f32, -1.5, 0.0, 1.0, 42.0, 514_202.0, f32::MAX] {
+                let present = perm_primary_key(Some(v), sort_col, descending);
+                assert_ne!(present, absent, "a real value collided with the sentinel ({sort_col:?} v={v} desc={descending})");
+                // Absent is "above every value" for the HIGHEST arm, and the direction negates the
+                // comparison exactly as it negates the value.
+                let absent_first = highest == descending;
+                if absent_first {
+                    assert!(present > absent, "{sort_col:?} desc={descending}: {v} should sort after absent");
+                } else {
+                    assert!(present < absent, "{sort_col:?} desc={descending}: {v} should sort before absent");
+                }
             }
         }
     }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -5,7 +5,7 @@ use super::{
     assign_artwork_groups, build_artwork_base_from, build_bit_planes, build_border_printing_planes, build_rarity_printing_planes, build_divergent_ids, build_name_bigram_index, build_name_unigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_printing_value_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
-    range_too_broad_to_narrow, run_query, run_query_routed, run_query_with_plan, explain, explain_analyze, AcquireFacts, PlanEstimate, PlanTrial,
+    perm_primary_key, range_too_broad_to_narrow, run_query, run_query_routed, run_query_with_plan, explain, explain_analyze, AcquireFacts, PlanEstimate, PlanTrial,
     acquire_plan_features, take_phase_stats, PagingTaken, CountSource, NarrowedRepr,
     EXACT_VALUE_TOTALS, RangeCardCounts, narrow_rec, ValueTotals, PairTotals, build_all_value_totals, build_pair_totals, build_range_card_counts, exact_result_total,
     PhysicalPlan, PlanScope, CandidatePlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingValueIndex, NARROW_FLOOR,
@@ -7260,10 +7260,16 @@ fn artwork_group_ids_handle_more_than_64_groups() {
     assert!(chosen.contains(&2) && !chosen.contains(&1));
 }
 
-// Permutations put missing sort values last in both directions and reverse
-// only the non-null primary order, matching sort_key_bits semantics.
+/// Permutations put a missing sort value where the LOWEST value goes — first ascending, last
+/// descending — matching `perm_primary_key`/`sort_key_bits` and what Scryfall does (measured
+/// 2026-08-11: `set:m10 order=power dir=asc` leads with the null-power cards, `dir=desc` trails
+/// with them).
+///
+/// Same three-card fixture as when this asserted nulls-LAST in both directions. The descending
+/// expectation is deliberately unchanged: that is the evidence only the ascending side moved, and
+/// therefore that only the ascending permutations need rebuilding.
 #[test]
-fn sort_permutations_nulls_last_both_directions() {
+fn sort_permutations_put_nulls_lowest_in_both_directions() {
     let mut vocab = VocabInterner::new();
     let mut cards = vec![
         stub_card(1, TYPE_CREATURE, &[], &mut vocab),
@@ -7275,8 +7281,26 @@ fn sort_permutations_nulls_last_both_directions() {
     cards[2].cmc = Some(1);
     let data = store_of(cards, &[1, 1, 1], vocab);
     let perms = build_sort_permutations(&data.cards);
-    assert_eq!(perms.cmc[0], vec![2, 0, 1], "asc: 1, 5, null");
-    assert_eq!(perms.cmc[1], vec![0, 2, 1], "desc: 5, 1, null");
+    assert_eq!(perms.cmc[0], vec![1, 2, 0], "asc: null, 1, 5");
+    assert_eq!(perms.cmc[1], vec![0, 2, 1], "desc: 5, 1, null — unchanged");
+}
+
+/// The definition, pinned directly on the key function rather than through a permutation: for every
+/// nullable column, absent sorts below every real value ascending and above it descending.
+#[test]
+fn a_missing_primary_sorts_lowest_in_both_directions() {
+    for descending in [false, true] {
+        let absent = perm_primary_key(None, descending);
+        for v in [-1000.0f32, -1.5, 0.0, 1.0, 42.0, 514_202.0, f32::MAX] {
+            let present = perm_primary_key(Some(v), descending);
+            assert_ne!(present, absent, "a real value collided with the sentinel (v={v}, desc={descending})");
+            if descending {
+                assert!(present < absent, "desc: {v} should sort before absent");
+            } else {
+                assert!(present > absent, "asc: {v} should sort after absent");
+            }
+        }
+    }
 }
 
 #[test]
@@ -8164,6 +8188,14 @@ fn orderby_walk_matches_gather_composed() {
                             let (gather, _) = super::gather_composed_page(
                                 &QueryCtx::from(archived), &params, &pbits, card_bits.as_deref(),
                             );
+                            // Ascending is only offered when the column has no nulls at all —
+                            // the walk cannot place a null block that sorts BEFORE what it emits,
+                            // and its decline test only detects a null SUFFIX. Production routes
+                            // through `orderby_walk_available`; mirror that here rather than
+                            // calling the walk into a state it documents as wrong.
+                            if !super::orderby_walk_available(sort_col, descending, &archived.indexes) {
+                                continue;
+                            }
                             let walk = super::walk_value_orderby_page(&QueryCtx::from(archived), &params, idx, &pbits, total);
                             if let Some((walk, _)) = walk {
                                 walked += 1;

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -7350,6 +7350,39 @@ fn a_missing_primary_sorts_on_its_column_side() {
     }
 }
 
+/// The same rule through the QUERY path rather than the stored array: `order=edhrec` must page an
+/// unranked card last ascending and first descending, whichever plan the router picks.
+///
+/// This is the shape of the api.scryfall.com anchor — `e:khm order=edhrec dir=desc` page 1 leads
+/// with 33 unranked printings — reduced to a fixture the engine suite can run offline. `run_query`
+/// rather than `build_sort_permutations` is the point: it is the half a reader would expect to
+/// follow from the permutation and does not have to, because a gathered plan builds its own key.
+#[test]
+fn order_edhrec_pages_an_unranked_card_last_ascending_and_first_descending() {
+    let mut vocab = VocabInterner::new();
+    let mut cards = vec![
+        stub_card(1, TYPE_CREATURE, &[], &mut vocab),
+        stub_card(2, TYPE_CREATURE, &[], &mut vocab),
+        stub_card(3, TYPE_CREATURE, &[], &mut vocab),
+    ];
+    cards[0].edhrec_rank = Some(13065);
+    cards[1].edhrec_rank = None;
+    cards[2].edhrec_rank = Some(199);
+    let data = store_of(cards, &[1, 1, 1], vocab);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    // scryfall_id is the printing index + 1 (store_of), so the unranked card is printing 1 -> id 2.
+    let ids = |direction: &str| -> Vec<u128> {
+        let mut filter = FilterExpr::True;
+        let (_total, page) =
+            run_query(&QueryCtx::from(archived), &mut filter, None, "card", "default", "edhrec", direction, 100, 0);
+        page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect()
+    };
+    assert_eq!(ids("asc"), vec![3, 1, 2], "asc: 199, 13065, then the unranked card");
+    assert_eq!(ids("desc"), vec![2, 1, 3], "desc: the unranked card, then 13065, 199");
+}
+
 #[test]
 fn set_code_and_date_narrowing() {
     let mut vocab = VocabInterner::new();


### PR DESCRIPTION
Based on `main`, independent of every open PR. **Requires a store rebuild** — see the last section.

## The behaviour

`order=` puts a missing value LAST in both directions. Scryfall treats it as a value *below* every real one, so the direction moves it. Measured against api.scryfall.com on 2026-08-11:

```
set:m10 order=power  dir=asc    leads with the null-power cards
set:m10 order=power  dir=desc   trails with them
set:m10 order=toughness         same, both directions
t:creature order=usd dir=asc    leads with the unpriced Alchemy cards
t:creature order=usd dir=desc   trails with them
```

Unpriced cards are not *dropped* from a price sort on either side — `total_cards` is 18,753 for `order=name`, `order=usd dir=asc` and `order=usd dir=desc` alike. They just move end to end.

## Three changes, smallest first

**1. One sentinel, not two.** `sort_key_bits` carried a second copy of the key encoder written out longhand, next to `perm_primary_key`'s. It now calls it. Pure refactor, no behaviour change (157 green on that commit alone) — and it is what turns the actual fix into a one-function change rather than a three-place change that can drift. The three places are `build_sort_permutations` (orders by it), `sort_key_bits` (every gathered plan's key) and `walk_bounds` (binary-searches for it); a divergence between them is not a slow walk, it is a walk that starts past real matches and silently returns the wrong page.

**2. The flip.** Absent maps to `0` ascending, `u32::MAX` descending. This is a change of *shape*, not of constant: the old sentinel sat past every finite key in both directions precisely **because** it did not take part in the direction reflection. Now it does. Present values are clamped off both sentinels so the separation is a property of the function rather than of the data, with a `debug_assert!` that no real value ever reaches the clamp.

**3. The one that would have been a silent bug.** `walk_value_orderby_page` enumerates only index-resident rows — nulls are absent from a `PrintingValueIndex` by construction — and detects leftovers with `seen < want && seen < total`. That is a **suffix** test: it means "there are rows I could not place, and they sort after everything I did". With nulls sorting lowest, on ascending the unplaceable rows sort *before* everything it emits, so the test never fires. The walk fills the page from real values, exits through its `seen == want` break, and returns a confidently wrong page 0 — not a fallback.

`orderby_walk_available` therefore takes the direction and the index, and offers ascending only when the index covers every printing (the column has no nulls, so nulls-first is vacuous):

```rust
descending || idx.len() == indexes.printing_to_card.len()
```

`card_rarity_int` is non-null corpus-wide, so **`order=rarity` keeps its walk in both directions**; only `order=usd dir=asc` falls to the gather — the direction where most rows are null and it would have declined on most pages regardless. The gate is a store-level constant available identically to `compose_paging_with_total`'s prediction and to the fastpath itself, so the two cannot disagree about which branch runs.

Kept deliberately separate from `orderby_walk_beats_gather`, which answers a **cost** question. A wrong cost heuristic picks a slower plan; a wrong correctness gate returns wrong rows. They should not share a predicate.

The walk asserts the invariant itself too, because the gate lives at the call site. That is not hypothetical — `orderby_walk_matches_gather_composed` calls the walk directly, and is what caught this.

## Deliberately unchanged

The two tiebreak keys, `edhrec_rank ASC` and `prefer_score DESC`, keep nulls last unconditionally. `dir` does not apply to them; `edhrec_rank` is baked into **both** directions of every permutation, so moving it would dirty twice as many stored arrays for no parity gain; and `page_cmp` drops the prefer key before comparing across cards anyway.

## SQL

`api_resource.py` mirrors it: `sort_value {dir} NULLS FIRST|LAST`. The clause has to stay explicit and simply invert — Postgres' default is the **opposite** of this (`NULLS LAST` for `ASC`, i.e. nulls as the highest value), so deleting it would silently restore what this fixes.

## Rebuild required

`build_sort_permutations` runs on the commit path and its output is archived, so the **ascending** permutations of the five nullable permuted columns (`cmc`, `power`, `toughness`, `cubecobra`, `edhrec`) plus their inverses — 10 stored arrays — change bytes. Verified by reading the call site, not assumed. `name` is unaffected, which is the evidence that only the ascending side moved. No struct size changes, so `ARCHIVE_FORMAT_VERSION` is what has to force it.

## Tests

`sort_permutations_nulls_last_both_directions` is **rewritten, not deleted** — same fixture, and its *descending* expectation deliberately unchanged, so the diff itself shows only the ascending side moved. Joined by `a_missing_primary_sorts_lowest_in_both_directions`, which pins the definition on the key function directly across every nullable column and both directions, and asserts no real value collides with either sentinel.

`cargo test` → 158 passed. `pytest api/tests` → 576 passed. `ruff check api/` clean.

---

## Added: the side belongs to the COLUMN, not the direction

The rule above was measured on `order=power` and `order=usd`. Re-measuring the rest of the
vocabulary shows it is right for those and **backwards for `order=edhrec`**, which is the default
`order=`. One page-1 request per (column, direction) over `e:khm unique=prints` (425 printings),
2026-08-17:

| column | asc head | desc head | absent sorts |
|---|---|---|---|
| `power` | null, null, null… | "8", "8", "8"… | **LOWEST** (19 nulls) |
| `toughness` | null, null, null… | "8", "8", "8"… | **LOWEST** (20 nulls) |
| `usd` | null, null, null… | null, "66.82"… | **LOWEST** (see below) |
| `edhrec` | 199, 378, 378… | null, null, null… | **HIGHEST** (33 nulls) |

What separates the two families is what the column *means*: a missing **magnitude** is a value
below every real one; a missing **rank** — "this card is not ranked" — is a position after every
real one. Both directions reflect it either way, so this is a per-column table
(`absent_sorts_highest`) with `SortCol` threaded through the four places that must agree on the
key, not a per-direction constant.

`edhrec` is worth more than its single row: it is the **default** `order=`, so treating its nulls
as lowest puts every unranked card at the head of an unordered search. And the
`edhrec_rank ASC NULLS LAST` tiebreak two lines below the changed clause has always said so —
that line *is* this table's edhrec row, written by hand for the tiebreak and contradicted by the
primary until now.

**The `usd` desc head is not a counterexample**, and reading only the ascending page would have
recorded it as one: `khm/407` leads `order=usd dir=desc` with a NULL `prices.usd` because its
`usd_foil` is $106.04 and Scryfall's price key coalesces the foil. The genuinely price-less rows
(the Arena `A-*` printings) lead **ascending**, which is the reading the table records. Worth
knowing separately: `order=usd` sorts on a coalesced price there and on `price_usd` alone here.

**The SQL clause must stay explicit for a new reason.** Postgres' default is `NULLS LAST` for
`ASC` / `NULLS FIRST` for `DESC` — which is exactly the *rank* rule. Deleting the clause would now
leave `order=edhrec` correct and every other column wrong, which is much harder to spot than the
uniform breakage it would have caused before.

Unmeasured columns keep the old side deliberately: `cubecobra` has no `order=` on
api.scryfall.com at all, and `cmc`, `rarity` and `name` had no null on the probed corpus.

**Tests.** The key-function test is now table-driven over every `SortCol` with no wildcard arm, so
a column added to the enum cannot inherit an unconsidered answer; the permutation test gains its
rank twin (opposite end, including the per-direction inverses); and the SQL half gains the
assertion it never had, on the compiled `ORDER BY` for six (column, direction) pairs. Each was
watched to fail — flipping the table's edhrec row reddens two Rust tests and two SQL ones.

`cargo test` → 159 passed. `pytest api/tests` → 616 passed. `ruff check api/` clean.


---

## Added: the walk's correctness gate still named a direction

`absent_sorts_highest` made the absent side a property of the **column**, and `orderby_walk_available`
was the last reader of that rule still reasoning about it in prose: its gate read
`descending || idx.len() == …` and its doc said "with absent sorting LOWEST" — true of every column
when it was written, and now true of every column except the one this PR moves.

Nothing about today's behaviour changes, and that is checkable rather than hoped for. The two
walkable columns are `usd` and `rarity`, both on the LOWEST arm, so
`absent_sorts_highest(col) != descending` **is** `descending` for both and the gate admits exactly
the pairs it did before.

What it buys is that the gate cannot be left behind. The walk enumerates only index-resident rows
and detects leftovers with a **suffix** test, so it is safe exactly in the direction where the
absent rows sort last — and which direction that is now comes from the column. A column joining the
HIGHEST arm would otherwise leave this predicate pointing at the safe direction while
`perm_primary_key` points at the other one: not a slow page, a silently wrong one.

**And the rule gains an assertion through the query path**, not only through the stored array.
`sort_permutations_put_a_missing_rank_highest` pins `build_sort_permutations`' output;
`order_edhrec_pages_an_unranked_card_last_ascending_and_first_descending` asks `run_query` the same
question, because a gathered plan builds its own key from `sort_key_bits` and never reads the
permutation. It is the fixture shape of the api.scryfall.com anchor — `e:khm order=edhrec dir=desc`
page 1 leads with 33 unranked printings — and flipping the table's `edhrec` row turns it red
(watched).

`cargo test` → 160 passed.
