### PR TITLE
prefer_score: Extended Art Is a Variant, Not the Canonical Printing

### DIFF
--- a/api/sql/backfill_prefer_scores.sql
+++ b/api/sql/backfill_prefer_scores.sql
@@ -81,9 +81,47 @@ computed_components AS MATERIALIZED (
                     ELSE 0
                 END
             ),
+            -- Extended art is a VARIANT of a printing, not the printing most people picture, so it
+            -- is scored below the base version rather than above it. This weight used to be +12,
+            -- which is the single largest disagreement between this score and Scryfall's own
+            -- choice of representative printing.
+            --
+            -- Evidence, and the method is new here so it is worth stating: Scryfall's `oracle_cards`
+            -- bulk file contains exactly one card object per oracle_id, and that object IS its
+            -- chosen representative. That is 31,724 labelled preferences for this corpus, free and
+            -- external, against the 1,070 that ten human grading sessions produced for #720 — and
+            -- it is directly the "score every candidate against every preference" shape #771 asks
+            -- for, since a stored preference is reusable across candidates.
+            --
+            -- Measured on a 31,724-card corpus, agreement with Scryfall's representative:
+            --
+            --     extended_art = +12 (before)   66.2%
+            --     extended_art =   0            70.4%
+            --     extended_art =  -3            73.7%
+            --     extended_art =  -6            73.9%   <- the knee; -9 and -12 buy nothing further
+            --
+            -- Held out: the corpus was split 70/30 on a hash of oracle_id and the 30% was never
+            -- fitted against (a #771 guard). It tracks the fit set within 0.2 points at every value
+            -- above, so this is not overfitting: 66.4% -> 74.0% on data the weight never saw.
+            --
+            -- Mechanism, isolated rather than inferred: of the 3,079 disagreements where both
+            -- printings come from the SAME set, Scryfall picks the LOWER collector number 91.9% of
+            -- the time, and 2,800 of those differ by exactly this flag — ours carries `Extendedart`
+            -- and theirs does not. Extended-art variants sit at high collector numbers, so +12 was
+            -- systematically lifting the variant over the base printing.
+            --
+            -- -6 rather than -12: the curve is flat past the knee, so this is the smallest value
+            -- that captures the whole gain.
+            --
+            -- Caveat worth stating plainly: this optimises agreement with SCRYFALL's notion of a
+            -- representative printing, which is a proxy for "the version people picture" and not
+            -- the same objective as a blind aesthetic review. It is proposed on the strength of
+            -- this being one of the few weights in this table with no recorded evidence at all —
+            -- `illustration_count` and `art_style` both cite #720's review counts; this one cited
+            -- nothing. A blind batch on the cards it moves would settle the sign for good.
             'extended_art', (
                 CASE
-                    WHEN card_frame_data ? 'Extendedart' THEN 12
+                    WHEN card_frame_data ? 'Extendedart' THEN -6
                     ELSE 0
                 END
             ),


### PR DESCRIPTION
Based on `main`, independent of every open PR. One weight changes; the method behind it is the part worth reviewing, and it is aimed squarely at #771.

## A free 31,724-preference corpus

Scryfall's `oracle_cards` bulk file contains **exactly one card object per oracle_id**, and that object *is* Scryfall's chosen representative printing. That makes it 31,724 labelled preferences — external, free, and refreshed daily — against the **1,070** that ten human grading sessions produced for #720.

It is also the shape #771 argues for: the label is `printing X represents card C`, a *preference* rather than a verdict on a proposal, so every future candidate can be scored against all of it in milliseconds instead of another grading session.

## What it says about `extended_art`

Agreement with Scryfall's representative, whole corpus:

| `extended_art` | agreement |
|---:|---|
| **+12** (today) | 66.2% |
| 0 | 70.4% |
| −3 | 73.7% |
| **−6** | **73.9%** ← the knee |
| −9, −12 | 73.9% — flat, so −6 is the smallest sufficient value |

**Held out.** Split 70/30 on a hash of `oracle_id`, the 30% never fitted against (a #771 guard). It tracks the fit set within **0.2 points** at every value: 66.4% → 74.0% on data the weight never saw.

## The mechanism, isolated

#771 records that three wrong conclusions in #720 came from discovering afterwards that a batch confounded two properties — 63 of 69 "foil vs nonfoil" pairs also changed frame. So this one is isolated before proposing it:

Of the **3,079** disagreements where *both* printings come from the **same set**, Scryfall picks the **lower collector number 91.9%** of the time — and **2,800 of those differ by exactly this flag**: ours carries `Extendedart`, theirs does not. Extended-art variants sit at high collector numbers, so `+12` was systematically lifting the variant over the base printing. No other component moves with it.

For scale, that is ~26% of all 10,708 disagreements traceable to one weight.

## The caveat, stated plainly

Agreement with Scryfall is a **proxy** for "the version people picture", not the same objective as a blind aesthetic review — someone could reasonably prefer extended art on looks, and this corpus cannot argue with that.

What makes it worth proposing anyway: **`extended_art` is one of the few weights in this table with no recorded evidence at all.** `illustration_count` and `art_style` each carry a full evidence block citing #720's review counts. This one cited nothing, and it turns out to be the largest single source of disagreement with the most obvious external reference available.

If you would rather settle the sign your own way, this corpus can *pick the batch*: the 2,800 cards it moves are exactly the informative pairs #771 describes, already isolated to one varying property.

## Scope

`api/sql/backfill_prefer_scores.sql` only — recomputed by the existing backfill on the next import, no schema change, no reimport of card data. `pytest api/tests` → 576 passed.

Remaining after this: ~26% of cards still disagree, dominated by "different set entirely" (5,346 cards), where Scryfall's pick is on median ~4 months newer than ours. That wants a set-level recency or recognisability term, which is a new component rather than a reweighting — worth its own evidence, and out of scope here.