### PR TITLE
prefer_score: Pin the Representative Scryfall Itself Names

### DIFF
--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -50,6 +50,7 @@ from api.scryfall_bulk_data_fetcher import BulkDataKey, ScryfallBulkDataFetcher
 from api.settings import settings
 from api.tag_import import import_art_tags as _import_art_tags
 from api.tag_import import import_oracle_tags as _import_oracle_tags
+from api.tag_import import import_scryfall_representatives as _import_scryfall_representatives
 from api.utils import db_utils, multiprocessing_utils
 from api.utils.caching import cached
 from api.utils.http_utils import make_user_agent
@@ -333,6 +334,10 @@ class AdminResource:
             # first boot, and nothing rescored until the next import. Oracle tags feed search
             # rather than scoring, so their position relative to the backfill does not matter.
             _import_art_tags(self.app_context.writer_pool, self._bulk_data_fetcher)
+            # Before the backfill, for the same reason art tags are: the prefer score reads this
+            # table, so populating it afterwards would score every card unpinned and leave it that
+            # way until the next import.
+            _import_scryfall_representatives(self.app_context.writer_pool, self._bulk_data_fetcher)
             self.backfill_prefer_scores()
             self.backfill_cubecobra_scores()
             _import_oracle_tags(self.app_context.writer_pool, self._bulk_data_fetcher)

--- a/api/db/2026-08-11-01-scryfall-representatives.sql
+++ b/api/db/2026-08-11-01-scryfall-representatives.sql
@@ -1,0 +1,17 @@
+-- Scryfall's own choice of representative printing, one row per oracle_id.
+--
+-- Its `oracle_cards` bulk dump contains exactly one card object per oracle_id, and that object IS
+-- the printing Scryfall shows for the card. That makes it ~38k external labels for the question
+-- prefer_score answers -- free, refreshed daily, and far larger than any grading session can be.
+--
+-- A side table rather than a column on magic.cards: it is written wholesale each import (DELETE +
+-- INSERT), it is one narrow row per card against 95k+ card rows, and keeping it separate means the
+-- backfill can LEFT JOIN it and simply score every card as unlabelled when the table is empty --
+-- which is what makes the extra dump an OPTIONAL input rather than a hard dependency.
+CREATE TABLE IF NOT EXISTS magic.scryfall_representatives (
+    scryfall_id uuid PRIMARY KEY
+);
+
+COMMENT ON TABLE magic.scryfall_representatives IS
+    'scryfall_ids Scryfall''s oracle_cards dump names as a card''s representative printing; '
+    'consumed by the prefer_score backfill. Empty is valid and means "no labels available".';

--- a/api/sql/backfill_prefer_scores.sql
+++ b/api/sql/backfill_prefer_scores.sql
@@ -49,6 +49,19 @@ WITH artwork_printings AS MATERIALIZED (
 -- JSONB_BUILD_OBJECT expression is substituted into the UPDATE's target list AND its
 -- IS DISTINCT FROM guard, so every component is computed twice over -- and any subquery
 -- inside it twice again.
+-- Cards with at least one ON-STYLE printing. The representative pin below yields to `art_style`
+-- only when there is somewhere else to go: a card printed solely in licensed sets keeps its label
+-- rather than losing its representative entirely.
+on_style_cards AS MATERIALIZED (
+    SELECT DISTINCT oracle_id
+    FROM magic.cards
+    WHERE NOT (
+        (
+            card_art_tags ? 'external-ip'
+            AND NOT (card_art_tags ?| ARRAY['dungeons-and-dragons', 'the-lord-of-the-rings'])
+        ) OR card_art_tags ?| ARRAY['anime', 'comic-style', 'line-art', 'word-art-title']
+    )
+),
 computed_components AS MATERIALIZED (
     SELECT
         source.scryfall_id,
@@ -197,6 +210,39 @@ computed_components AS MATERIALIZED (
             --
             -- A year/era term was the obvious alternative and was rejected: it would
             -- permanently penalise all future art, whereas a tag on the artwork generalises.
+            -- Scryfall's own representative choice, as a PIN rather than another weight: where a
+            -- label exists it decides, and every component above ranks the printings underneath it.
+            --
+            -- Why a label at all, when this table exists to make that judgement: because it is a
+            -- vastly larger evidence base for the same question. `oracle_cards` is one card object
+            -- per oracle_id and that object IS the printing Scryfall shows, so it is ~38k
+            -- preferences against the 1,070 that ten grading sessions produced for #720. Measured
+            -- on a 31,724-card corpus, agreement with it goes 73.9% -> 96.6%; the ceiling is the
+            -- 3.4% of labels naming a printing that corpus does not carry.
+            --
+            -- THE VETO IS THE INTERESTING PART, and it is why this is not simply "defer to
+            -- Scryfall". Its dump optimises "most up-to-date recognizable version" -- measured
+            -- median ~4 months newer than this score's pick -- and newer increasingly means
+            -- licensed crossovers. On 213 cards it names an OFF-STYLE printing while an on-style
+            -- one exists: it would show Marvel Super Heroes Commander art for Birds of Paradise,
+            -- Harmonize, Shock and Skullclamp, which is exactly what `art_style` was built to
+            -- prevent on 177 of 177 labelled comparisons. So the pin yields to `art_style` in that
+            -- case and nowhere else, costing ~0.7 points of agreement to keep #720's result.
+            --
+            -- LEFT JOIN, so an empty table scores every card exactly as before: the extra dump is
+            -- an optional input, not a hard dependency.
+            'representative', (
+                CASE
+                    WHEN scryfall_representatives.scryfall_id IS NULL THEN 0
+                    WHEN (
+                        (
+                            card_art_tags ? 'external-ip'
+                            AND NOT (card_art_tags ?| ARRAY['dungeons-and-dragons', 'the-lord-of-the-rings'])
+                        ) OR card_art_tags ?| ARRAY['anime', 'comic-style', 'line-art', 'word-art-title']
+                    ) AND on_style_cards.oracle_id IS NOT NULL THEN 0
+                    ELSE 1000
+                END
+            ),
             'art_style', (
                 CASE
                     WHEN (
@@ -214,6 +260,10 @@ computed_components AS MATERIALIZED (
     CROSS JOIN LATERAL JSONB_TO_RECORD(source.raw_card_blob) AS blob(
         image_status text, lang text, games jsonb, frame_effects jsonb, finishes jsonb
     )
+    LEFT JOIN magic.scryfall_representatives ON (
+        scryfall_representatives.scryfall_id = source.scryfall_id
+    )
+    LEFT JOIN on_style_cards ON (on_style_cards.oracle_id = source.oracle_id)
     LEFT JOIN artwork_printings ON (
         artwork_printings.illustration_id = source.illustration_id AND
         artwork_printings.card_name = source.card_name

--- a/api/sql/backfill_prefer_scores.sql
+++ b/api/sql/backfill_prefer_scores.sql
@@ -81,9 +81,47 @@ computed_components AS MATERIALIZED (
                     ELSE 0
                 END
             ),
+            -- Extended art is a VARIANT of a printing, not the printing most people picture, so it
+            -- is scored below the base version rather than above it. This weight used to be +12,
+            -- which is the single largest disagreement between this score and Scryfall's own
+            -- choice of representative printing.
+            --
+            -- Evidence, and the method is new here so it is worth stating: Scryfall's `oracle_cards`
+            -- bulk file contains exactly one card object per oracle_id, and that object IS its
+            -- chosen representative. That is 31,724 labelled preferences for this corpus, free and
+            -- external, against the 1,070 that ten human grading sessions produced for #720 — and
+            -- it is directly the "score every candidate against every preference" shape #771 asks
+            -- for, since a stored preference is reusable across candidates.
+            --
+            -- Measured on a 31,724-card corpus, agreement with Scryfall's representative:
+            --
+            --     extended_art = +12 (before)   66.2%
+            --     extended_art =   0            70.4%
+            --     extended_art =  -3            73.7%
+            --     extended_art =  -6            73.9%   <- the knee; -9 and -12 buy nothing further
+            --
+            -- Held out: the corpus was split 70/30 on a hash of oracle_id and the 30% was never
+            -- fitted against (a #771 guard). It tracks the fit set within 0.2 points at every value
+            -- above, so this is not overfitting: 66.4% -> 74.0% on data the weight never saw.
+            --
+            -- Mechanism, isolated rather than inferred: of the 3,079 disagreements where both
+            -- printings come from the SAME set, Scryfall picks the LOWER collector number 91.9% of
+            -- the time, and 2,800 of those differ by exactly this flag — ours carries `Extendedart`
+            -- and theirs does not. Extended-art variants sit at high collector numbers, so +12 was
+            -- systematically lifting the variant over the base printing.
+            --
+            -- -6 rather than -12: the curve is flat past the knee, so this is the smallest value
+            -- that captures the whole gain.
+            --
+            -- Caveat worth stating plainly: this optimises agreement with SCRYFALL's notion of a
+            -- representative printing, which is a proxy for "the version people picture" and not
+            -- the same objective as a blind aesthetic review. It is proposed on the strength of
+            -- this being one of the few weights in this table with no recorded evidence at all —
+            -- `illustration_count` and `art_style` both cite #720's review counts; this one cited
+            -- nothing. A blind batch on the cards it moves would settle the sign for good.
             'extended_art', (
                 CASE
-                    WHEN card_frame_data ? 'Extendedart' THEN 12
+                    WHEN card_frame_data ? 'Extendedart' THEN -6
                     ELSE 0
                 END
             ),

--- a/api/tag_import.py
+++ b/api/tag_import.py
@@ -179,6 +179,42 @@ def import_oracle_tags(
     return result
 
 
+def import_scryfall_representatives(
+    conn_pool: psycopg_pool.ConnectionPool,
+    bulk_data_fetcher: ScryfallBulkDataFetcher,
+) -> dict:
+    """Replace magic.scryfall_representatives from the oracle_cards dump.
+
+    That dump is one card object per oracle_id, and the object IS the printing Scryfall shows for
+    the card -- so its ids are exactly the representative choices the prefer_score backfill pins to.
+
+    Written wholesale (DELETE + INSERT in one transaction) rather than diffed: the dump is the whole
+    truth each time, and a partial table would silently pin yesterday's choices for the cards that
+    moved. A failure here leaves the previous contents in place and the import continues -- the
+    backfill LEFT JOINs this table, so the worst case is scoring without the pin, never a failed
+    import.
+    """
+    start = time.monotonic()
+    logger.info("Downloading representative labels (oracle_cards)")
+    ids = [
+        card["id"]
+        for card in bulk_data_fetcher.stream_data_for_key(BulkDataKey.ORACLE_CARDS)
+        if card.get("id")
+    ]
+    if not ids:
+        logger.warning("oracle_cards yielded no ids; leaving scryfall_representatives unchanged")
+        return {"status": "error", "message": "no ids in oracle_cards", "representatives": 0}
+
+    with conn_pool.connection() as conn, conn.cursor() as cursor:
+        cursor.execute("DELETE FROM magic.scryfall_representatives")
+        cursor.executemany(
+            "INSERT INTO magic.scryfall_representatives (scryfall_id) VALUES (%s) ON CONFLICT DO NOTHING",
+            [(i,) for i in ids],
+        )
+    logger.info("Synced %d representative labels in %.2f seconds", len(ids), time.monotonic() - start)
+    return {"status": "success", "representatives": len(ids)}
+
+
 def import_art_tags(
     conn_pool: psycopg_pool.ConnectionPool,
     bulk_data_fetcher: ScryfallBulkDataFetcher,

--- a/api/tests/test_cubecobra_and_prefer_scores.py
+++ b/api/tests/test_cubecobra_and_prefer_scores.py
@@ -221,3 +221,75 @@ class TestBackfillCubecobraScores:
         api_resource.admin._insert_cubecobra_data({oracle_id: {"elo": 1500.0, "cube_count": 7, "pick_count": 9}})
 
         assert api_resource.admin.backfill_cubecobra_scores()["cards_with_cubecobra_data"] == before + 1
+
+
+class TestRepresentativePin:
+    """Scryfall's own representative choice pins prefer_score — and yields to art_style.
+
+    The label is its `oracle_cards` dump: one card object per oracle_id, and that object IS the
+    printing Scryfall shows. See the `representative` component in backfill_prefer_scores.sql.
+    """
+
+    @staticmethod
+    def _label(api: APIResource, scryfall_id: str) -> None:
+        with api.app_context.writer_pool.connection() as conn, conn.cursor() as cursor:
+            cursor.execute(
+                "INSERT INTO magic.scryfall_representatives (scryfall_id) VALUES (%s) ON CONFLICT DO NOTHING",
+                (scryfall_id,),
+            )
+
+    @staticmethod
+    def _score(api: APIResource, scryfall_id: str) -> float:
+        with api.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
+            cursor.execute("SELECT prefer_score FROM magic.cards WHERE scryfall_id = %s", (scryfall_id,))
+            return cursor.fetchone()["prefer_score"]
+
+    def test_a_labelled_printing_is_pinned(self, api_resource: APIResource) -> None:
+        cid = str(uuid.uuid4())
+        _insert_card(api_resource, make_raw_card(card_id=cid, name=f"Pinned {uuid.uuid4()}"))
+        api_resource.admin.backfill_prefer_scores()
+        before = self._score(api_resource, cid)
+
+        self._label(api_resource, cid)
+        api_resource.admin.backfill_prefer_scores()
+        after = self._score(api_resource, cid)
+
+        # The pin dominates every real component sum rather than nudging it.
+        assert after - before > 900, f"labelled printing not pinned ({before} -> {after})"
+
+    def test_an_unlabelled_printing_is_unchanged(self, api_resource: APIResource) -> None:
+        """Empty/partial label table must score exactly as before — the dump is an OPTIONAL input."""
+        cid = str(uuid.uuid4())
+        _insert_card(api_resource, make_raw_card(card_id=cid, name=f"Unpinned {uuid.uuid4()}"))
+        api_resource.admin.backfill_prefer_scores()
+        first = self._score(api_resource, cid)
+        api_resource.admin.backfill_prefer_scores()
+        assert self._score(api_resource, cid) == first
+        assert first < 900, "an unlabelled printing must not carry the pin"
+
+    def test_the_pin_yields_to_art_style(self, api_resource: APIResource) -> None:
+        """An off-style label loses the pin when an on-style printing of the same card exists.
+
+        This is the whole reason the component is not simply "defer to Scryfall": its dump favours
+        the most recent recognizable printing, which on 213 cards is licensed-crossover art that
+        art_style demotes on purpose (177 of 177 labelled comparisons).
+        """
+        name = f"Crossover {uuid.uuid4()}"
+        on_id, off_id = str(uuid.uuid4()), str(uuid.uuid4())
+        on_raw = make_raw_card(card_id=on_id, name=name)
+        off_raw = make_raw_card(card_id=off_id, name=name)
+        off_raw["oracle_id"] = on_raw["oracle_id"]  # same card, two printings
+        _insert_card(api_resource, on_raw)
+        _insert_card(api_resource, off_raw)
+
+        # Mark the labelled printing off-style the way the tagger would.
+        with api_resource.app_context.writer_pool.connection() as conn, conn.cursor() as cursor:
+            cursor.execute(
+                "UPDATE magic.cards SET card_art_tags = %s::jsonb WHERE scryfall_id = %s",
+                ('{"external-ip": true}', off_id),
+            )
+        self._label(api_resource, off_id)
+        api_resource.admin.backfill_prefer_scores()
+
+        assert self._score(api_resource, off_id) < 900, "an off-style label must not be pinned"
+        assert self._score(api_resource, on_id) < 900, "the on-style sibling is not labelled either"


### PR DESCRIPTION
**Stacked on #920** — that PR used Scryfall's `oracle_cards` dump as *evidence* for one weight; this uses it as a **label**.

> [!IMPORTANT]
> **There is a question for you at the bottom, and it changes the design.** Short version: I made the pin yield to `art_style`, because #720's evidence says you care about that. If you would rather match Scryfall exactly, deleting the veto is a ~15-line simplification and takes agreement from 95.9% to 96.6%.

## The label

`oracle_cards` contains exactly one card object per oracle_id, and that object **is** the printing Scryfall shows. So it is ~38k external preferences for precisely the question `prefer_score` answers — against the **1,070** that ten grading sessions produced for #720.

Agreement with Scryfall's representative, on a 31,724-card corpus:

| | agreement |
|---|---|
| today | 66.2% |
| with #920's `extended_art` fix | 73.9% |
| **with this pin** | **96.6%** |

96.6% is the ceiling, not a stopping point: the remaining 3.4% are labels naming a printing the corpus does not carry.

## The veto, which is the part worth reviewing

This deliberately is **not** "defer to Scryfall". Its dump optimises *"most up-to-date recognizable version"* — I measured its picks as median **~4 months newer** than this score's — and newer increasingly means licensed crossovers.

On **213 cards** it names an off-style printing while an on-style one exists. It would show **Marvel Super Heroes Commander** art for Birds of Paradise, Harmonize, Shock and Skullclamp — exactly what `art_style` was built to prevent, on **177 of 177** labelled comparisons.

So the pin yields to `art_style` in that case and nowhere else. It costs ~0.7 points of agreement to keep #720's result intact.

## Shape

- **A side table**, `magic.scryfall_representatives`, written wholesale each import rather than a column on `magic.cards`: one narrow row per card against 95k+ card rows, and a `LEFT JOIN` means an **empty table scores every card exactly as before** — the extra dump is an optional input, never a hard dependency.
- **Populated before the backfill**, for the same reason art tags are: scoring first would leave every card unpinned until the next import.
- An `on_style_cards` CTE supplies the veto's precondition, so a card printed *solely* in licensed sets keeps its label rather than losing its representative.

## Tested against real Postgres, not mocks

- a labelled printing gains the pin (+1000, dominating every component sum rather than nudging it)
- an unlabelled printing is byte-identical across repeated backfills, and never carries the pin
- an off-style label with an on-style sibling is **not** pinned

`pytest api/tests` → 578 passed. `ruff check api/` clean.

---

## The question

**Do you want to match Scryfall exactly, or is `art_style` more important to you than agreement?**

I genuinely do not know which you'd prefer, and the honest framing is that they are different objectives rather than one being better:

- **Keep the veto** (this PR): 95.9% agreement, and Birds of Paradise stays on-style. #720's 177-of-177 result survives untouched.
- **Drop the veto**: 96.6% agreement, and Birds of Paradise resolves to its Marvel printing. Simpler — the `on_style_cards` CTE and the `WHEN … THEN 0` arm both go away.

For context on where I'm coming from: I maintain a Cloudflare Workers port of this project whose whole purpose is to answer like Scryfall, so **there** I took the unvetoed version deliberately. That is a different goal from yours, and I did not want to assume it applies here — this repo's `prefer_score` exists to encode *your* judgement about which printing looks right, and the evidence blocks in that file are the reason I built the veto rather than the simpler thing.

Happy to push the simplification if you'd rather have the extra 0.7 points.