### PR TITLE
Engine+Schema: A Mana Value Is a Decimal, and Half of One Rounded to Zero

### DIFF
--- a/api/card_processing.py
+++ b/api/card_processing.py
@@ -147,7 +147,8 @@ def preprocess_card(card: dict[str, Any]) -> list[dict[str, Any]]:  # noqa: PLR0
         return [card]
 
     # Lift the card name before processing faces, because it shouldn't be clobbered by card_faces
-    if "card_name" not in card:
+    is_merged_face = "card_name" in card
+    if not is_merged_face:
         # Non-recursive case: first time seeing this card
         card["card_name"] = card.get("name")
     else:
@@ -191,7 +192,27 @@ def preprocess_card(card: dict[str, Any]) -> list[dict[str, Any]]:  # noqa: PLR0
     card["card_subtypes"] = card_subtypes
 
     card["planeswalker_loyalty"] = maybe_int(card.get("loyalty"))
-    if "Creature" in card_types or {"Vehicle", "Spacecraft"} & set(card_subtypes):
+    # The parsed type line is the ORDINARY reason a row carries stats. It is not the only one, and
+    # Scryfall does not treat it as one. Eighteen printings print a real power and toughness behind
+    # a type line that says neither Creature nor Vehicle nor Spacecraft: the pre-Sixth-Edition
+    # `Summon` template (Old Fogey `Summon — Dinosaur`, Flanking Licid `Summon Licid`,
+    # Shichifukujin Dragon `Summon Dragon`) and Atinlay Igpay's pig-latin `Eaturecray — Igpay`.
+    # Checked against the live API on 2026-08-17, `-t:creature -t:vehicle -t:spacecraft (pow>=0 or
+    # pow<0) include:extras` with unique=prints returns exactly those eighteen — and Scryfall
+    # answers each of them NUMERICALLY, so the printed keys, not the parsed type, are what decide
+    # whether a stat exists. A raw `power`/`toughness` key is sufficient on its own here.
+    #
+    # THE TYPE PARSE IS NOT WIDENED, which is the whole point of spelling it this way. `Summon` and
+    # `Eaturecray` stay the unrecognised words they are, so no row here starts answering
+    # `t:creature`; only the stat it actually prints becomes visible. Widening parse_type_line
+    # instead would have made the counts agree and quietly broken `t:creature`.
+    #
+    # Whole cards only, never a merged face: `merged = card | face_data` lets a face inherit the
+    # CARD-level `power`, and Scryfall publishes one there for adventures — Obyra's Attendants is
+    # `3`/`4` at the top level while its Adventure face prints none. For a face the parsed type
+    # line is the only trustworthy signal. Costs nothing: all eighteen printings are single-faced.
+    has_printed_stats = not is_merged_face and (card.get("power") is not None or card.get("toughness") is not None)
+    if "Creature" in card_types or {"Vehicle", "Spacecraft"} & set(card_subtypes) or has_printed_stats:
         # Power and toughness are STRINGS in Scryfall's schema, and eleven cards print a HALF in
         # them: /cards/named?exact=Little+Girl answers "power":".5", "toughness":".5", and the
         # other ten are Unhinged's Ass cycle plus Fraction Jackson, Cardpecker, Stone-Cold

--- a/api/card_processing.py
+++ b/api/card_processing.py
@@ -256,8 +256,10 @@ def preprocess_card(card: dict[str, Any]) -> list[dict[str, Any]]:  # noqa: PLR0
     card["planeswalker_loyalty_text"] = card.get("loyalty")
     card["card_artist"] = card.get("artist")
 
-    # Handle CMC and edhrec_rank conversion using helper function
-    card["cmc"] = maybe_int(card.get("cmc"))
+    # Mana value is a Decimal in Scryfall's schema, not an Integer: {HW} gives Little Girl a
+    # cmc of exactly 0.5. maybe_int here did `int(float(val))`, which rounded that to 0 — the
+    # column is `real` as of 2026-08-12-01-fractional-mana-value.sql, so keep the float.
+    card["cmc"] = maybe_float(card.get("cmc"))
 
     # Handle rarity conversion - implement in Python to avoid SQL boilerplate
     rarity_text = card.get("rarity", "").lower()

--- a/api/card_processing.py
+++ b/api/card_processing.py
@@ -192,8 +192,18 @@ def preprocess_card(card: dict[str, Any]) -> list[dict[str, Any]]:  # noqa: PLR0
 
     card["planeswalker_loyalty"] = maybe_int(card.get("loyalty"))
     if "Creature" in card_types or {"Vehicle", "Spacecraft"} & set(card_subtypes):
-        card["creature_power"] = maybe_int(card.get("power"))
-        card["creature_toughness"] = maybe_int(card.get("toughness"))
+        # Power and toughness are STRINGS in Scryfall's schema, and eleven cards print a HALF in
+        # them: /cards/named?exact=Little+Girl answers "power":".5", "toughness":".5", and the
+        # other ten are Unhinged's Ass cycle plus Fraction Jackson, Cardpecker, Stone-Cold
+        # Basilisk and Vile Bile. maybe_int here did `int(float(val))`, which rounded each onto
+        # its floor — where it then MATCHED that floor, so `power=2` picked up every 2.5. The
+        # columns are `real` as of 2026-08-17-01-fractional-power-toughness.sql, so keep the
+        # float. Non-numeric printings (`*`, `1+*`, `?`, `∞`) still fall through to None exactly
+        # as before: maybe_float and maybe_int reject them identically, via the same
+        # ValueError/TypeError in @maybeify. The printed string is preserved verbatim either way
+        # in creature_power_text/creature_toughness_text below.
+        card["creature_power"] = maybe_float(card.get("power"))
+        card["creature_toughness"] = maybe_float(card.get("toughness"))
         card["creature_power_text"] = card.get("power")
         card["creature_toughness_text"] = card.get("toughness")
     else:

--- a/api/db/2026-08-12-01-fractional-mana-value.sql
+++ b/api/db/2026-08-12-01-fractional-mana-value.sql
@@ -1,0 +1,47 @@
+-- cmc has been `integer` since the great reset, and Scryfall has never typed it that way: its
+-- own docs list cmc as Decimal, and the API answers `"cmc":1.0` for Lightning Bolt even though
+-- one is a whole number. The reason the type matters and not just the formatting is the
+-- half-mana symbol {HW}: /cards/named?exact=Little+Girl answers `"mana_cost":"{HW}"`,
+-- `"cmc":0.5`. An integer column cannot hold that value, so the importer's int cast silently
+-- rounds it to 0 and the card becomes indistinguishable from a zero-cost card. (Its printed
+-- `"power":".5"` / `"toughness":".5"` are STRINGS in Scryfall's own schema and are already
+-- stored as text here — they need nothing.)
+--
+-- This is a CAPABILITY change, not a corpus change. api/card_processing.py still drops
+-- set_type == "funny", and Little Girl is legal in no format so the legality filter above that
+-- would drop it anyway; after this migration every row in the table is still integral. What
+-- changes is that the column stops being the thing that would lose the fraction if the corpus
+-- filter were ever relaxed.
+--
+-- `real` rather than `numeric`, deliberately:
+--
+--   * It is EXACT over the whole domain. Every value Scryfall publishes is either a whole
+--     number or a half step, and binary floating point represents halves exactly; integers are
+--     exact in f32 up to 2^24, which covers the corpus maximum by a wide margin (the largest
+--     mana value in all of Scryfall is Gleemax at 1,000,000, itself exactly representable).
+--     `numeric` would buy exactness for arbitrary decimals the domain does not contain.
+--
+--   * It is the same 4 bytes as `integer`, so the row layout does not grow and neither do the
+--     three btree indexes that carry cmc (idx_cards_cmc_edhrec_btree_include and the two
+--     include-lists in idx_cards_setcode_edhrec_btree_include /
+--     idx_cards_cardname_edhrec_btree_include). `numeric` is variable-width and would widen
+--     all three for a precision nothing asks for.
+--
+--   * It matches what the reader actually stores. card_engine holds cmc as an f32 (see
+--     OracleCard in card_engine/src/lib.rs); a `numeric` column would be exact in Postgres and
+--     then round on its way into the engine, which is a worse place for the rounding to live
+--     than nowhere. It also matches how psycopg hands the value over: `real` arrives as a
+--     Python float, straight into the engine's `opt_f32`, whereas `numeric` arrives as a
+--     `decimal.Decimal`.
+--
+--   * The schema already uses `real` for the three price columns, for the same reasons.
+--
+-- ALTER ... TYPE rewrites the table and rebuilds the dependent indexes, holding an ACCESS
+-- EXCLUSIVE lock for the duration. Sized against the corpus (~31.5k oracle rows) that is a
+-- sub-second rewrite, well inside what the import path's own upsert already blocks for.
+--
+-- The USING clause is spelled out rather than left implicit: integer -> real is an assignment
+-- cast Postgres will do on its own, but writing it makes the widening the migration's stated
+-- intent rather than a coincidence of cast rules.
+ALTER TABLE magic.cards
+    ALTER COLUMN cmc TYPE real USING cmc::real;

--- a/api/db/2026-08-17-01-fractional-power-toughness.sql
+++ b/api/db/2026-08-17-01-fractional-power-toughness.sql
@@ -1,0 +1,67 @@
+-- The companion to 2026-08-12-01-fractional-mana-value.sql, one column family over, and the
+-- reason it is a separate migration is that the two defects are not the same defect. That one
+-- was about a column typed against Scryfall's own schema: cmc is a Decimal there, and `integer`
+-- could not hold the value the schema promised. This one is about a column typed against an
+-- assumption the corpus happened to satisfy. Power and toughness are STRINGS in Scryfall's
+-- schema — creature_power_text/creature_toughness_text hold them verbatim — and the numeric
+-- columns beside them are this project's own parse of those strings. The parse used
+-- int(float(val)), and eleven cards print a value it cannot hold:
+--
+--   $ curl -s 'https://api.scryfall.com/cards/named?exact=Little+Girl'
+--       "power": ".5",
+--       "toughness": ".5",
+--
+--   Little Girl .5/.5, Fraction Jackson 1/1.5, Smart Ass 2.5/1, Stone-Cold Basilisk 2.5/5,
+--   Vile Bile 2.5/2.5, Assquatch 3.5/3.5, Bad Ass 3.5/1, Dumb Ass 3.5/2, Cheap Ass 1/3.5,
+--   Fat Ass 2/3.5, Cardpecker 1.5/1
+--
+-- (Checked against the live API on 2026-08-17: `(power=.5 or power=1.5 or power=2.5 or
+-- power=3.5 or toughness=.5 or toughness=1.5 or toughness=2.5 or toughness=3.5)
+-- include:extras` returns exactly those eleven, all Unhinged.)
+--
+-- THE FAILURE DIRECTION IS THE POINT, and it is the opposite of what "a value was lost" suggests.
+-- Truncation cannot make `toughness<1` MISS a half-toughness card — 0 satisfies that predicate
+-- exactly as 0.5 does. It makes `toughness=0` and `power=2` MATCH cards that print .5 and 2.5.
+-- The rounding does not lose rows from a query, it adds them to the wrong one, and the query it
+-- adds them to is a common one nobody would think to check.
+--
+-- This is a CAPABILITY change, not a corpus change, on exactly the same terms as the mana value
+-- migration. api/card_processing.py still drops set_type == "funny", and all eleven cards are
+-- Unhinged, which is legal in no format and would be dropped by the legality filter anyway.
+-- After this migration every row in the table is still integral and no query answer over the
+-- real corpus moves. What changes is that the column stops being the thing that would lose the
+-- fraction if the corpus filter were ever relaxed.
+--
+-- `real` rather than `numeric`, for the reasons 2026-08-12-01 sets out at length and which apply
+-- unchanged here — exact over the domain (every printed fraction in Magic is a half step, and a
+-- half is exact in binary floating point), the same 4 bytes as `integer` so neither the row nor
+-- idx_cards_creature_power_btree / idx_cards_creature_toughness_btree grows, and the same type
+-- card_engine holds (OracleCard::creature_power is Option<f32>, arriving from psycopg as a
+-- Python float straight into opt_f32, where `numeric` would arrive as a decimal.Decimal).
+--
+-- Two columns, so `real` also has to stay wide enough for the extremes at the OTHER end of the
+-- domain: B.F.M. is 99/99, Impervious Greatwurm is 16/16, and the corpus maximum is well inside
+-- f32's exact-integer range (2^24). The alternative encoding considered and rejected — a scaled
+-- integer at half-unit granularity, which every printed fraction being a half would have made
+-- arithmetically sufficient — fails here specifically: doubling 99 leaves `smallint` territory
+-- fine but the engine's matching column could not have stayed an `i8`, and every read site would
+-- have needed a matching unscale, with a missed one silently mis-ordering rather than visibly
+-- miscounting.
+--
+-- ALTER ... TYPE rewrites the table and rebuilds the two dependent btree indexes, holding an
+-- ACCESS EXCLUSIVE lock for the duration. Sized against the corpus (~31.5k oracle rows) that is
+-- a sub-second rewrite, well inside what the import path's own upsert already blocks for. Both
+-- columns are altered in ONE statement so the table is rewritten once rather than twice.
+--
+-- creature_attributes_null_for_non_creatures is a CHECK over NULL-ness only, so the type change
+-- does not touch it; it is revalidated against the rewritten rows regardless, and every existing
+-- row satisfies it before and after because the widening cannot turn a NULL into a value or the
+-- reverse.
+--
+-- The USING clauses are spelled out rather than left implicit, for the same reason the mana
+-- value migration spells its one out: integer -> real is an assignment cast Postgres would do on
+-- its own, and writing it makes the widening the migration's stated intent rather than a
+-- coincidence of cast rules.
+ALTER TABLE magic.cards
+    ALTER COLUMN creature_power TYPE real USING creature_power::real,
+    ALTER COLUMN creature_toughness TYPE real USING creature_toughness::real;

--- a/api/db/2026-08-17-02-printed-stats-on-any-type-line.sql
+++ b/api/db/2026-08-17-02-printed-stats-on-any-type-line.sql
@@ -1,0 +1,74 @@
+-- The second half of the same defect as 2026-08-17-01-fractional-power-toughness.sql, and the
+-- reason it is a schema change and not just a Python one.
+--
+-- That migration was about a column that could not hold a printed value. This one is about a
+-- column that was not allowed to hold it at all. creature_attributes_null_for_non_creatures says
+-- a row may carry power/toughness only if its PARSED type line names Creature, Vehicle or
+-- Spacecraft — and api/card_processing.py gates on exactly the same test, because the constraint
+-- is what it was written against. The claim underneath both is that a printed stat implies a
+-- modern creature type line. It does not:
+--
+--   $ curl -s 'https://api.scryfall.com/cards/search' \
+--       --data-urlencode 'q=-t:creature -t:vehicle -t:spacecraft (pow>=0 or pow<0) include:extras' \
+--       --data-urlencode 'unique=prints'
+--       "total_cards": 18,
+--
+--   Old Fogey            Summon — Dinosaur     7/7    Atinlay Igpay      Eaturecray — Igpay  3/3
+--   1996 World Champion  Summon Legend         */*    Aswan Jaguar       Summon Jaguar       2/2
+--   Faerie Dragon        Summon Dragon         1/3    Flanking Licid     Summon Licid        1/1
+--   Goblin Polka Band    Summon Goblin         1/1    Prismatic Dragon   Summon Dragon       2/3
+--   Rainbow Knights      Summon Knights        2/1    Shichifukujin Dr.  Summon Dragon       0/0
+--   Throat Wolf          Summon Wolf           3/1    Xyru Specter       Summon — Specter    2/2
+--
+-- (Checked against the live API on 2026-08-17. Mostly the pre-Sixth-Edition `Summon` template,
+-- which Scryfall preserves verbatim on the printings that used it rather than rewriting it to
+-- `Creature`; Atinlay Igpay is the pig-latin one. Counted with unique=prints, so Old Fogey's four
+-- printings and the two Aswan Jaguars are each counted once per printing.)
+--
+-- Scryfall itself searches every one of them numerically — `pow=3` and `tou=3` both count Atinlay
+-- Igpay, `tou>=3.5` counts Old Fogey — so the printed keys, not the parsed type, are what decide
+-- whether a stat exists. The constraint is the thing that would reject the row, so it has to move
+-- before the import can be taught to keep the value.
+--
+-- WHAT REPLACES IT, AND WHY NOT NOTHING. The useful half of the old rule survives: a stat on a
+-- non-creature row must be a PRINTED one. The numeric columns are this project's parse of
+-- creature_power_text/creature_toughness_text, so a numeric stat with no printed string beside it
+-- on a row whose type line does not claim a creature is a derived value that came from somewhere
+-- it should not have — which is the failure this table wants to keep catching. What the old rule
+-- asserted beyond that, that only a modern creature type line may print a stat, is what the
+-- eighteen printings above disprove.
+--
+-- NOT WIDENED: the type parse. `Summon` and `Eaturecray` remain unrecognised words, here and in
+-- parse_type_line, so none of these rows begins to answer `t:creature`. Teaching the parser those
+-- spellings would have satisfied the old constraint and made the numeric counts agree, at the
+-- price of inventing a card type the printing does not have.
+--
+-- CORPUS EFFECT TODAY: none, on exactly the terms 2026-08-12-01 and 2026-08-17-01 set out. All
+-- eighteen printings fail preprocess_card's legality filter — not one is legal or restricted in
+-- any format — and most also fail the funny-set, playtest or paper-games rules. So no row in the
+-- table changes and no query answer moves. This is a CAPABILITY change: the schema stops being
+-- the thing that would drop the stat if the import filter were ever relaxed.
+--
+-- COST: DROP is a catalog update. The ADD validates the whole table, a sequential scan under a
+-- SHARE ROW EXCLUSIVE lock; at ~31.5k oracle rows that is milliseconds, and every existing row
+-- passes it vacuously — the old constraint already guaranteed that a non-creature row has all
+-- four columns NULL, so the new disjunct nobody currently reaches is the one being added. Both
+-- statements are in one ALTER TABLE so the table is examined once.
+--
+-- IF NOT EXISTS on the drop: the constraint is created inline by the CREATE TABLE in
+-- 2025-09-29-great-reset.sql, which is not edited here — migrations stack on top of it — but a
+-- database restored from a dump taken after this migration will not have it.
+ALTER TABLE magic.cards
+    DROP CONSTRAINT IF EXISTS creature_attributes_null_for_non_creatures,
+    ADD CONSTRAINT creature_attributes_printed_or_null_for_non_creatures CHECK (
+        (card_types ?| ARRAY['Creature'::text])
+        OR (card_subtypes ?| ARRAY['Vehicle'::text, 'Spacecraft'::text])
+        OR (creature_power_text IS NOT NULL)
+        OR (creature_toughness_text IS NOT NULL)
+        OR (
+            (creature_power IS NULL)
+            AND (creature_power_text IS NULL)
+            AND (creature_toughness IS NULL)
+            AND (creature_toughness_text IS NULL)
+        )
+    );

--- a/api/parsing/tests/test_fractional_mana_value.py
+++ b/api/parsing/tests/test_fractional_mana_value.py
@@ -1,0 +1,60 @@
+"""Fractional values in `cmc:` / `mv:` / `manavalue:` comparisons.
+
+A mana value is a Decimal in Scryfall's schema, not an Integer: {HW} gives Little Girl a
+cmc of exactly 0.5. Neither parser needed changing to accept `mv=0.5` — the tokenizer has
+always produced a float for a literal with a decimal point (api/parsing/hand_parser.py's
+NUMBER token), and `p_float_*` binding carries it through to SQL untouched. That was true
+before the column could hold a fraction too, and nothing tested it, which is why it is
+worth pinning: the storage change is what makes these queries mean something, and a
+future "cmc is an integer, coerce it" shortcut anywhere on this path would now be a
+silent regression rather than a no-op.
+"""
+
+import pytest
+
+from api.parsing import generate_sql_query
+from api.parsing.card_query_nodes import CardAttributeNode
+from api.parsing.nodes import BinaryOperatorNode, NumericValueNode
+
+testcases = {
+    "cmc_equals_half": {"query": "cmc=0.5", "operator": "=", "value": 0.5},
+    "mv_equals_half": {"query": "mv=0.5", "operator": "=", "value": 0.5},
+    "manavalue_equals_half": {"query": "manavalue=0.5", "operator": "=", "value": 0.5},
+    # ':' on a numeric attribute is Scryfall's spelling of '='; it stays ':' in the AST.
+    "colon_operator": {"query": "mv:0.5", "operator": ":", "value": 0.5},
+    "greater_or_equal": {"query": "mv>=0.5", "operator": ">=", "value": 0.5},
+    "less_than": {"query": "mv<0.5", "operator": "<", "value": 0.5},
+    "not_equals": {"query": "mv!=0.5", "operator": "!=", "value": 0.5},
+    # A half step above a whole number, so the fraction is not just a leading "0.".
+    "one_and_a_half": {"query": "mv=1.5", "operator": "=", "value": 1.5},
+}
+
+
+@pytest.mark.parametrize(
+    argnames=sorted(next(iter(testcases.values()))),
+    argvalues=[[v for k, v in sorted(testcases[testname].items())] for testname in sorted(testcases)],
+    ids=sorted(testcases),
+)
+def test_fractional_mana_value_parses(parse_query, operator: str, query: str, value: float) -> None:
+    """A fractional literal reaches the AST as a float, under every alias, on both parsers."""
+    root = parse_query(query).root
+    assert isinstance(root, BinaryOperatorNode), f"{query!r} did not parse to a comparison: {root}"
+    assert isinstance(root.lhs, CardAttributeNode)
+    assert root.lhs.attribute_name == "cmc"
+    assert root.operator == operator
+    assert root.rhs == NumericValueNode(value)
+
+
+def test_fractional_mana_value_binds_as_a_float_parameter(parse_query) -> None:
+    """The value stays a float all the way into the bound parameter, not rounded to an int."""
+    sql, params = generate_sql_query(parse_query("mv=0.5"))
+    assert "card.cmc = " in sql
+    assert list(params.values()) == [0.5]
+    assert all(isinstance(v, float) for v in params.values())
+
+
+def test_a_whole_mana_value_still_binds_as_an_int(parse_query) -> None:
+    """Unchanged for the values every card in the corpus actually has."""
+    _, params = generate_sql_query(parse_query("mv=1"))
+    assert list(params.values()) == [1]
+    assert all(isinstance(v, int) for v in params.values())

--- a/api/tests/test_card_processing.py
+++ b/api/tests/test_card_processing.py
@@ -397,6 +397,29 @@ class TestCardProcessing:
         assert result["creature_power"] is None
         assert result["creature_toughness"] is None
 
+    def test_preprocess_card_keeps_a_fractional_mana_value(self) -> None:
+        """A half-mana card's cmc survives the import cast.
+
+        Scryfall types cmc Decimal, and the {HW} symbol is what makes that matter:
+        /cards/named?exact=Little+Girl answers "mana_cost":"{HW}", "cmc":0.5. The cast here
+        used to be int(float(val)), which turned that into 0 — the same value a zero-cost
+        card has. (Little Girl itself is still filtered out of the corpus by the funny-set
+        and legality rules above; this is about the cast, not the corpus.)
+        """
+        card = create_test_card(name="Little Girl", mana_cost="{HW}", cmc=0.5, power="1", toughness="1")
+
+        result = preprocess_card(card)
+
+        assert result[0]["cmc"] == 0.5
+
+    def test_preprocess_card_keeps_a_whole_mana_value_whole(self) -> None:
+        """Widening the cast must not perturb the ~31.5k rows that are already integral."""
+        card = create_test_card(name="Lightning Bolt", mana_cost="{R}", cmc=1)
+
+        result = preprocess_card(card)
+
+        assert result[0]["cmc"] == 1
+
     def test_preprocess_hound_tamer_dfc(self) -> None:
         """Test preprocess_card processes Hound Tamer DFC sample data correctly."""
         sample_file = _SAMPLE_DATA_DIR / "hound_tamer.json"

--- a/api/tests/test_card_processing.py
+++ b/api/tests/test_card_processing.py
@@ -7,6 +7,8 @@ import pathlib
 import uuid
 from typing import Any
 
+import pytest
+
 from api.card_processing import extract_frame_data_from_raw_card, preprocess_card
 
 # Project root directory for accessing sample data
@@ -465,6 +467,78 @@ class TestCardProcessing:
 
         assert result[0]["creature_power"] == -1
         assert result[0]["creature_toughness"] == -1
+
+    @pytest.mark.parametrize(
+        ("name", "type_line", "power", "toughness"),
+        [
+            ("Old Fogey", "Summon — Dinosaur", "7", "7"),
+            ("Flanking Licid", "Summon Licid", "1", "1"),
+            ("Atinlay Igpay", "Eaturecray — Igpay", "3", "3"),
+        ],
+    )
+    def test_preprocess_card_keeps_a_printed_stat_behind_a_noncanonical_type_line(
+        self,
+        name: str,
+        type_line: str,
+        power: str,
+        toughness: str,
+    ) -> None:
+        """A printed power/toughness is data even when the type line does not say Creature.
+
+        The pre-Sixth-Edition `Summon` template is what most of these are, preserved verbatim by
+        Scryfall on the printings that used it; Atinlay Igpay is the pig-latin one. Checked
+        against the live API on 2026-08-17, `-t:creature -t:vehicle -t:spacecraft (pow>=0 or
+        pow<0) include:extras` with unique=prints returns exactly eighteen printings, and
+        api.scryfall.com searches every one of them numerically — `pow=3` and `tou=3` both count
+        Atinlay Igpay, `tou>=3.5` counts Old Fogey. The keys, not the parsed type, decide whether
+        a stat exists.
+        """
+        card = create_test_card(name=name, type_line=type_line, power=power, toughness=toughness)
+
+        result = preprocess_card(card)[0]
+
+        assert result["creature_power"] == float(power)
+        assert result["creature_toughness"] == float(toughness)
+        assert result["creature_power_text"] == power
+        assert result["creature_toughness_text"] == toughness
+
+    @pytest.mark.parametrize("type_line", ["Summon — Dinosaur", "Eaturecray — Igpay"])
+    def test_preprocess_card_does_not_invent_a_creature_type_from_a_printed_stat(self, type_line: str) -> None:
+        """Keeping the stat must not widen the type parse, or `t:creature` breaks instead.
+
+        `Summon` and `Eaturecray` are unrecognised words and stay that way. Teaching
+        parse_type_line to read them as `Creature` would have made the stat counts agree too,
+        at the price of a card type the printing does not have.
+        """
+        card = create_test_card(type_line=type_line, power="3", toughness="3")
+
+        result = preprocess_card(card)[0]
+
+        assert "Creature" not in result["card_types"]
+
+    def test_preprocess_card_does_not_give_a_face_the_card_level_stat(self) -> None:
+        """A face's stats are the face's. The raw-key rule above is for whole cards only.
+
+        `merged = card | face_data` lets a face inherit the card-level `power`, and Scryfall
+        publishes one there for adventures: Obyra's Attendants is `3`/`4` at the top level while
+        its Adventure face prints neither. For a face the parsed type line is the only
+        trustworthy signal — and all eighteen noncanonical-type-line printings are single-faced,
+        so nothing is lost by keeping the face path on the type gate.
+        """
+        sample_file = _SAMPLE_DATA_DIR / "obyras_attendants.json"
+        with sample_file.open() as f:
+            obyras_attendants = json.load(f)
+
+        assert obyras_attendants["power"] == "3"
+        assert "power" not in obyras_attendants["card_faces"][1]
+
+        _front, back = preprocess_card(obyras_attendants)
+
+        assert back["card_types"] == ["Instant"]
+        assert back["creature_power"] is None
+        assert back["creature_power_text"] is None
+        assert back["creature_toughness"] is None
+        assert back["creature_toughness_text"] is None
 
     def test_preprocess_hound_tamer_dfc(self) -> None:
         """Test preprocess_card processes Hound Tamer DFC sample data correctly."""

--- a/api/tests/test_card_processing.py
+++ b/api/tests/test_card_processing.py
@@ -420,6 +420,52 @@ class TestCardProcessing:
 
         assert result[0]["cmc"] == 1
 
+    def test_preprocess_card_keeps_a_fractional_power_and_toughness(self) -> None:
+        """A printed half survives the import cast, in the column the query compares.
+
+        Power and toughness are STRINGS in Scryfall's schema, and eleven cards print a half
+        in them — checked against the live API on 2026-08-17,
+        /cards/named?exact=Little+Girl answers "power":".5", "toughness":".5". The cast here
+        used to be int(float(val)), which turned .5 into 0.
+        """
+        card = create_test_card(name="Little Girl", power=".5", toughness=".5")
+
+        result = preprocess_card(card)
+
+        assert result[0]["creature_power"] == 0.5
+        assert result[0]["creature_toughness"] == 0.5
+
+    def test_preprocess_card_does_not_round_a_half_onto_its_floor(self) -> None:
+        """The direction an integer column gets wrong SILENTLY.
+
+        `power=2` finding nothing when a 2.5 card exists would be visible. `power=2`
+        matching that card is not — and truncation does the second, not the first.
+        """
+        card = create_test_card(name="Smart Ass", power="2.5", toughness="1")
+
+        result = preprocess_card(card)
+
+        assert result[0]["creature_power"] == 2.5
+        assert result[0]["creature_power"] != 2
+
+    def test_preprocess_card_keeps_whole_stats_whole(self) -> None:
+        """Widening the cast must not perturb the rows that are already integral."""
+        card = create_test_card(name="Grizzly Bears", power="2", toughness="2")
+
+        result = preprocess_card(card)
+
+        assert result[0]["creature_power"] == 2
+        assert result[0]["creature_toughness"] == 2
+
+    def test_preprocess_card_keeps_a_negative_power(self) -> None:
+        """Power is signed and stays so: Char-Rumbler and Spinal Parasite print -1."""
+        card = create_test_card(name="Spinal Parasite", power="-1", toughness="-1")
+
+        result = preprocess_card(card)
+
+        assert result[0]["creature_power"] == -1
+        assert result[0]["creature_toughness"] == -1
+
     def test_preprocess_hound_tamer_dfc(self) -> None:
         """Test preprocess_card processes Hound Tamer DFC sample data correctly."""
         sample_file = _SAMPLE_DATA_DIR / "hound_tamer.json"

--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -73,6 +73,34 @@ def engine_fixture(fresh_engine: Callable[[], QueryEngine]) -> QueryEngine:
     return e
 
 
+#: Ascending, and one of them is a half — see TestFractionalManaValue.
+_HALF_MANA_CMCS = (0.0, 0.5, 1.0, 2.5, 3.0)
+
+
+@pytest.fixture(scope="module", name="half_mana_engine")
+def half_mana_engine_fixture(fresh_engine: Callable[[], QueryEngine]) -> QueryEngine:
+    """Five cards named after their own mana value, one of them a half.
+
+    Built off a real fixture row so every other column is a shape the engine has already
+    been loaded with; only the identity fields and cmc vary.
+    """
+    template = json.loads(_FIXTURE.read_text())[0]
+    cards = []
+    for i, cmc in enumerate(_HALF_MANA_CMCS):
+        card = dict(template)
+        card["card_name"] = f"Card {cmc}"
+        card["card_name_folded"] = card["card_name"].lower()
+        card["cmc"] = cmc
+        card["oracle_id"] = str(uuid.UUID(int=i + 1))
+        card["scryfall_id"] = str(uuid.UUID(int=1000 + i))
+        card["illustration_id"] = str(uuid.UUID(int=2000 + i))
+        card["edhrec_rank"] = i + 1
+        cards.append(card)
+    e = fresh_engine()
+    e.reload(cards)
+    return e
+
+
 def _run(
     engine: QueryEngine,
     q: str = "",
@@ -582,6 +610,48 @@ class TestSort:
         _, desc_cards = _run(engine, 'name="Lightning Bolt"', orderby="edhrec", direction="desc")
         # Reversed direction should produce reversed order (10 distinct printings)
         assert _names(asc_cards) == list(reversed(_names(desc_cards)))
+
+
+class TestFractionalManaValue:
+    """A mana value is a Decimal in Scryfall's schema, and one card exercises that.
+
+    The half-mana symbol {HW} gives Little Girl (Unhinged) a mana value of exactly 0.5 —
+    checked against the live API on 2026-08-12, /cards/named?exact=Little+Girl answers
+    "mana_cost":"{HW}", "cmc":0.5, and it is the only card in the whole corpus with a
+    fractional one. It is not in the dataset (api/card_processing.py drops set_type ==
+    "funny", and it is legal in no format either), so this builds its own store rather
+    than adding a 91st printing to the shared fixture: the point is that the value can
+    make the round trip from a query string, through the parser, into the engine and back
+    out in the right order — not that the corpus contains it.
+
+    Each of these fails when cmc is an integer, and in both directions: `mv=0.5` finds
+    nothing, and `mv=0` starts finding the half-mana card.
+    """
+
+    def test_half_mana_value_is_findable(self, half_mana_engine: QueryEngine) -> None:
+        total, cards = _run(half_mana_engine, "mv=0.5")
+        assert total == 1
+        assert _names(cards) == ["Card 0.5"]
+
+    def test_zero_does_not_match_a_half(self, half_mana_engine: QueryEngine) -> None:
+        """The direction an integer column gets wrong silently: 0.5 truncates onto 0."""
+        total, cards = _run(half_mana_engine, "cmc=0")
+        assert total == 1
+        assert _names(cards) == ["Card 0.0"]
+
+    def test_a_half_sits_strictly_between_its_neighbours(self, half_mana_engine: QueryEngine) -> None:
+        assert _run(half_mana_engine, "mv<1")[0] == 2  # 0 and 0.5
+        assert _run(half_mana_engine, "mv>0.5")[0] == 3  # 1, 2.5, 3 — not 0.5 itself
+        assert _run(half_mana_engine, "mv>=0.5 mv<=2.5")[0] == 3  # 0.5, 1, 2.5
+
+    def test_every_alias_spells_the_same_fraction(self, half_mana_engine: QueryEngine) -> None:
+        """The cmc / mv / manavalue aliases are one field (api/parsing/db_info.py), fraction included."""
+        for alias in ("cmc", "mv", "manavalue"):
+            assert _run(half_mana_engine, f"{alias}=2.5")[0] == 1, alias
+
+    def test_sort_orders_a_half_between_the_integers(self, half_mana_engine: QueryEngine) -> None:
+        _, cards = _run(half_mana_engine, orderby="cmc", direction="asc")
+        assert _names(cards) == [f"Card {cmc}" for cmc in _HALF_MANA_CMCS]
 
 
 class TestDevotion:

--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -101,6 +101,40 @@ def half_mana_engine_fixture(fresh_engine: Callable[[], QueryEngine]) -> QueryEn
     return e
 
 
+#: (power, toughness), ascending by power, and three of the six are halves — see
+#: TestFractionalPowerAndToughness. The negative is as real as the halves: Char-Rumbler and
+#: Spinal Parasite print a -1 power.
+_HALF_STATS = ((-1.0, -1.0), (0.0, 0.5), (0.5, 0.5), (1.5, 1.0), (2.5, 3.5), (3.5, 2.0))
+
+
+@pytest.fixture(scope="module", name="half_stat_engine")
+def half_stat_engine_fixture(fresh_engine: Callable[[], QueryEngine]) -> QueryEngine:
+    """Six cards named after their own power/toughness, three of them fractional.
+
+    Built off a real fixture row for the same reason `half_mana_engine` is: every other
+    column stays a shape the engine has already been loaded with, and only the identity
+    fields and the two stat columns vary.
+    """
+    template = json.loads(_FIXTURE.read_text())[0]
+    cards = []
+    for i, (power, toughness) in enumerate(_HALF_STATS):
+        card = dict(template)
+        card["card_name"] = f"Card {power}/{toughness}"
+        card["card_name_folded"] = card["card_name"].lower()
+        card["creature_power"] = power
+        card["creature_toughness"] = toughness
+        card["creature_power_text"] = str(power)
+        card["creature_toughness_text"] = str(toughness)
+        card["oracle_id"] = str(uuid.UUID(int=i + 1))
+        card["scryfall_id"] = str(uuid.UUID(int=1000 + i))
+        card["illustration_id"] = str(uuid.UUID(int=2000 + i))
+        card["edhrec_rank"] = i + 1
+        cards.append(card)
+    e = fresh_engine()
+    e.reload(cards)
+    return e
+
+
 def _run(
     engine: QueryEngine,
     q: str = "",
@@ -652,6 +686,55 @@ class TestFractionalManaValue:
     def test_sort_orders_a_half_between_the_integers(self, half_mana_engine: QueryEngine) -> None:
         _, cards = _run(half_mana_engine, orderby="cmc", direction="asc")
         assert _names(cards) == [f"Card {cmc}" for cmc in _HALF_MANA_CMCS]
+
+
+class TestFractionalPowerAndToughness:
+    """Power and toughness are strings in Scryfall's schema, and eleven cards print a half.
+
+    Checked against the live API on 2026-08-17: /cards/named?exact=Little+Girl answers
+    "power":".5", "toughness":".5", and `(power=.5 or power=1.5 or power=2.5 or power=3.5 or
+    toughness=.5 or toughness=1.5 or toughness=2.5 or toughness=3.5) include:extras` returns
+    exactly eleven cards, all Unhinged. None of them is in the dataset — card_processing drops
+    set_type == "funny" — so this builds its own store, exactly as TestFractionalManaValue
+    does: the point is that the value makes the round trip from a query string, through the
+    parser, into the engine and back out in the right order.
+
+    Each of these fails when the columns are integers, and the SECOND direction is the one
+    that matters: `power=0.5` finding nothing is visible, while `power=2` quietly gaining
+    every 2.5 card is not. Truncation over-catches the floor; it does not lose rows.
+    """
+
+    def test_a_half_is_findable(self, half_stat_engine: QueryEngine) -> None:
+        total, cards = _run(half_stat_engine, "power=0.5")
+        assert total == 1
+        assert _names(cards) == ["Card 0.5/0.5"]
+
+    def test_a_floor_does_not_match_the_half_above_it(self, half_stat_engine: QueryEngine) -> None:
+        """The silent direction. `pow=0` must find only the card that actually prints 0."""
+        assert _names(_run(half_stat_engine, "pow=0")[1]) == ["Card 0.0/0.5"]
+        assert _run(half_stat_engine, "pow=2")[0] == 0
+        assert _run(half_stat_engine, "pow=3")[0] == 0
+        assert _run(half_stat_engine, "tou=0")[0] == 0
+
+    def test_a_half_sits_strictly_between_its_neighbours(self, half_stat_engine: QueryEngine) -> None:
+        assert _run(half_stat_engine, "tou<1")[0] == 3  # -1, and both 0.5s
+        assert _run(half_stat_engine, "pow>2")[0] == 2  # 2.5 and 3.5
+        assert _run(half_stat_engine, "pow>=0.5 pow<=2.5")[0] == 3  # 0.5, 1.5, 2.5
+
+    def test_every_alias_spells_the_same_fraction(self, half_stat_engine: QueryEngine) -> None:
+        """power/pow and toughness/tou are one field each (api/parsing/db_info.py)."""
+        for alias in ("power", "pow"):
+            assert _run(half_stat_engine, f"{alias}=2.5")[0] == 1, alias
+        for alias in ("toughness", "tou"):
+            assert _run(half_stat_engine, f"{alias}=3.5")[0] == 1, alias
+
+    def test_a_half_compares_against_the_other_column(self, half_stat_engine: QueryEngine) -> None:
+        """Field-vs-field, where truncation would tie 1.5/1 at 1/1 instead of ordering it."""
+        assert _names(_run(half_stat_engine, "pow>tou")[1]) == ["Card 1.5/1.0", "Card 3.5/2.0"]
+
+    def test_sort_orders_a_half_between_the_integers(self, half_stat_engine: QueryEngine) -> None:
+        _, cards = _run(half_stat_engine, orderby="power", direction="asc")
+        assert _names(cards) == [f"Card {p}/{t}" for p, t in _HALF_STATS]
 
 
 class TestDevotion:

--- a/api/tests/test_upsert_cards.py
+++ b/api/tests/test_upsert_cards.py
@@ -290,6 +290,100 @@ class TestFractionalManaValue:
         assert row["data_type"] == "real"
 
 
+def _stats_for(api_resource: APIResource, scryfall_id: str) -> tuple[float | None, float | None] | None:
+    with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        cursor.execute(
+            "SELECT creature_power, creature_toughness FROM magic.cards WHERE scryfall_id = %(sid)s",
+            {"sid": scryfall_id},
+        )
+        row = cursor.fetchone()
+    return (row["creature_power"], row["creature_toughness"]) if row else None
+
+
+def _creature(name: str, power: str, toughness: str) -> dict:
+    card = make_raw_card(name=name)
+    card["type_line"] = "Creature — Test"
+    card["power"] = power
+    card["toughness"] = toughness
+    return card
+
+
+class TestFractionalPowerAndToughness:
+    """A printed half survives the whole import round trip: parse, column, read back.
+
+    Power and toughness are STRINGS in Scryfall's schema and these columns are this project's
+    own parse of them. The parse was int(float(val)) into an `integer` column until
+    2026-08-17-01-fractional-power-toughness.sql, and eleven cards print a value it could not
+    hold — Little Girl ".5"/".5" and the rest of Unhinged's half-stat cards. These write
+    through the real _upsert_cards path and read the stored columns, so they cover the import
+    cast and the schema together; either one still being integer-shaped fails them.
+
+    The corpus itself is unchanged: every card with a fractional stat is in a funny set, which
+    preprocess_card still drops. These construct their own cards.
+    """
+
+    def test_a_half_stores_as_a_half(self, api_resource: APIResource) -> None:
+        card = _creature("Half Stat Import Test", ".5", ".5")
+        api_resource._upsert_cards([card])
+        assert _stats_for(api_resource, card["id"]) == (0.5, 0.5)
+
+    def test_a_half_does_not_store_as_its_floor(self, api_resource: APIResource) -> None:
+        """The silent direction: 2.5 truncated onto 2 would then ANSWER `power=2`."""
+        card = _creature("Two And A Half Import Test", "2.5", "1")
+        api_resource._upsert_cards([card])
+        assert _stats_for(api_resource, card["id"]) == (2.5, 1)
+
+    def test_whole_stats_still_store_whole(self, api_resource: APIResource) -> None:
+        """The rows that were already integral must read back unchanged."""
+        card = _creature("Whole Stat Import Test", "3", "4")
+        api_resource._upsert_cards([card])
+        assert _stats_for(api_resource, card["id"]) == (3, 4)
+
+    def test_a_non_numeric_stat_is_still_null(self, api_resource: APIResource) -> None:
+        """`*` and its arithmetic forms were never numbers and are not now.
+
+        The printed string is what creature_power_text holds; the numeric column stays NULL,
+        and maybe_float rejects these exactly where maybe_int did.
+        """
+        card = _creature("Star Stat Import Test", "*", "1+*")
+        api_resource._upsert_cards([card])
+        assert _stats_for(api_resource, card["id"]) == (None, None)
+
+    def test_a_half_is_findable_through_the_sql_search_path(self, api_resource: APIResource) -> None:
+        """`power=2.5` binds a Python float against the column and matches in real Postgres.
+
+        Membership rather than equality on the result set, as this fixture's session-shared
+        database requires — other tests in this class import half-stat cards of their own.
+        """
+        card = _creature("Half Stat Search Test", "2.5", "1")
+        api_resource._upsert_cards([card])
+
+        found = {c["name"] for c in api_resource._search_sql(**search_kwargs("power=2.5", limit=100))["cards"]}
+        assert "Half Stat Search Test" in found
+        # ...and the whole-number predicate its floor would have collapsed into stays clean.
+        floor = {c["name"] for c in api_resource._search_sql(**search_kwargs("power=2", limit=100))["cards"]}
+        assert "Half Stat Search Test" not in floor
+
+    def test_the_columns_are_not_an_integer_type(self, api_resource: APIResource) -> None:
+        """The column types are asserted directly, not just inferred from a round trip.
+
+        A passing round trip alone would not distinguish a `real` column from an `integer`
+        one that happened to be handed whole numbers.
+        """
+        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+            cursor.execute(
+                """SELECT column_name, data_type FROM information_schema.columns
+                   WHERE table_schema = 'magic' AND table_name = 'cards'
+                     AND column_name IN ('creature_power', 'creature_toughness')
+                   ORDER BY column_name""",
+            )
+            rows = cursor.fetchall()
+        assert [(r["column_name"], r["data_type"]) for r in rows] == [
+            ("creature_power", "real"),
+            ("creature_toughness", "real"),
+        ]
+
+
 # ---------------------------------------------------------------------------
 # _CardStream counting tests
 # ---------------------------------------------------------------------------

--- a/api/tests/test_upsert_cards.py
+++ b/api/tests/test_upsert_cards.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import logging
 import multiprocessing
 import uuid
-from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import psycopg
 import pytest
@@ -221,7 +220,7 @@ class TestBooleanIsTags:
 
 
 def _cmc_for(api_resource: APIResource, scryfall_id: str) -> float | None:
-    with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+    with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
         cursor.execute("SELECT cmc FROM magic.cards WHERE scryfall_id = %(sid)s", {"sid": scryfall_id})
         row = cursor.fetchone()
     return row["cmc"] if row else None
@@ -244,7 +243,7 @@ class TestFractionalManaValue:
         card = make_raw_card(name="Half Mana Import Test")
         card["mana_cost"] = "{HW}"
         card["cmc"] = 0.5
-        api_resource._upsert_cards([card])
+        api_resource.admin._upsert_cards([card])
         assert _cmc_for(api_resource, card["id"]) == 0.5
 
     def test_whole_mana_value_still_stores_whole(self, api_resource: APIResource) -> None:
@@ -252,7 +251,7 @@ class TestFractionalManaValue:
         card = make_raw_card(name="Whole Mana Import Test")
         card["mana_cost"] = "{2}{R}"
         card["cmc"] = 3
-        api_resource._upsert_cards([card])
+        api_resource.admin._upsert_cards([card])
         assert _cmc_for(api_resource, card["id"]) == 3
 
     def test_a_half_is_findable_through_the_sql_search_path(self, api_resource: APIResource) -> None:
@@ -264,7 +263,7 @@ class TestFractionalManaValue:
         card = make_raw_card(name="Half Mana Search Test")
         card["mana_cost"] = "{HW}"
         card["cmc"] = 0.5
-        api_resource._upsert_cards([card])
+        api_resource.admin._upsert_cards([card])
 
         found = {c["name"] for c in api_resource._search_sql(**search_kwargs("mv=0.5", limit=100))["cards"]}
         assert "Half Mana Search Test" in found
@@ -278,7 +277,7 @@ class TestFractionalManaValue:
         A passing round trip alone would not distinguish a `real` column from an `integer`
         one that happened to be handed whole numbers.
         """
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 """SELECT data_type FROM information_schema.columns
                    WHERE table_schema = 'magic' AND table_name = 'cards' AND column_name = 'cmc'""",
@@ -289,7 +288,7 @@ class TestFractionalManaValue:
 
 
 def _stats_for(api_resource: APIResource, scryfall_id: str) -> tuple[float | None, float | None] | None:
-    with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+    with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
         cursor.execute(
             "SELECT creature_power, creature_toughness FROM magic.cards WHERE scryfall_id = %(sid)s",
             {"sid": scryfall_id},
@@ -322,19 +321,19 @@ class TestFractionalPowerAndToughness:
 
     def test_a_half_stores_as_a_half(self, api_resource: APIResource) -> None:
         card = _creature("Half Stat Import Test", ".5", ".5")
-        api_resource._upsert_cards([card])
+        api_resource.admin._upsert_cards([card])
         assert _stats_for(api_resource, card["id"]) == (0.5, 0.5)
 
     def test_a_half_does_not_store_as_its_floor(self, api_resource: APIResource) -> None:
         """The silent direction: 2.5 truncated onto 2 would then ANSWER `power=2`."""
         card = _creature("Two And A Half Import Test", "2.5", "1")
-        api_resource._upsert_cards([card])
+        api_resource.admin._upsert_cards([card])
         assert _stats_for(api_resource, card["id"]) == (2.5, 1)
 
     def test_whole_stats_still_store_whole(self, api_resource: APIResource) -> None:
         """The rows that were already integral must read back unchanged."""
         card = _creature("Whole Stat Import Test", "3", "4")
-        api_resource._upsert_cards([card])
+        api_resource.admin._upsert_cards([card])
         assert _stats_for(api_resource, card["id"]) == (3, 4)
 
     def test_a_non_numeric_stat_is_still_null(self, api_resource: APIResource) -> None:
@@ -344,7 +343,7 @@ class TestFractionalPowerAndToughness:
         and maybe_float rejects these exactly where maybe_int did.
         """
         card = _creature("Star Stat Import Test", "*", "1+*")
-        api_resource._upsert_cards([card])
+        api_resource.admin._upsert_cards([card])
         assert _stats_for(api_resource, card["id"]) == (None, None)
 
     def test_a_half_is_findable_through_the_sql_search_path(self, api_resource: APIResource) -> None:
@@ -354,7 +353,7 @@ class TestFractionalPowerAndToughness:
         database requires — other tests in this class import half-stat cards of their own.
         """
         card = _creature("Half Stat Search Test", "2.5", "1")
-        api_resource._upsert_cards([card])
+        api_resource.admin._upsert_cards([card])
 
         found = {c["name"] for c in api_resource._search_sql(**search_kwargs("power=2.5", limit=100))["cards"]}
         assert "Half Stat Search Test" in found
@@ -368,7 +367,7 @@ class TestFractionalPowerAndToughness:
         A passing round trip alone would not distinguish a `real` column from an `integer`
         one that happened to be handed whole numbers.
         """
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 """SELECT column_name, data_type FROM information_schema.columns
                    WHERE table_schema = 'magic' AND table_name = 'cards'
@@ -383,7 +382,7 @@ class TestFractionalPowerAndToughness:
 
 
 def _row_for(api_resource: APIResource, scryfall_id: str) -> dict | None:
-    with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+    with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
         cursor.execute(
             """SELECT card_types, creature_power, creature_toughness,
                       creature_power_text, creature_toughness_text
@@ -425,13 +424,13 @@ class TestPrintedStatsOnANoncanonicalTypeLine:
     def test_a_summon_type_line_keeps_its_printed_stats(self, api_resource: APIResource) -> None:
         """Old Fogey's shape: `Summon — Dinosaur`, 7/7, and Scryfall counts it under `tou>=3.5`."""
         card = _summoned("Old Fogey Import Test", "7", "7")
-        api_resource._upsert_cards([card])
+        api_resource.admin._upsert_cards([card])
         assert _stats_for(api_resource, card["id"]) == (7, 7)
 
     def test_an_unparseable_type_line_keeps_its_printed_stats(self, api_resource: APIResource) -> None:
         """Atinlay Igpay's shape: not a word the parser knows in either position, still 3/3."""
         card = _summoned("Atinlay Igpay Import Test", "3", "3", type_line="Eaturecray — Igpay")
-        api_resource._upsert_cards([card])
+        api_resource.admin._upsert_cards([card])
         assert _stats_for(api_resource, card["id"]) == (3, 3)
 
     def test_the_stored_row_is_still_not_a_creature(self, api_resource: APIResource) -> None:
@@ -442,7 +441,7 @@ class TestPrintedStatsOnANoncanonicalTypeLine:
         printed text columns come along with the numbers; the type does not.
         """
         card = _summoned("Summon Not A Creature Test", "7", "7")
-        api_resource._upsert_cards([card])
+        api_resource.admin._upsert_cards([card])
 
         row = _row_for(api_resource, card["id"])
         assert row is not None
@@ -457,7 +456,7 @@ class TestPrintedStatsOnANoncanonicalTypeLine:
         database requires.
         """
         card = _summoned("Summon Search Test", "7", "7")
-        api_resource._upsert_cards([card])
+        api_resource.admin._upsert_cards([card])
 
         found = {c["name"] for c in api_resource._search_sql(**search_kwargs("power=7", limit=100))["cards"]}
         assert "Summon Search Test" in found
@@ -475,11 +474,11 @@ class TestPrintedStatsOnANoncanonicalTypeLine:
         cannot produce it -- which is the point of asking the table to reject it.
         """
         card = make_raw_card(name="Bare Numeric Stat Test")
-        api_resource._upsert_cards([card])
+        api_resource.admin._upsert_cards([card])
 
         with (
             pytest.raises(psycopg.errors.CheckViolation),
-            api_resource._conn_pool.connection() as conn,
+            api_resource.app_context.reader_pool.connection() as conn,
             conn.cursor() as cursor,
         ):
             cursor.execute(

--- a/api/tests/test_upsert_cards.py
+++ b/api/tests/test_upsert_cards.py
@@ -15,7 +15,7 @@ from api.api_resource import APIResource
 from api.card_processing import preprocess_card
 from api.db.bulk_upsert import bulk_upsert
 from api.scryfall_bulk_data_fetcher import BulkDataKey
-from api.tests.helpers import make_raw_card
+from api.tests.helpers import make_raw_card, search_kwargs
 from api.tests.support import mock_app_context
 
 if TYPE_CHECKING:
@@ -220,6 +220,74 @@ class TestBooleanIsTags:
         card["preview"] = {"source": "The Command Zone"}
         api_resource.admin._upsert_cards([card])
         assert "scryfallpreview" not in _is_tags_for(api_resource, card["id"])
+
+
+def _cmc_for(api_resource: APIResource, scryfall_id: str) -> float | None:
+    with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        cursor.execute("SELECT cmc FROM magic.cards WHERE scryfall_id = %(sid)s", {"sid": scryfall_id})
+        row = cursor.fetchone()
+    return row["cmc"] if row else None
+
+
+class TestFractionalManaValue:
+    """A fractional cmc survives the whole import round trip: cast, column, read back.
+
+    Scryfall types cmc Decimal — /cards/named?exact=Little+Girl answers "mana_cost":"{HW}",
+    "cmc":0.5 — and the column was `integer` until
+    2026-08-12-01-fractional-mana-value.sql. These write through the real _upsert_cards
+    path and read the stored column, so they cover the import cast and the schema
+    together; either one still being integer-shaped fails them.
+
+    The corpus itself is unchanged: the only card with a fractional mana value is in a
+    funny set, which preprocess_card still drops. These construct their own card.
+    """
+
+    def test_half_mana_value_stores_as_a_half(self, api_resource: APIResource) -> None:
+        card = make_raw_card(name="Half Mana Import Test")
+        card["mana_cost"] = "{HW}"
+        card["cmc"] = 0.5
+        api_resource._upsert_cards([card])
+        assert _cmc_for(api_resource, card["id"]) == 0.5
+
+    def test_whole_mana_value_still_stores_whole(self, api_resource: APIResource) -> None:
+        """The ~31.5k rows that were already integral must read back unchanged."""
+        card = make_raw_card(name="Whole Mana Import Test")
+        card["mana_cost"] = "{2}{R}"
+        card["cmc"] = 3
+        api_resource._upsert_cards([card])
+        assert _cmc_for(api_resource, card["id"]) == 3
+
+    def test_a_half_is_findable_through_the_sql_search_path(self, api_resource: APIResource) -> None:
+        """`mv=0.5` binds a Python float against the column and matches in real Postgres.
+
+        Membership rather than equality on the result set, as this fixture's session-shared
+        database requires — other tests in this class import half-mana cards of their own.
+        """
+        card = make_raw_card(name="Half Mana Search Test")
+        card["mana_cost"] = "{HW}"
+        card["cmc"] = 0.5
+        api_resource._upsert_cards([card])
+
+        found = {c["name"] for c in api_resource._search_sql(**search_kwargs("mv=0.5", limit=100))["cards"]}
+        assert "Half Mana Search Test" in found
+        # ...and the whole-number predicate its floor would have collapsed into stays clean.
+        zero = {c["name"] for c in api_resource._search_sql(**search_kwargs("mv=0", limit=100))["cards"]}
+        assert "Half Mana Search Test" not in zero
+
+    def test_the_column_is_not_an_integer_type(self, api_resource: APIResource) -> None:
+        """The column type is asserted directly, not just inferred from a round trip.
+
+        A passing round trip alone would not distinguish a `real` column from an `integer`
+        one that happened to be handed whole numbers.
+        """
+        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+            cursor.execute(
+                """SELECT data_type FROM information_schema.columns
+                   WHERE table_schema = 'magic' AND table_name = 'cards' AND column_name = 'cmc'""",
+            )
+            row = cursor.fetchone()
+        assert row is not None
+        assert row["data_type"] == "real"
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/test_upsert_cards.py
+++ b/api/tests/test_upsert_cards.py
@@ -6,9 +6,10 @@ import logging
 import multiprocessing
 import uuid
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import psycopg
+import pytest
 
 from api.admin_resource import AdminResource
 from api.api_resource import APIResource
@@ -17,9 +18,6 @@ from api.db.bulk_upsert import bulk_upsert
 from api.scryfall_bulk_data_fetcher import BulkDataKey
 from api.tests.helpers import make_raw_card, search_kwargs
 from api.tests.support import mock_app_context
-
-if TYPE_CHECKING:
-    import pytest
 
 # ---------------------------------------------------------------------------
 # Status-code tests
@@ -382,6 +380,112 @@ class TestFractionalPowerAndToughness:
             ("creature_power", "real"),
             ("creature_toughness", "real"),
         ]
+
+
+def _row_for(api_resource: APIResource, scryfall_id: str) -> dict | None:
+    with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        cursor.execute(
+            """SELECT card_types, creature_power, creature_toughness,
+                      creature_power_text, creature_toughness_text
+               FROM magic.cards WHERE scryfall_id = %(sid)s""",
+            {"sid": scryfall_id},
+        )
+        return cursor.fetchone()
+
+
+def _summoned(name: str, power: str, toughness: str, type_line: str = "Summon — Dinosaur") -> dict:
+    card = make_raw_card(name=name)
+    card["type_line"] = type_line
+    card["power"] = power
+    card["toughness"] = toughness
+    return card
+
+
+class TestPrintedStatsOnANoncanonicalTypeLine:
+    """A printed power/toughness survives a type line that does not say Creature.
+
+    Eighteen printings print one — checked against the live API on 2026-08-17,
+    `-t:creature -t:vehicle -t:spacecraft (pow>=0 or pow<0) include:extras` with unique=prints
+    returns exactly that many. Mostly the pre-Sixth-Edition `Summon` template, which Scryfall
+    preserves verbatim rather than rewriting to `Creature` (Old Fogey `Summon — Dinosaur` 7/7,
+    Flanking Licid `Summon Licid` 1/1); Atinlay Igpay's `Eaturecray — Igpay` 3/3 is the
+    pig-latin one. Scryfall searches all of them numerically, so the printed keys and not the
+    parsed type are what decide whether a stat exists.
+
+    These write through the real _upsert_cards path, which is the only way to cover BOTH halves
+    of the fix at once: creature_attributes_null_for_non_creatures would have rejected every
+    insert below, so a passing test here is also the evidence that
+    2026-08-17-02-printed-stats-on-any-type-line.sql applied.
+
+    The corpus itself is unchanged: all eighteen printings fail preprocess_card's legality
+    filter, and most also fail the funny-set, playtest or paper-games rules. These construct
+    their own cards, as the fractional-stat tests above do.
+    """
+
+    def test_a_summon_type_line_keeps_its_printed_stats(self, api_resource: APIResource) -> None:
+        """Old Fogey's shape: `Summon — Dinosaur`, 7/7, and Scryfall counts it under `tou>=3.5`."""
+        card = _summoned("Old Fogey Import Test", "7", "7")
+        api_resource._upsert_cards([card])
+        assert _stats_for(api_resource, card["id"]) == (7, 7)
+
+    def test_an_unparseable_type_line_keeps_its_printed_stats(self, api_resource: APIResource) -> None:
+        """Atinlay Igpay's shape: not a word the parser knows in either position, still 3/3."""
+        card = _summoned("Atinlay Igpay Import Test", "3", "3", type_line="Eaturecray — Igpay")
+        api_resource._upsert_cards([card])
+        assert _stats_for(api_resource, card["id"]) == (3, 3)
+
+    def test_the_stored_row_is_still_not_a_creature(self, api_resource: APIResource) -> None:
+        """The negative that makes this the right fix rather than a parser change.
+
+        Widening parse_type_line to read `Summon` as `Creature` would have kept the stats too,
+        and would have put eighteen printings into `t:creature` that print no such word. The
+        printed text columns come along with the numbers; the type does not.
+        """
+        card = _summoned("Summon Not A Creature Test", "7", "7")
+        api_resource._upsert_cards([card])
+
+        row = _row_for(api_resource, card["id"])
+        assert row is not None
+        assert "Creature" not in row["card_types"]
+        assert row["creature_power_text"] == "7"
+        assert row["creature_toughness_text"] == "7"
+
+    def test_a_printed_stat_is_findable_through_the_sql_search_path(self, api_resource: APIResource) -> None:
+        """The stat is searchable, and searching it does not drag the row into `t:creature`.
+
+        Membership rather than equality on the result set, as this fixture's session-shared
+        database requires.
+        """
+        card = _summoned("Summon Search Test", "7", "7")
+        api_resource._upsert_cards([card])
+
+        found = {c["name"] for c in api_resource._search_sql(**search_kwargs("power=7", limit=100))["cards"]}
+        assert "Summon Search Test" in found
+        # Conjoined with the stat rather than bare, so the assertion cannot pass merely by the
+        # row falling off the end of a truncated `t:creature` result set.
+        creatures = {c["name"] for c in api_resource._search_sql(**search_kwargs("power=7 t:creature", limit=100))["cards"]}
+        assert "Summon Search Test" not in creatures
+
+    def test_a_non_creature_row_without_a_printed_stat_is_still_rejected(self, api_resource: APIResource) -> None:
+        """The half of the old constraint the migration deliberately keeps.
+
+        The numeric columns are this project's parse of the printed text ones, so a number with
+        no printed string beside it on a row claiming no creature type is a derived value that
+        arrived from somewhere it should not have. Written as raw SQL because the import path
+        cannot produce it -- which is the point of asking the table to reject it.
+        """
+        card = make_raw_card(name="Bare Numeric Stat Test")
+        api_resource._upsert_cards([card])
+
+        with (
+            pytest.raises(psycopg.errors.CheckViolation),
+            api_resource._conn_pool.connection() as conn,
+            conn.cursor() as cursor,
+        ):
+            cursor.execute(
+                "UPDATE magic.cards SET creature_power = 2 WHERE scryfall_id = %(sid)s",
+                {"sid": card["id"]},
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/card_engine/src/estimator.rs
+++ b/card_engine/src/estimator.rs
@@ -318,18 +318,19 @@ fn name_bigram_count(indexes: &Archived<CardIndexes>, bg: [u8; 2], n_cards: u32)
 fn numeric_count(idx: &Archived<NumericIndex>, op: CmpOp, val: f64) -> Option<u32> {
     let (start, end) = match op {
         CmpOp::Ne => return None,
+        // No fractional-threshold shortcut, for the same reason numeric_candidates dropped
+        // its own: cmc is fractional now, so `=0.5` is a real question and the binary
+        // search answers it. The two must agree — an estimate of 0 for a predicate that
+        // matches a card would misplan the query.
         CmpOp::Eq => {
-            if val.fract() != 0.0 {
-                return Some(0);
-            }
-            let s = idx.partition_point(|p| (i16::from(p.0) as f64) < val);
-            let e = idx.partition_point(|p| (i16::from(p.0) as f64) <= val);
+            let s = idx.partition_point(|p| (f32::from(p.0) as f64) < val);
+            let e = idx.partition_point(|p| (f32::from(p.0) as f64) <= val);
             (s, e)
         }
-        CmpOp::Lt => (0, idx.partition_point(|p| (i16::from(p.0) as f64) < val)),
-        CmpOp::Le => (0, idx.partition_point(|p| (i16::from(p.0) as f64) <= val)),
-        CmpOp::Gt => (idx.partition_point(|p| (i16::from(p.0) as f64) <= val), idx.len()),
-        CmpOp::Ge => (idx.partition_point(|p| (i16::from(p.0) as f64) < val), idx.len()),
+        CmpOp::Lt => (0, idx.partition_point(|p| (f32::from(p.0) as f64) < val)),
+        CmpOp::Le => (0, idx.partition_point(|p| (f32::from(p.0) as f64) <= val)),
+        CmpOp::Gt => (idx.partition_point(|p| (f32::from(p.0) as f64) <= val), idx.len()),
+        CmpOp::Ge => (idx.partition_point(|p| (f32::from(p.0) as f64) < val), idx.len()),
     };
     Some((end - start) as u32)
 }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -11688,7 +11688,8 @@ const FIELD_TABLE: &[(&str, FieldExtractor)] = &[
     // shapes match RESULT_FIELD_COLUMNS in api/api_resource.py, which reshapes the SQL
     // path's raw columns to agree with these).
     ("layout", |py, c, _p, s, _v| Ok(str_at(s, u32::from(c.card_layout_id)).into_pyobject(py)?.into_any())),
-    ("cmc", |py, c, _p, _s, _v| Ok(c.cmc.as_ref().copied().into_pyobject(py)?.into_any())),
+    // f32_le on this branch (a mana value is a decimal): to_native(), not copied().
+    ("cmc", |py, c, _p, _s, _v| Ok(c.cmc.as_ref().map(|v| v.to_native()).into_pyobject(py)?.into_any())),
     ("rarity", |py, _c, p, _s, _v| {
         Ok(p.card_rarity_int.as_ref().and_then(|v| rarity_int_to_text(*v)).into_pyobject(py)?.into_any())
     }),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -268,8 +268,17 @@ struct OracleCard {
     // drops funny sets, so today every stored value is integral and this only stops the
     // TYPE from being the thing that loses the fraction.
     cmc: Option<f32>,
-    creature_power: Option<i8>,       // can be negative (e.g. Char-Rumbler)
-    creature_toughness: Option<i8>,
+    // Fractional for the same reason cmc above is, and from the same corner of the same corpus.
+    // Scryfall types power/toughness as STRINGS, and eleven Unhinged cards print a HALF in them:
+    // Little Girl ".5"/".5", Fraction Jackson "1"/"1.5", Smart Ass "2.5"/"1", Stone-Cold Basilisk
+    // "2.5"/"5", Vile Bile "2.5"/"2.5", Assquatch "3.5"/"3.5", Bad Ass "3.5"/"1", Dumb Ass
+    // "3.5"/"2", Cheap Ass "1"/"3.5", Fat Ass "2"/"3.5", Cardpecker "1.5"/"1". The importer's
+    // int(float(...)) cast truncated each onto its floor, and the failure that leaves is the same
+    // asymmetric pair cmc had: `power=2.5` finding nothing is visible, while `power=2` silently
+    // gaining a 2.5 card is not. Still SIGNED — power is genuinely negative on Char-Rumbler and
+    // Spinal Parasite, which is why the low-tail plane bucket exists.
+    creature_power: Option<f32>,
+    creature_toughness: Option<f32>,
     planeswalker_loyalty: Option<u8>, // always 1-12
     edhrec_rank: Option<u32>,         // up to ~30k unique cards
     cubecobra_score: Option<f32>,
@@ -378,8 +387,8 @@ struct CardRow {
     released_at_int: Option<u32>,
 
     cmc: Option<f32>,
-    creature_power: Option<i8>,
-    creature_toughness: Option<i8>,
+    creature_power: Option<f32>,
+    creature_toughness: Option<f32>,
     planeswalker_loyalty: Option<u8>,
     card_rarity_int: Option<u8>,
     collector_number_int: Option<u16>,
@@ -616,10 +625,6 @@ fn opt_f32(d: &Bound<PyDict>, key: &str) -> Option<f32> {
     })
 }
 
-fn opt_i8(d: &Bound<PyDict>, key: &str) -> Option<i8> {
-    opt_f32(d, key).map(|v| v as i8)
-}
-
 fn opt_u8(d: &Bound<PyDict>, key: &str) -> Option<u8> {
     opt_f32(d, key).map(|v| v as u8)
 }
@@ -771,9 +776,12 @@ fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner, vocab: &mut VocabInter
 
         // Read as f32, not truncated to an integer: `mana_cost` below already asked for the
         // same key as an f32, so an integer cmc here was the only place the two disagreed.
+        // Power and toughness read the same way, and `opt_i8` is gone with them — they were its
+        // only two callers. A `real` column arrives from psycopg as a Python float, and the
+        // truncating `as i8` on the way in was the last place a printed half could be lost.
         cmc: opt_f32(d, "cmc"),
-        creature_power: opt_i8(d, "creature_power"),
-        creature_toughness: opt_i8(d, "creature_toughness"),
+        creature_power: opt_f32(d, "creature_power"),
+        creature_toughness: opt_f32(d, "creature_toughness"),
         planeswalker_loyalty: opt_u8(d, "planeswalker_loyalty"),
         card_rarity_int: opt_u8(d, "card_rarity_int"),
         collector_number_int: opt_u16(d, "collector_number_int"),
@@ -1605,22 +1613,26 @@ fn numeric_candidates(idx: &Archived<NumericIndex>, op: CmpOp, val: f64, n_cards
 
 /// One card's joint numeric key. Derived Hash/Eq handle the NULL (`None`) cases
 /// natively at build-time interning — no sentinel encoding. `f64::from` on the
-/// stored ints is lossless (all four domains fit exactly in f32, so also f64) and
+/// stored values is lossless (all four domains fit exactly in f32, so also f64) and
 /// matches field_num's own widening exactly (the differential test asserts this).
 ///
-/// cmc is held as its `f32::to_bits` pattern rather than as an `f32`, because this key
-/// is a HashMap key and f32 has neither `Eq` nor `Hash`. The two ways bit equality can
-/// disagree with numeric equality are NaN (never equal to itself) and ±0.0 (equal but
-/// bitwise distinct); neither reaches here, because every value is a mana value Postgres
-/// stored — a finite, non-negative number, and Scryfall's own `0` for a zero-cost card
-/// arrives as +0.0. Interning on bits is therefore exactly interning on value, and a
-/// mis-intern would cost only a duplicate combination, never a wrong verdict: each
-/// combination is re-evaluated from its own stored key.
+/// cmc, power and toughness are held as their `f32::to_bits` patterns rather than as `f32`s,
+/// because this key is a HashMap key and f32 has neither `Eq` nor `Hash`. The two ways bit
+/// equality can disagree with numeric equality are NaN (never equal to itself) and ±0.0
+/// (equal but bitwise distinct). NaN cannot reach here — every value is a number Postgres
+/// stored, so it is finite by construction. ±0.0 is a real possibility on power and toughness
+/// in a way it never was on cmc: a mana value is non-negative, but power is signed, and while
+/// Scryfall prints "0" (which parses to +0.0) rather than "-0", `+ 0.0` on the way in
+/// normalizes the negative zero onto the positive one so a value every comparison treats as
+/// equal cannot intern as two combinations and inflate the distinct-key budget. Interning on
+/// bits is therefore exactly interning on value, and a mis-intern would cost only a duplicate
+/// combination, never a wrong verdict: each combination is re-evaluated from its own stored
+/// key.
 #[derive(Archive, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
 struct ArithTupleKey {
     cmc_bits: Option<u32>,
-    power: Option<i8>,
-    toughness: Option<i8>,
+    power_bits: Option<u32>,
+    toughness_bits: Option<u32>,
     loyalty: Option<u8>,
 }
 
@@ -1675,10 +1687,11 @@ fn build_arith_tuple_index(cards: &[OracleCard]) -> ArithTupleIndex {
     let mut keys: Vec<ArithTupleKey> = Vec::new();
     let mut postings: Vec<Vec<u32>> = Vec::new();
     for (i, c) in cards.iter().enumerate() {
+        // `+ 0.0` normalizes -0.0 onto +0.0 before interning — see ArithTupleKey's own comment.
         let key = ArithTupleKey {
-            cmc_bits: c.cmc.map(f32::to_bits),
-            power: c.creature_power,
-            toughness: c.creature_toughness,
+            cmc_bits: c.cmc.map(|v| (v + 0.0).to_bits()),
+            power_bits: c.creature_power.map(|v| (v + 0.0).to_bits()),
+            toughness_bits: c.creature_toughness.map(|v| (v + 0.0).to_bits()),
             loyalty: c.planeswalker_loyalty,
         };
         let id = *interner.entry(key).or_insert_with(|| {
@@ -1719,15 +1732,16 @@ fn arith_tuple_narrow(filter: &FilterExpr, idx: &Archived<ArithTupleIndex>, n_ca
     let mut matched: Vec<usize> = Vec::new();
     let mut count: usize = 0;
     for (t, key) in idx.keys.iter().enumerate() {
-        // Widen exactly as field_num does (see ArithTupleKey's doc): u8/i8 → f64 is lossless and
-        // matches field_num's `_ as f32 as f64` for these domains. The archived Option<u8>/<i8>
-        // store their scalars natively (no endian wrapper), so `f64::from(*v)` reads them directly.
-        // cmc goes back through `from_bits` first — same round trip `to_bits` made at build time,
-        // so what field_num would read off the card and what this reads off the key are the same
-        // f32 before either widens to f64.
-        let cmc = key.cmc_bits.as_ref().map(|v| f64::from(f32::from_bits(u32::from(*v))));
-        let power = key.power.as_ref().map(|v| f64::from(*v));
-        let toughness = key.toughness.as_ref().map(|v| f64::from(*v));
+        // Widen exactly as field_num does (see ArithTupleKey's doc): u8 → f64 is lossless and
+        // matches field_num's `_ as f32 as f64` for loyalty's domain. The archived Option<u8>
+        // stores its scalar natively (no endian wrapper), so `f64::from(*v)` reads it directly.
+        // The three f32 columns go back through `from_bits` first — same round trip `to_bits`
+        // made at build time, so what field_num would read off the card and what this reads off
+        // the key are the same f32 before either widens to f64.
+        let bits_to_f64 = |v: &rkyv::Archived<u32>| f64::from(f32::from_bits(u32::from(*v)));
+        let cmc = key.cmc_bits.as_ref().map(bits_to_f64);
+        let power = key.power_bits.as_ref().map(bits_to_f64);
+        let toughness = key.toughness_bits.as_ref().map(bits_to_f64);
         let loyalty = key.loyalty.as_ref().map(|v| f64::from(*v));
         if eval_arith_tuple_tri(lhs, *op, rhs, cmc, power, toughness, loyalty) == want {
             matched.push(t);
@@ -2355,7 +2369,9 @@ fn sort_col_card_value(card: &AOracleCard, sort_col: SortCol) -> Option<f32> {
     match sort_col {
         SortCol::EdhrecRank => card.edhrec_rank.as_ref().map(|v| u32::from(*v) as f32),
         SortCol::Cubecobra  => card.cubecobra_score.as_ref().map(|v| f32::from(*v)),
-        // Single bytes, so archived and native are the same type — no `u8::from` to unwrap.
+        // All three are `f32` columns now, so the `f32::from` here unwraps rkyv's endian-aware
+        // archived scalar rather than widening an integer — the same shape `cubecobra_score`
+        // above has, not the single-byte identity these two lines used to be.
         SortCol::Cmc        => card.cmc.as_ref().map(|v| f32::from(*v)),
         SortCol::Power      => card.creature_power.as_ref().map(|v| f32::from(*v)),
         SortCol::Toughness  => card.creature_toughness.as_ref().map(|v| f32::from(*v)),
@@ -2455,8 +2471,8 @@ fn build_sort_permutations(cards: &[OracleCard]) -> SortPermutations {
     let (edhrec, edhrec_inv) = both(&|c| c.edhrec_rank.map(|v| v as f32));
     let (cubecobra, cubecobra_inv) = both(&|c| c.cubecobra_score);
     let (cmc, cmc_inv) = both(&|c| c.cmc);
-    let (power, power_inv) = both(&|c| c.creature_power.map(|v| v as f32));
-    let (toughness, toughness_inv) = both(&|c| c.creature_toughness.map(|v| v as f32));
+    let (power, power_inv) = both(&|c| c.creature_power);
+    let (toughness, toughness_inv) = both(&|c| c.creature_toughness);
     let (name, name_inv) = both(&|c| Some(c.name_rank as f32));
     SortPermutations {
         edhrec, cubecobra, cmc, power, toughness, name,
@@ -11784,7 +11800,18 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 // slip straight through. That is the case this field exists for, and reading an old store under
 // the new layout would reinterpret integer cmc bytes as float bits and answer nonsense rather
 // than fail loudly.
-const ARCHIVE_FORMAT_VERSION: u32 = 2026082301;
+//
+// 2026082302 — `creature_power` and `creature_toughness` went `Option<i8>` -> `Option<f32>` on
+// `OracleCard`, and `ArithTupleKey`'s two matching fields went with them (`power`/`toughness` ->
+// `power_bits`/`toughness_bits`). Eleven Unhinged cards print a HALF in those columns and the
+// integer cast truncated each onto the value it would then wrongly ANSWER — the same defect cmc
+// had, one column family over.
+// THIS IS THE CASE THE VERSION FIELD EXISTS FOR, and unlike cmc's it is not also caught by luck:
+// `size_of::<AOracleCard>` measures 304 both before and after (padding absorbed the 12 bytes the
+// two columns gained), `size_of::<APrinting>` is untouched at 160, and `ArithTupleKey` is not
+// measured by the header at all. Without this bump, get_mmap would accept an archive written by
+// the old build and read i8 power bytes as f32 bits.
+const ARCHIVE_FORMAT_VERSION: u32 = 2026082302;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -12341,8 +12368,8 @@ impl QueryEngine {
             name_trigram:   build_trigram_index(&cards, |c| c.card_name_folded.as_str()),
             oracle_trigram: build_oracle_text_index(&cards, &strings),
             cmc:            build_numeric_index(&cards, |c| c.cmc),
-            power:          build_numeric_index(&cards, |c| c.creature_power.map(f32::from)),
-            toughness:      build_numeric_index(&cards, |c| c.creature_toughness.map(f32::from)),
+            power:          build_numeric_index(&cards, |c| c.creature_power),
+            toughness:      build_numeric_index(&cards, |c| c.creature_toughness),
             rarity:         build_rarity_index(&printings, &offsets),
             subtypes:       build_hybrid_tag_index(&cards, &coll_vocab, |c| &c.card_subtypes),
             keywords:       build_hybrid_tag_index(&cards, &coll_vocab, |c| &c.card_keywords),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -261,7 +261,13 @@ struct OracleCard {
     mana_cost_text_id: u32,
     type_line_id: u32,
 
-    cmc: Option<u8>,                  // always an integer; max ~16 in practice
+    // Mana value. Scryfall types this field Decimal, not Integer, and means it: the
+    // half-mana symbol {HW} gives Little Girl (Unhinged) a cmc of exactly 0.5. f32 is the
+    // same type the `real` column it loads from holds, so nothing rounds on the way in;
+    // whole numbers up to 2^24 and every half step are exact. The corpus filter still
+    // drops funny sets, so today every stored value is integral and this only stops the
+    // TYPE from being the thing that loses the fraction.
+    cmc: Option<f32>,
     creature_power: Option<i8>,       // can be negative (e.g. Char-Rumbler)
     creature_toughness: Option<i8>,
     planeswalker_loyalty: Option<u8>, // always 1-12
@@ -371,7 +377,7 @@ struct CardRow {
     set_name_id: u32,
     released_at_int: Option<u32>,
 
-    cmc: Option<u8>,
+    cmc: Option<f32>,
     creature_power: Option<i8>,
     creature_toughness: Option<i8>,
     planeswalker_loyalty: Option<u8>,
@@ -763,7 +769,9 @@ fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner, vocab: &mut VocabInter
         card_color_identity: jsonb_color_to_bits(d, "card_color_identity"),
         produced_mana: jsonb_color_to_bits(d, "produced_mana"),
 
-        cmc: opt_u8(d, "cmc"), // Un-set cards have fractional cmc, but we don't load those into the dataset
+        // Read as f32, not truncated to an integer: `mana_cost` below already asked for the
+        // same key as an f32, so an integer cmc here was the only place the two disagreed.
+        cmc: opt_f32(d, "cmc"),
         creature_power: opt_i8(d, "creature_power"),
         creature_toughness: opt_i8(d, "creature_toughness"),
         planeswalker_loyalty: opt_u8(d, "planeswalker_loyalty"),
@@ -1500,19 +1508,28 @@ fn union_sorted(a: Vec<u32>, b: Vec<u32>) -> Vec<u32> {
 }
 
 // ─── Numeric index ────────────────────────────────────────────────────────────
-// Sorted Vec<(i16, u32)> maps field value -> card index for cmc/power/toughness.
-// i16 covers both u8 (cmc: 0-255) and i8 (power/toughness: -128-127) without loss.
+// Sorted Vec<(f32, u32)> maps field value -> card index for cmc/power/toughness.
+// f32 was i16 until cmc became fractional (Scryfall types it Decimal — {HW} is 0.5):
+// the key has to hold what the field holds, or `cmc=0.5` can only ever answer nothing.
+// Widening costs no memory — (i16, u32) already padded to 8 bytes for the u32's
+// alignment, and (f32, u32) is 8 bytes with no padding at all — and no precision:
+// power/toughness are i8 and every i8 is exact in f32.
 // Binary search gives the candidate slice; sort by card index for intersection.
 
-type NumericIndex = Vec<(i16, u32)>;
+type NumericIndex = Vec<(f32, u32)>;
 
-fn build_numeric_index(cards: &[OracleCard], get_val: impl Fn(&OracleCard) -> Option<i16>) -> NumericIndex {
+fn build_numeric_index(cards: &[OracleCard], get_val: impl Fn(&OracleCard) -> Option<f32>) -> NumericIndex {
     let mut idx: NumericIndex = cards
         .iter()
         .enumerate()
         .filter_map(|(i, c)| get_val(c).map(|v| (v, i as u32)))
         .collect();
-    idx.sort_unstable();
+    // total_cmp rather than a derived Ord, which f32 doesn't have. No value in here is NaN
+    // (each one is a number Postgres stored in a `real`/`integer` column), so the total
+    // order and the numeric order agree on everything actually present; total_cmp just
+    // spares the partial_cmp unwrap. Ties break on card index so the slice stays ascending
+    // in id — the invariant `sort_unstable` on a (key, id) tuple used to give for free.
+    idx.sort_unstable_by(|a, b| a.0.total_cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
     idx
 }
 
@@ -1554,18 +1571,21 @@ fn negate_op(op: CmpOp) -> CmpOp {
 /// `n_cards` is the id DOMAIN, which is not `idx.len()`: the numeric indexes are nullable (a card with
 /// no power has no entry), so ids run past the index's length and a bitmap sized from it would panic.
 fn numeric_candidates(idx: &Archived<NumericIndex>, op: CmpOp, val: f64, n_cards: usize) -> Option<Vec<u32>> {
+    // No `val.fract() != 0.0 => empty` shortcut for Eq any more: that was only ever sound
+    // while every indexed value was an integer, and `cmc=0.5` is exactly the query it
+    // would answer wrongly now. Binary search needs no such special case — a threshold no
+    // card holds produces an empty [s, e) on its own.
     let (start, end) = match op {
         CmpOp::Ne => return None,
         CmpOp::Eq => {
-            if val.fract() != 0.0 { return Some(Vec::new()); }
-            let s = idx.partition_point(|p| (i16::from(p.0) as f64) < val);
-            let e = idx.partition_point(|p| (i16::from(p.0) as f64) <= val);
+            let s = idx.partition_point(|p| (f32::from(p.0) as f64) < val);
+            let e = idx.partition_point(|p| (f32::from(p.0) as f64) <= val);
             (s, e)
         }
-        CmpOp::Lt => (0, idx.partition_point(|p| (i16::from(p.0) as f64) < val)),
-        CmpOp::Le => (0, idx.partition_point(|p| (i16::from(p.0) as f64) <= val)),
-        CmpOp::Gt => (idx.partition_point(|p| (i16::from(p.0) as f64) <= val), idx.len()),
-        CmpOp::Ge => (idx.partition_point(|p| (i16::from(p.0) as f64) < val), idx.len()),
+        CmpOp::Lt => (0, idx.partition_point(|p| (f32::from(p.0) as f64) < val)),
+        CmpOp::Le => (0, idx.partition_point(|p| (f32::from(p.0) as f64) <= val)),
+        CmpOp::Gt => (idx.partition_point(|p| (f32::from(p.0) as f64) <= val), idx.len()),
+        CmpOp::Ge => (idx.partition_point(|p| (f32::from(p.0) as f64) < val), idx.len()),
     };
     // Card space, so the domain is `n_cards` -- `MATERIALIZE_BITMAP_RATIO` reads the domain rather than
     // assuming printing space, which is the whole reason it is a ratio.
@@ -1587,9 +1607,18 @@ fn numeric_candidates(idx: &Archived<NumericIndex>, op: CmpOp, val: f64, n_cards
 /// natively at build-time interning — no sentinel encoding. `f64::from` on the
 /// stored ints is lossless (all four domains fit exactly in f32, so also f64) and
 /// matches field_num's own widening exactly (the differential test asserts this).
+///
+/// cmc is held as its `f32::to_bits` pattern rather than as an `f32`, because this key
+/// is a HashMap key and f32 has neither `Eq` nor `Hash`. The two ways bit equality can
+/// disagree with numeric equality are NaN (never equal to itself) and ±0.0 (equal but
+/// bitwise distinct); neither reaches here, because every value is a mana value Postgres
+/// stored — a finite, non-negative number, and Scryfall's own `0` for a zero-cost card
+/// arrives as +0.0. Interning on bits is therefore exactly interning on value, and a
+/// mis-intern would cost only a duplicate combination, never a wrong verdict: each
+/// combination is re-evaluated from its own stored key.
 #[derive(Archive, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
 struct ArithTupleKey {
-    cmc: Option<u8>,
+    cmc_bits: Option<u32>,
     power: Option<i8>,
     toughness: Option<i8>,
     loyalty: Option<u8>,
@@ -1647,7 +1676,7 @@ fn build_arith_tuple_index(cards: &[OracleCard]) -> ArithTupleIndex {
     let mut postings: Vec<Vec<u32>> = Vec::new();
     for (i, c) in cards.iter().enumerate() {
         let key = ArithTupleKey {
-            cmc: c.cmc,
+            cmc_bits: c.cmc.map(f32::to_bits),
             power: c.creature_power,
             toughness: c.creature_toughness,
             loyalty: c.planeswalker_loyalty,
@@ -1693,7 +1722,10 @@ fn arith_tuple_narrow(filter: &FilterExpr, idx: &Archived<ArithTupleIndex>, n_ca
         // Widen exactly as field_num does (see ArithTupleKey's doc): u8/i8 → f64 is lossless and
         // matches field_num's `_ as f32 as f64` for these domains. The archived Option<u8>/<i8>
         // store their scalars natively (no endian wrapper), so `f64::from(*v)` reads them directly.
-        let cmc = key.cmc.as_ref().map(|v| f64::from(*v));
+        // cmc goes back through `from_bits` first — same round trip `to_bits` made at build time,
+        // so what field_num would read off the card and what this reads off the key are the same
+        // f32 before either widens to f64.
+        let cmc = key.cmc_bits.as_ref().map(|v| f64::from(f32::from_bits(u32::from(*v))));
         let power = key.power.as_ref().map(|v| f64::from(*v));
         let toughness = key.toughness.as_ref().map(|v| f64::from(*v));
         let loyalty = key.loyalty.as_ref().map(|v| f64::from(*v));
@@ -2422,7 +2454,7 @@ fn build_sort_permutations(cards: &[OracleCard]) -> SortPermutations {
     };
     let (edhrec, edhrec_inv) = both(&|c| c.edhrec_rank.map(|v| v as f32));
     let (cubecobra, cubecobra_inv) = both(&|c| c.cubecobra_score);
-    let (cmc, cmc_inv) = both(&|c| c.cmc.map(|v| v as f32));
+    let (cmc, cmc_inv) = both(&|c| c.cmc);
     let (power, power_inv) = both(&|c| c.creature_power.map(|v| v as f32));
     let (toughness, toughness_inv) = both(&|c| c.creature_toughness.map(|v| v as f32));
     let (name, name_inv) = both(&|c| Some(c.name_rank as f32));
@@ -11743,7 +11775,16 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 // are `AOracleCard` and `APrinting`, and neither moves, because the change is entirely inside
 // `CardIndexes`. So this constant is the only thing stopping a reader from accessing an older
 // store's `HashMap<String, Vec<u32>>` as a `HybridTagIndex` through `access_unchecked`.
-const ARCHIVE_FORMAT_VERSION: u32 = 2026081301;
+//
+// 2026082301 — cmc went `Option<u8>` -> `Option<f32>` on `OracleCard`, `NumericIndex`'s key went
+// `i16` -> `f32`, and `ArithTupleKey` / `BucketBounds` changed with them. The struct sizes below
+// happen to move too (`size_of::<AOracleCard>` measures 288 before and 304 after), so the header
+// would reject an old store even without this — but only by luck of the OracleCard change: the
+// three INDEX types are not measured by the header at all, and a change confined to them would
+// slip straight through. That is the case this field exists for, and reading an old store under
+// the new layout would reinterpret integer cmc bytes as float bits and answer nonsense rather
+// than fail loudly.
+const ARCHIVE_FORMAT_VERSION: u32 = 2026082301;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -12299,9 +12340,9 @@ impl QueryEngine {
         let indexes = CardIndexes {
             name_trigram:   build_trigram_index(&cards, |c| c.card_name_folded.as_str()),
             oracle_trigram: build_oracle_text_index(&cards, &strings),
-            cmc:            build_numeric_index(&cards, |c| c.cmc.map(|v| v as i16)),
-            power:          build_numeric_index(&cards, |c| c.creature_power.map(|v| v as i16)),
-            toughness:      build_numeric_index(&cards, |c| c.creature_toughness.map(|v| v as i16)),
+            cmc:            build_numeric_index(&cards, |c| c.cmc),
+            power:          build_numeric_index(&cards, |c| c.creature_power.map(f32::from)),
+            toughness:      build_numeric_index(&cards, |c| c.creature_toughness.map(f32::from)),
             rarity:         build_rarity_index(&printings, &offsets),
             subtypes:       build_hybrid_tag_index(&cards, &coll_vocab, |c| &c.card_subtypes),
             keywords:       build_hybrid_tag_index(&cards, &coll_vocab, |c| &c.card_keywords),

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -91,7 +91,8 @@ pub(crate) const PLANE_RESTRICTED_ABSENT: usize = PLANE_RESTRICTED_EXISTS + MAX_
 /// high values, e.g. toughness up to 30) and a shared "<0" low-tail bucket
 /// for power/toughness only (a mana value is never negative, so cmc never
 /// needs one). The interior is a lattice of INTEGER points, so a fractional
-/// cmc goes to the hi bucket however small it is — see `set_numeric_plane`.
+/// value in ANY of the three goes to a bucket however small it is — see
+/// `set_numeric_plane`.
 /// Buckets are cumulative planes built with the exact same machinery as the
 /// interior values — "power<=0" is
 /// just another plane, no different from "power==5" — which is what lets a
@@ -293,6 +294,11 @@ fn devotion_count(card: &OracleCard, lane: usize) -> u8 {
 /// (they fall back to `numeric_candidates`) but can never make one answer
 /// wrongly: `bucket_verdict` reasons only from the endpoints and monotonicity,
 /// which holds wherever in the number line the bucket's members sit.
+///
+/// Power and toughness reach this the same way cmc does, and a fraction there
+/// picks whichever bucket it is nearest: a NEGATIVE off-lattice value goes to
+/// the lo bucket by the first arm, which tracks its own [min,max] and so is
+/// sound for the same reason. Only the interior lattice is closed to them.
 fn set_numeric_plane(
     set: &mut impl FnMut(usize),
     v: Option<f32>,
@@ -455,18 +461,18 @@ pub(crate) fn build_bit_planes(cards: &[OracleCard], printings: &[Printing], off
             }
         }
         // #655: a mana value is never negative, so cmc has no low bucket.
-        // Power/toughness are Option<i8> and do (Char-Rumbler and similar).
+        // Power/toughness are signed and do (Char-Rumbler and similar).
         set_numeric_plane(&mut set, card.cmc, PLANE_CMC, None, (PLANE_CMC_HI, &mut cmc_hi));
         set_numeric_plane(
             &mut set,
-            card.creature_power.map(f32::from),
+            card.creature_power,
             PLANE_POWER,
             Some((PLANE_POWER_LO, &mut power_lo)),
             (PLANE_POWER_HI, &mut power_hi),
         );
         set_numeric_plane(
             &mut set,
-            card.creature_toughness.map(f32::from),
+            card.creature_toughness,
             PLANE_TOUGHNESS,
             Some((PLANE_TOUGHNESS_LO, &mut toughness_lo)),
             (PLANE_TOUGHNESS_HI, &mut toughness_hi),

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -89,9 +89,11 @@ pub(crate) const PLANE_RESTRICTED_ABSENT: usize = PLANE_RESTRICTED_EXISTS + MAX_
 /// range [0,12] — hundreds-to-thousands of cards per value — plus a shared
 /// "13+" high-tail bucket per field (all three have a genuine spread of rare
 /// high values, e.g. toughness up to 30) and a shared "<0" low-tail bucket
-/// for power/toughness only (`cmc: Option<u8>` is type-guaranteed
-/// non-negative, so it never needs one). Buckets are cumulative planes built
-/// with the exact same machinery as the interior values — "power<=0" is
+/// for power/toughness only (a mana value is never negative, so cmc never
+/// needs one). The interior is a lattice of INTEGER points, so a fractional
+/// cmc goes to the hi bucket however small it is — see `set_numeric_plane`.
+/// Buckets are cumulative planes built with the exact same machinery as the
+/// interior values — "power<=0" is
 /// just another plane, no different from "power==5" — which is what lets a
 /// sparse tail (power has 2 cards at -1) get absorbed automatically instead
 /// of needing a side table or a live re-query. See
@@ -190,20 +192,27 @@ pub(crate) const RARITY_PRINTING_PLANE_INTS: [u8; RARITY_INTERIOR] = [0, 1, 2, 3
 /// bucket sentinel: no card has ever been observed there, so the bucket
 /// contributes nothing to any comparison, in either direction — see
 /// `bucket_verdict`.
+///
+/// f32, not i16: cmc is fractional (Scryfall types it Decimal — {HW} is 0.5), and a
+/// bucket's bounds have to be able to say so. Rounding a fractional observation to an
+/// integer would not merely be imprecise, it would be UNSOUND in one direction — a
+/// bucket holding only 16.5 whose max rounded down to 16 reports `cmc>16` FullyExcluded,
+/// dropping the very card that satisfies it. Widening the two fields costs 4 bytes per
+/// bucket across the five buckets in the whole store.
 #[derive(Archive, Serialize, Deserialize, Clone, Copy)]
 pub(crate) struct BucketBounds {
-    pub(crate) min: i16,
-    pub(crate) max: i16,
+    pub(crate) min: f32,
+    pub(crate) max: f32,
 }
 
 impl Default for BucketBounds {
     fn default() -> Self {
-        BucketBounds { min: i16::MAX, max: i16::MIN }
+        BucketBounds { min: f32::INFINITY, max: f32::NEG_INFINITY }
     }
 }
 
 impl BucketBounds {
-    fn observe(&mut self, v: i16) {
+    fn observe(&mut self, v: f32) {
         self.min = self.min.min(v);
         self.max = self.max.max(v);
     }
@@ -264,27 +273,43 @@ fn devotion_count(card: &OracleCard, lane: usize) -> u8 {
 }
 
 /// One card's cmc/power/toughness value against one field's plane layout:
-/// set the interior one-hot plane for values in [0,12], or a bucket plane
-/// (tracking its live [min,max]) for values outside it. `lo_bucket` is
-/// `None` for cmc (`Option<u8>` is type-guaranteed non-negative, so no card
-/// can ever land below the interior).
+/// set the interior one-hot plane for whole-number values in [0,12], or a
+/// bucket plane (tracking its live [min,max]) for anything else. `lo_bucket`
+/// is `None` for cmc: a mana value is a sum of per-symbol contributions that
+/// are each non-negative, so no card can land below the interior. (That used
+/// to be argued from `Option<u8>`; the type is `Option<f32>` now, and the
+/// reason it still holds is the domain, not the type.)
+///
+/// "Whole-number" is the added condition, and it is what keeps the interior
+/// sound now that a value can be fractional. The interior planes are a LATTICE
+/// of single integer points: there is a plane meaning "cmc == 0" and one
+/// meaning "cmc == 1", and none that can hold 0.5. Letting 0.5 fall into the
+/// `v <= NUM_INTERIOR_HI` arm would truncate it onto the "cmc == 0" plane and
+/// make `cmc=0` match Little Girl. Off-lattice values go to the hi bucket
+/// instead, which retains no per-card value at all — only [min,max] — so
+/// `bucket_verdict` resolves it exactly when the endpoints settle the question
+/// and declines otherwise. That widens the hi bucket's observed range down
+/// past the interior, which costs some plane-compiled queries their fast path
+/// (they fall back to `numeric_candidates`) but can never make one answer
+/// wrongly: `bucket_verdict` reasons only from the endpoints and monotonicity,
+/// which holds wherever in the number line the bucket's members sit.
 fn set_numeric_plane(
     set: &mut impl FnMut(usize),
-    v: Option<i32>,
+    v: Option<f32>,
     interior_base: usize,
     lo_bucket: Option<(usize, &mut BucketBounds)>,
     hi_bucket: (usize, &mut BucketBounds),
 ) {
     let Some(v) = v else { return }; // missing value: no bit set anywhere, correctly excluded from any comparison
-    if v < NUM_INTERIOR_LO {
+    if v < NUM_INTERIOR_LO as f32 {
         let (plane, bounds) = lo_bucket.expect("value below the interior range with no low bucket configured");
-        bounds.observe(v as i16);
+        bounds.observe(v);
         set(plane);
-    } else if v <= NUM_INTERIOR_HI {
-        set(interior_base + (v - NUM_INTERIOR_LO) as usize);
+    } else if v <= NUM_INTERIOR_HI as f32 && v.fract() == 0.0 {
+        set(interior_base + (v as i32 - NUM_INTERIOR_LO) as usize);
     } else {
         let (plane, bounds) = hi_bucket;
-        bounds.observe(v as i16);
+        bounds.observe(v);
         set(plane);
     }
 }
@@ -429,20 +454,19 @@ pub(crate) fn build_bit_planes(cards: &[OracleCard], printings: &[Printing], off
                 }
             }
         }
-        // #655: cmc is Option<u8>, type-guaranteed non-negative, so it has no
-        // low bucket. Power/toughness are Option<i8> and do (Char-Rumbler and
-        // similar).
-        set_numeric_plane(&mut set, card.cmc.map(i32::from), PLANE_CMC, None, (PLANE_CMC_HI, &mut cmc_hi));
+        // #655: a mana value is never negative, so cmc has no low bucket.
+        // Power/toughness are Option<i8> and do (Char-Rumbler and similar).
+        set_numeric_plane(&mut set, card.cmc, PLANE_CMC, None, (PLANE_CMC_HI, &mut cmc_hi));
         set_numeric_plane(
             &mut set,
-            card.creature_power.map(i32::from),
+            card.creature_power.map(f32::from),
             PLANE_POWER,
             Some((PLANE_POWER_LO, &mut power_lo)),
             (PLANE_POWER_HI, &mut power_hi),
         );
         set_numeric_plane(
             &mut set,
-            card.creature_toughness.map(i32::from),
+            card.creature_toughness.map(f32::from),
             PLANE_TOUGHNESS,
             Some((PLANE_TOUGHNESS_LO, &mut toughness_lo)),
             (PLANE_TOUGHNESS_HI, &mut toughness_hi),
@@ -764,15 +788,17 @@ struct NumericLayout {
 }
 
 /// A bucket's live-observed range. `min > max` means empty (no card has ever
-/// landed there) — see `bucket_verdict`.
+/// landed there) — see `bucket_verdict`. f64 because the bounds it reads are
+/// f32 and the thresholds it is compared against are f64; widening once here
+/// keeps `bucket_verdict` free of casts.
 #[derive(Clone, Copy)]
 struct Bucket {
-    min: i32,
-    max: i32,
+    min: f64,
+    max: f64,
 }
 
 fn numeric_layout(field: NumField, bounds: &rkyv::Archived<BitPlanes>) -> Option<NumericLayout> {
-    let bucket = |b: &rkyv::Archived<BucketBounds>| Bucket { min: i16::from(b.min) as i32, max: i16::from(b.max) as i32 };
+    let bucket = |b: &rkyv::Archived<BucketBounds>| Bucket { min: f32::from(b.min) as f64, max: f32::from(b.max) as f64 };
     match field {
         NumField::Cmc => Some(NumericLayout {
             interior_base: PLANE_CMC,
@@ -830,7 +856,7 @@ fn bucket_verdict(op: CmpOp, threshold: f64, bucket: Bucket) -> BucketVerdict {
     if bucket.min > bucket.max {
         return BucketVerdict::FullyExcluded; // empty: no observed member at all
     }
-    let (min, max) = (bucket.min as f64, bucket.max as f64);
+    let (min, max) = (bucket.min, bucket.max);
     match op {
         CmpOp::Ge => {
             if min >= threshold {
@@ -883,7 +909,9 @@ fn bucket_verdict(op: CmpOp, threshold: f64, bucket: Bucket) -> BucketVerdict {
 
 /// Compile `field <op> threshold` for cmc/power/toughness. Interior values
 /// are never ambiguous (a one-hot plane is a single integer point — either
-/// fully in or fully out); only the bucket planes can force a decline.
+/// fully in or fully out, and that stays true against a fractional threshold:
+/// `matches_op(op, 0.0, 0.5)` is a decided answer, not a guess); only the
+/// bucket planes can force a decline.
 /// Missing values (non-creature power/toughness, an unset cmc) set no bit
 /// anywhere in the field's planes, so they're correctly excluded from any
 /// `Or` here — the Null-collapses-to-false semantics `filter.rs`'s

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2253,7 +2253,14 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
         // it so bigger stats cost more and P~T track each other, and are present only on the
         // matching card kind: creatures have power/toughness, planeswalkers have loyalty.
         let cmc = fuzz_weighted(rng, &[(0u8, 1), (1, 3), (2, 7), (3, 8), (4, 6), (5, 4), (6, 2), (7, 1), (8, 1)]);
-        card.cmc = Some(cmc);
+        // Every 17th card is a half-mana card ({HW}, as Little Girl is). Assigned from the card
+        // index rather than by an rng draw for the same reason `card_layout_id` above is: a draw
+        // here would shift the stream and change every fuzz store in the suite. The point is that
+        // the differential assertions -- which compare the routed pipeline against the trusted
+        // per-printing `FilterExpr::matches` scan -- run over a store where the numeric index, the
+        // cmc bit planes and the arith-tuple postings all have to agree about a value that is not
+        // an integer, on every seed, not only in the dedicated tests below.
+        card.cmc = Some(f32::from(cmc) + if i % 17 == 0 { 0.5 } else { 0.0 });
         card.edhrec_rank = Some(rng.random_range(1..=30_000u32)); // distinct-ish, gives the sort keys something to order
         // creature 55% / planeswalker 6% / neither 39%. Planeswalkers are over-represented vs the
         // corpus's ~1% so loyalty predicates actually match something under the fuzzer's small stores.
@@ -2463,9 +2470,9 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
     data.indexes.legal_divergent = build_divergent_ids(&data.cards);
     data.indexes.sort_perms = build_sort_permutations(&data.cards);
-    data.indexes.cmc = build_numeric_index(&data.cards, |c| c.cmc.map(i16::from));
-    data.indexes.power = build_numeric_index(&data.cards, |c| c.creature_power.map(i16::from));
-    data.indexes.toughness = build_numeric_index(&data.cards, |c| c.creature_toughness.map(i16::from));
+    data.indexes.cmc = build_numeric_index(&data.cards, |c| c.cmc);
+    data.indexes.power = build_numeric_index(&data.cards, |c| c.creature_power.map(f32::from));
+    data.indexes.toughness = build_numeric_index(&data.cards, |c| c.creature_toughness.map(f32::from));
     // #743 arith-tuple postings — load-bearing like the numeric indexes above: an unbuilt index
     // (n_cards mismatch) makes arith_tuple_narrow decline, so building it here is what actually
     // exercises the new positive/negated narrowing through run_query in fuzz_row_identity_matches_reference.
@@ -6370,7 +6377,7 @@ fn bench_checked_vs_unchecked_access() {
         card.oracle_text_id = interner.intern(oracle.clone());
         card.oracle_text_lower_id = interner.intern(oracle.to_lowercase());
         card.card_keywords = vocab_ids(&mut vocab, &[words[i % 10]]);
-        card.cmc = Some((i % 8) as u8);
+        card.cmc = Some((i % 8) as f32);
         offsets.push(printings.len() as u32);
         for k in 0..PRINTINGS_PER_CARD {
             let flavor = format!("Flavor text for printing {i}-{k}, roughly the length of a real flavor quote.");
@@ -6393,9 +6400,9 @@ fn bench_checked_vs_unchecked_access() {
         name_trigram:   build_trigram_index(&cards, |c| c.card_name_folded.as_str()),
         name_unigrams:  build_name_unigram_index(&cards),
         oracle_trigram: build_oracle_text_index(&cards, &strings),
-        cmc:            build_numeric_index(&cards, |c| c.cmc.map(|v| v as i16)),
-        power:          build_numeric_index(&cards, |c| c.creature_power.map(|v| v as i16)),
-        toughness:      build_numeric_index(&cards, |c| c.creature_toughness.map(|v| v as i16)),
+        cmc:            build_numeric_index(&cards, |c| c.cmc),
+        power:          build_numeric_index(&cards, |c| c.creature_power.map(f32::from)),
+        toughness:      build_numeric_index(&cards, |c| c.creature_toughness.map(f32::from)),
         rarity:         build_rarity_index(&printings, &offsets),
         subtypes:       build_hybrid_tag_index(&cards, &vocab.strings, |c| &c.card_subtypes),
         keywords:       build_hybrid_tag_index(&cards, &vocab.strings, |c| &c.card_keywords),
@@ -6812,7 +6819,7 @@ fn all_match_promotion_correct_for_card_space_exact_predicate() {
     let mut card1 = stub_card(2, TYPE_CREATURE, &[], &mut vocab);
     card1.creature_power = Some(1);
     let mut data = store_of(vec![card0, card1], &[2, 3], vocab);
-    data.indexes.power = build_numeric_index(&data.cards, |c| c.creature_power.map(|v| v as i16));
+    data.indexes.power = build_numeric_index(&data.cards, |c| c.creature_power.map(f32::from));
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
@@ -6845,19 +6852,19 @@ fn all_match_promotion_correct_for_card_space_exact_predicate() {
 fn tie_break_fixture() -> (Vec<OracleCard>, VocabInterner) {
     let mut vocab = VocabInterner::new();
     let mut card0 = stub_card(1, TYPE_CREATURE, &[], &mut vocab); // cmc=3, edhrec=10
-    card0.cmc = Some(3);
+    card0.cmc = Some(3.0);
     card0.edhrec_rank = Some(10);
     let mut card1 = stub_card(2, TYPE_CREATURE, &[], &mut vocab); // cmc=3, edhrec=5 (lowest in the tie)
-    card1.cmc = Some(3);
+    card1.cmc = Some(3.0);
     card1.edhrec_rank = Some(5);
     let mut card2 = stub_card(3, TYPE_CREATURE, &[], &mut vocab); // cmc=3, edhrec=20 (highest in the tie)
-    card2.cmc = Some(3);
+    card2.cmc = Some(3.0);
     card2.edhrec_rank = Some(20);
     let mut card3 = stub_card(4, TYPE_CREATURE, &[], &mut vocab); // cmc=1
-    card3.cmc = Some(1);
+    card3.cmc = Some(1.0);
     card3.edhrec_rank = Some(1);
     let mut card4 = stub_card(5, TYPE_CREATURE, &[], &mut vocab); // cmc=5
-    card4.cmc = Some(5);
+    card4.cmc = Some(5.0);
     card4.edhrec_rank = Some(1);
     (vec![card0, card1, card2, card3, card4], vocab)
 }
@@ -7014,7 +7021,7 @@ fn streamed_selection_matches_gathered() {
         let mut cards = Vec::with_capacity(N);
         for i in 0..N {
             let mut c = stub_card((i + 1) as u128, TYPE_CREATURE, &[], &mut vocab);
-            c.cmc = Some((i % 8) as u8);
+            c.cmc = Some((i % 8) as f32);
             c.edhrec_rank = Some(((i * 37) % N) as u32 + 1); // distinct, shuffled
             if i % 11 == 0 {
                 c.edhrec_rank = None; // a null block, ordered by canonical secondary
@@ -7108,7 +7115,7 @@ fn streamed_walk_bounds_itself_by_the_sort_column_predicate() {
         // The anti-correlation: cmc 0 for the prefix, MATCH_CMC for the tail, so the ascending cmc
         // permutation puts every match last and the descending one puts every match first. One
         // fixture then covers both "the seek skips almost everything" and "the seek is a no-op".
-        c.cmc = Some(if i < PREFIX { 0 } else { MATCH_CMC });
+        c.cmc = Some(if i < PREFIX { 0.0 } else { f32::from(MATCH_CMC) });
         c.edhrec_rank = Some(((i * 37) % N) as u32 + 1); // distinct, shuffled: no full-key tie blocks
         cards.push(c);
     }
@@ -7272,9 +7279,9 @@ fn sort_permutations_nulls_last_both_directions() {
         stub_card(2, TYPE_CREATURE, &[], &mut vocab),
         stub_card(3, TYPE_CREATURE, &[], &mut vocab),
     ];
-    cards[0].cmc = Some(5);
+    cards[0].cmc = Some(5.0);
     cards[1].cmc = None;
-    cards[2].cmc = Some(1);
+    cards[2].cmc = Some(1.0);
     let data = store_of(cards, &[1, 1, 1], vocab);
     let perms = build_sort_permutations(&data.cards);
     assert_eq!(perms.cmc[0], vec![2, 0, 1], "asc: 1, 5, null");
@@ -8488,7 +8495,7 @@ fn usd_inside_arithmetic_evaluates_in_dollars_not_cents() {
 fn usd_compared_directly_against_another_field_evaluates_in_dollars() {
     let mut vocab = VocabInterner::new();
     let mut card = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
-    card.cmc = Some(3);
+    card.cmc = Some(3.0);
     let mut data = store_of(vec![card], &[1], vocab);
     data.printings[0].price_usd = Some(200); // $2.00
     data.indexes.price_usd = build_printing_value_index(&data.printings, &data.cards, &data.offsets, |p| p.price_usd);
@@ -8514,14 +8521,14 @@ fn usd_compared_directly_against_another_field_evaluates_in_dollars() {
 fn numeric_plane_fixture_store() -> CardData {
     let mut vocab = VocabInterner::new();
     // (cmc, power, toughness); card 0 is a noncreature (power/toughness absent).
-    let specs: &[(u8, Option<i8>, Option<i8>)] = &[
-        (0, None, None),
-        (4, Some(-1), Some(-1)),
-        (12, Some(12), Some(12)),
-        (13, Some(15), Some(20)),
-        (14, Some(16), Some(25)),
-        (6, Some(3), Some(3)),
-        (3, Some(0), Some(0)),
+    let specs: &[(f32, Option<i8>, Option<i8>)] = &[
+        (0.0, None, None),
+        (4.0, Some(-1), Some(-1)),
+        (12.0, Some(12), Some(12)),
+        (13.0, Some(15), Some(20)),
+        (14.0, Some(16), Some(25)),
+        (6.0, Some(3), Some(3)),
+        (3.0, Some(0), Some(0)),
     ];
     let cards = specs
         .iter()
@@ -8617,6 +8624,145 @@ fn numeric_plane_boundary_inclusion_and_decline() {
     assert!(compile_plane(&cmp(NumField::Cmc, CmpOp::Eq, 13.0), bounds, words).is_none());
     assert!(compile_plane(&cmp(NumField::Toughness, CmpOp::Eq, 20.0), bounds, words).is_none());
     assert!(compile_plane(&cmp(NumField::Toughness, CmpOp::Lt, 22.0), bounds, words).is_none());
+}
+
+// ─── Fractional mana value ─────────────────────────────────────────────────────
+// Scryfall types cmc Decimal and means it: the half-mana symbol {HW} gives Little Girl
+// (Unhinged) a mana value of exactly 0.5 -- checked against the live API on 2026-08-12,
+// /cards/named?exact=Little+Girl answers `"mana_cost":"{HW}"`, `"cmc":0.5`. It is the
+// only card in the entire Scryfall corpus with a fractional mana value (searching
+// `cmc<1 cmc>0` with extras and variations included returns exactly one card), and the
+// corpus filter keeps it out of the dataset today -- api/card_processing.py drops
+// set_type == "funny", and Unhinged is legal nowhere so the legality filter above it
+// would drop the card anyway.
+//
+// These tests are therefore about the value being REPRESENTABLE, not about importing it.
+// Every one of them fails when cmc is an integer, and fails in the way that matters: 0.5
+// truncates to 0, so `cmc=0` starts matching a half-mana card and `cmc=0.5` matches
+// nothing at all.
+
+/// Cards spanning the three ways an integer cmc loses a fraction: a 0.5 against a 0 it
+/// must stay distinct from, a fraction in the middle of the plane interior (2.5), and a
+/// fraction in the plane HIGH TAIL (16.5, past the [0,12] interior) where the bucket
+/// keeps only [min,max] and a rounded bound would answer `cmc>16` wrongly.
+fn fractional_cmc_fixture_store() -> CardData {
+    let mut vocab = VocabInterner::new();
+    let cards: Vec<OracleCard> = FRACTIONAL_CMCS
+        .iter()
+        .enumerate()
+        .map(|(i, &cmc)| {
+            let mut c = stub_card(i as u128 + 1, TYPE_CREATURE, &[], &mut vocab);
+            c.cmc = Some(cmc);
+            c
+        })
+        .collect();
+    let mut data = store_of(cards, &[1usize; FRACTIONAL_CMCS.len()], vocab);
+    // store_of builds planes and sort permutations but leaves the postings indexes
+    // Default::default(); these two are the ones a cmc predicate can route through.
+    data.indexes.cmc = build_numeric_index(&data.cards, |c| c.cmc);
+    data.indexes.arith_tuple = build_arith_tuple_index(&data.cards);
+    data
+}
+
+/// Ascending, so card id == position in this array is also the expected cmc sort order.
+const FRACTIONAL_CMCS: [f32; 6] = [0.0, 0.5, 1.0, 2.5, 3.0, 16.5];
+
+/// End to end through `run_query`: the predicate the truncation would break in each
+/// direction. `cmc=0.5` must find the half-mana card, and `cmc=0` must NOT -- the second
+/// half is the one an integer store gets wrong while still looking like it works.
+#[test]
+fn fractional_cmc_is_not_truncated_to_its_floor() {
+    let data = fractional_cmc_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let cases: [(CmpOp, f64, usize, &str); 8] = [
+        (CmpOp::Eq, 0.5, 1, "cmc=0.5 finds the half-mana card"),
+        (CmpOp::Eq, 0.0, 1, "cmc=0 finds ONLY the zero-cost card, not the half-mana one"),
+        (CmpOp::Eq, 2.5, 1, "an interior fraction is its own value, not 2"),
+        (CmpOp::Lt, 1.0, 2, "cmc<1 is {0, 0.5}"),
+        (CmpOp::Le, 0.0, 1, "cmc<=0 is {0} — 0.5 is strictly greater"),
+        (CmpOp::Ge, 0.5, 5, "cmc>=0.5 is everything but the zero-cost card"),
+        (CmpOp::Gt, 16.0, 1, "cmc>16 finds the 16.5 card the high-tail bucket holds"),
+        (CmpOp::Le, 16.0, 5, "cmc<=16 excludes it, from the same bucket bounds"),
+    ];
+    for (op, val, want, label) in cases {
+        let mut filter = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op, rhs: NumExpr::Const(val) };
+        let (total, _) = run_query(&QueryCtx::from(archived), &mut filter, None, "card", "default", "edhrec", "asc", 100, 0);
+        assert_eq!(total, want, "{label}");
+    }
+}
+
+/// The plane path is allowed to decline a fractional threshold (the hi bucket now
+/// stretches down past the interior, so `bucket_verdict` says Ambiguous more often), but
+/// it is never allowed to DISAGREE. Same bit-for-bit parity contract as
+/// `numeric_plane_parity_interior_and_tails`, over thresholds on and off the integer
+/// lattice.
+#[test]
+fn fractional_cmc_plane_compilation_agrees_with_the_filter() {
+    let data = fractional_cmc_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let mut bitmap: Vec<u64> = Vec::new();
+    let mut compiled = 0;
+    let thresholds: [f64; 9] = [0.0, 0.25, 0.5, 0.75, 1.0, 2.5, 3.0, 16.0, 16.5];
+    for op in [CmpOp::Eq, CmpOp::Ne, CmpOp::Lt, CmpOp::Le, CmpOp::Gt, CmpOp::Ge] {
+        for &t in &thresholds {
+            let f = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op, rhs: NumExpr::Const(t) };
+            let Some(pe) = compile_plane(&f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words) else { continue };
+            compiled += 1;
+            eval_planes(&pe, &archived.indexes.planes, &mut bitmap);
+            for (cid, card) in archived.cards.iter().enumerate() {
+                let want = f.eval_card(card, &archived.strings) == Tri::True;
+                assert_eq!(bitmap_contains(&bitmap, cid as u32), want, "cmc {op:?} {t}: plane disagrees at card {cid}");
+            }
+        }
+    }
+    // Parity is vacuous if nothing compiled. A fractional card in the store widens the hi
+    // bucket's observed range down to 0.5, so more thresholds decline than before — but
+    // "declines everything" would be a silent loss of the whole plane fast path for cmc,
+    // not a correctness matter the assertions above could ever notice.
+    assert!(compiled > 0, "every cmc threshold declined — the plane path for cmc is gone, not just narrower");
+}
+
+/// A half step is a real position in the ordering, not a tie with its floor. Under an
+/// integer cmc the first two cards both read 0 and their order would fall to the sort's
+/// secondary key instead.
+#[test]
+fn fractional_cmc_orders_between_its_integer_neighbours() {
+    let data = fractional_cmc_fixture_store();
+    let perms = build_sort_permutations(&data.cards);
+    assert_eq!(perms.cmc[0], vec![0, 1, 2, 3, 4, 5], "asc: 0, 0.5, 1, 2.5, 3, 16.5");
+    assert_eq!(perms.cmc[1], vec![5, 4, 3, 2, 1, 0], "desc: the exact reverse — no ties to preserve");
+}
+
+/// The arith-tuple route (#743) interns cmc into a HashMap key, which is why the key
+/// holds `f32::to_bits` rather than an f32. Two cards a half apart must intern as two
+/// combinations and evaluate as two values: `cmc*2 = 1` is Little Girl's row and nobody
+/// else's, and it reaches the tuple index rather than the dedicated bare-compare arm.
+#[test]
+fn fractional_cmc_survives_the_arith_tuple_route() {
+    let data = fractional_cmc_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    assert_eq!(
+        archived.indexes.arith_tuple.keys.len(),
+        FRACTIONAL_CMCS.len(),
+        "each distinct cmc must intern as its own combination — a truncating key would collapse 0/0.5 and 2.5/3"
+    );
+
+    let doubled = || FilterExpr::NumericCmp {
+        lhs: NumExpr::Arith(Box::new(NumExpr::Field(NumField::Cmc)), ArithOp::Mul, Box::new(NumExpr::Const(2.0))),
+        op: CmpOp::Eq,
+        rhs: NumExpr::Const(1.0),
+    };
+    assert!(is_arith_tuple_route(&doubled()), "cmc*2=1 is an arith expression over card fields — the tuple route owns it");
+    let mut filter = doubled();
+    let (total, page) = run_query(&QueryCtx::from(archived), &mut filter, None, "card", "default", "edhrec", "asc", 100, 0);
+    assert_eq!(total, 1, "cmc*2=1 is exactly the half-mana card");
+    assert_eq!(u128::from(page[0].0.oracle_id), 2, "…and it is card 2, the one with cmc 0.5");
 }
 
 // Ne is declined unconditionally, matching numeric_candidates' own choice
@@ -10634,7 +10780,7 @@ fn printing_range_fixture(seed: u64, n_cards: usize) -> CardData {
     for i in 0..n_cards {
         let mut c = stub_card(i as u128, 0, &[], &mut vocab);
         c.edhrec_rank = Some(ranks[i]);
-        c.cmc = Some(rng.random_range(0..8u8));
+        c.cmc = Some(f32::from(rng.random_range(0..8u8)));
         cards.push(c);
     }
     let counts: Vec<usize> = (0..n_cards).map(|_| rng.random_range(1..=4)).collect();
@@ -11344,7 +11490,7 @@ fn arith_tuple_key_budget_catches_a_blown_domain() {
     let cards: Vec<OracleCard> = (0..ARITH_TUPLE_BLOWUP_CARDS)
         .map(|i| {
             let mut c = stub_card(i as u128, TYPE_CREATURE, &[], &mut vocab);
-            c.cmc = Some((i % 251) as u8);
+            c.cmc = Some((i % 251) as f32);
             c.creature_power = Some((i / 251) as i8);
             c
         })

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2266,10 +2266,18 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
         // corpus's ~1% so loyalty predicates actually match something under the fuzzer's small stores.
         match fuzz_weighted(rng, &[(0u8, 55), (1, 6), (2, 39)]) {
             0 => {
-                let power = (i32::from(cmc) - 1 + rng.random_range(-1..=2)).clamp(0, 12) as i8;
-                let toughness = (i32::from(power) + rng.random_range(-1..=2)).clamp(1, 13) as i8;
-                card.creature_power = Some(power);
-                card.creature_toughness = Some(toughness);
+                let power = (i32::from(cmc) - 1 + rng.random_range(-1..=2)).clamp(0, 12);
+                let toughness = (power + rng.random_range(-1..=2)).clamp(1, 13);
+                // A HALF on a slice of the creatures, the same way cmc gets one above and for the
+                // same reason: the corpus's eleven printed halves are why these columns are f32,
+                // and a fuzzer that only ever emits integers cannot falsify the agreement between
+                // the numeric index, the bit planes and the arith-tuple postings for a value that
+                // sits BETWEEN two interior planes. Keyed off the card index, not an rng draw, so
+                // the stream — and every existing fuzz store in the suite — is unchanged. 13 and
+                // cmc's 17 are coprime, so some cards get a fractional cmc AND fractional stats.
+                let half = if i % 13 == 0 { 0.5 } else { 0.0 };
+                card.creature_power = Some(power as f32 + half);
+                card.creature_toughness = Some(toughness as f32 + half);
                 // Subtypes correlate with the creature type (real data: creature subtypes only
                 // appear on creatures, modulo the rare kindred/tribal tail we don't model). Set the
                 // bit so `t:creature` and `type:human` co-select. 1-2 subtypes, biased frequency.
@@ -2471,8 +2479,8 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     data.indexes.legal_divergent = build_divergent_ids(&data.cards);
     data.indexes.sort_perms = build_sort_permutations(&data.cards);
     data.indexes.cmc = build_numeric_index(&data.cards, |c| c.cmc);
-    data.indexes.power = build_numeric_index(&data.cards, |c| c.creature_power.map(f32::from));
-    data.indexes.toughness = build_numeric_index(&data.cards, |c| c.creature_toughness.map(f32::from));
+    data.indexes.power = build_numeric_index(&data.cards, |c| c.creature_power);
+    data.indexes.toughness = build_numeric_index(&data.cards, |c| c.creature_toughness);
     // #743 arith-tuple postings — load-bearing like the numeric indexes above: an unbuilt index
     // (n_cards mismatch) makes arith_tuple_narrow decline, so building it here is what actually
     // exercises the new positive/negated narrowing through run_query in fuzz_row_identity_matches_reference.
@@ -6401,8 +6409,8 @@ fn bench_checked_vs_unchecked_access() {
         name_unigrams:  build_name_unigram_index(&cards),
         oracle_trigram: build_oracle_text_index(&cards, &strings),
         cmc:            build_numeric_index(&cards, |c| c.cmc),
-        power:          build_numeric_index(&cards, |c| c.creature_power.map(f32::from)),
-        toughness:      build_numeric_index(&cards, |c| c.creature_toughness.map(f32::from)),
+        power:          build_numeric_index(&cards, |c| c.creature_power),
+        toughness:      build_numeric_index(&cards, |c| c.creature_toughness),
         rarity:         build_rarity_index(&printings, &offsets),
         subtypes:       build_hybrid_tag_index(&cards, &vocab.strings, |c| &c.card_subtypes),
         keywords:       build_hybrid_tag_index(&cards, &vocab.strings, |c| &c.card_keywords),
@@ -6815,11 +6823,11 @@ fn all_match_promotion_never_fires_for_printing_space_tight_results() {
 fn all_match_promotion_correct_for_card_space_exact_predicate() {
     let mut vocab = VocabInterner::new();
     let mut card0 = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
-    card0.creature_power = Some(5);
+    card0.creature_power = Some(5.0);
     let mut card1 = stub_card(2, TYPE_CREATURE, &[], &mut vocab);
-    card1.creature_power = Some(1);
+    card1.creature_power = Some(1.0);
     let mut data = store_of(vec![card0, card1], &[2, 3], vocab);
-    data.indexes.power = build_numeric_index(&data.cards, |c| c.creature_power.map(f32::from));
+    data.indexes.power = build_numeric_index(&data.cards, |c| c.creature_power);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
@@ -8468,7 +8476,7 @@ fn run_query_plane_path_parity() {
 fn usd_inside_arithmetic_evaluates_in_dollars_not_cents() {
     let mut vocab = VocabInterner::new();
     let mut card = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
-    card.creature_power = Some(52);
+    card.creature_power = Some(52.0);
     let mut data = store_of(vec![card], &[1], vocab);
     data.printings[0].price_usd = Some(5000); // $50.00
     data.indexes.price_usd = build_printing_value_index(&data.printings, &data.cards, &data.offsets, |p| p.price_usd);
@@ -8521,14 +8529,18 @@ fn usd_compared_directly_against_another_field_evaluates_in_dollars() {
 fn numeric_plane_fixture_store() -> CardData {
     let mut vocab = VocabInterner::new();
     // (cmc, power, toughness); card 0 is a noncreature (power/toughness absent).
-    let specs: &[(f32, Option<i8>, Option<i8>)] = &[
+    // NO FRACTIONAL ROW HERE, deliberately. The stat columns can hold one now, but an off-lattice
+    // value widens a bucket's observed range for the WHOLE fixture and would make `compile_plane`
+    // decline thresholds these tests exist to prove it accepts. Fractions get their own store,
+    // exactly as cmc's do — see `fractional_stat_fixture_store`.
+    let specs: &[(f32, Option<f32>, Option<f32>)] = &[
         (0.0, None, None),
-        (4.0, Some(-1), Some(-1)),
-        (12.0, Some(12), Some(12)),
-        (13.0, Some(15), Some(20)),
-        (14.0, Some(16), Some(25)),
-        (6.0, Some(3), Some(3)),
-        (3.0, Some(0), Some(0)),
+        (4.0, Some(-1.0), Some(-1.0)),
+        (12.0, Some(12.0), Some(12.0)),
+        (13.0, Some(15.0), Some(20.0)),
+        (14.0, Some(16.0), Some(25.0)),
+        (6.0, Some(3.0), Some(3.0)),
+        (3.0, Some(0.0), Some(0.0)),
     ];
     let cards = specs
         .iter()
@@ -8763,6 +8775,158 @@ fn fractional_cmc_survives_the_arith_tuple_route() {
     let (total, page) = run_query(&QueryCtx::from(archived), &mut filter, None, "card", "default", "edhrec", "asc", 100, 0);
     assert_eq!(total, 1, "cmc*2=1 is exactly the half-mana card");
     assert_eq!(u128::from(page[0].0.oracle_id), 2, "…and it is card 2, the one with cmc 0.5");
+}
+
+// ─── Fractional power and toughness ────────────────────────────────────────────
+// The cmc block above, one column family over. Scryfall types power and toughness as STRINGS,
+// and eleven Unhinged cards print a HALF in them -- checked against the live API on 2026-08-17,
+// /cards/named?exact=Little+Girl answers `"power":".5"`, `"toughness":".5"`, and
+// `(power=.5 or power=1.5 or power=2.5 or power=3.5 or toughness=.5 or toughness=1.5 or
+// toughness=2.5 or toughness=3.5) include:extras` returns exactly those eleven: Little Girl
+// .5/.5, Fraction Jackson 1/1.5, Smart Ass 2.5/1, Stone-Cold Basilisk 2.5/5, Vile Bile 2.5/2.5,
+// Assquatch 3.5/3.5, Bad Ass 3.5/1, Dumb Ass 3.5/2, Cheap Ass 1/3.5, Fat Ass 2/3.5,
+// Cardpecker 1.5/1.
+//
+// As with cmc, these tests are about the value being REPRESENTABLE, not about importing it:
+// every one of those cards is in a funny set, which api/card_processing.py still drops. And the
+// failure an integer column leaves has the same asymmetry -- `power=2.5` finding nothing is
+// visible, `power=2` silently gaining a 2.5 card is not. Note the DIRECTION, which is what makes
+// truncation easy to misdiagnose: it cannot LOSE a row from `toughness<1`, because 0 satisfies
+// that predicate exactly as 0.5 does. It over-catches the floor it rounds onto.
+
+/// Ascending by power, so card id == position in this array is also the expected `order=power`
+/// sort order. The negatives are as real as the halves: Char-Rumbler and Spinal Parasite print a
+/// -1 power, which is why the plane layout carries a low-tail bucket for these two columns.
+const FRACTIONAL_STATS: [(f32, f32); 6] = [(-1.0, -1.0), (0.0, 0.5), (0.5, 0.5), (1.5, 1.0), (2.5, 3.5), (3.5, 2.0)];
+
+/// A store whose power/toughness take the fractional shape, kept SEPARATE from
+/// `numeric_plane_fixture_store` for the reason recorded there: one off-lattice value widens a
+/// bucket's observed range for the whole fixture, so mixing the two would weaken both sets of
+/// assertions. Same reason `fractional_cmc_fixture_store` stands apart.
+fn fractional_stat_fixture_store() -> CardData {
+    let mut vocab = VocabInterner::new();
+    let cards: Vec<OracleCard> = FRACTIONAL_STATS
+        .iter()
+        .enumerate()
+        .map(|(i, &(power, toughness))| {
+            let mut c = stub_card(i as u128 + 1, TYPE_CREATURE, &[], &mut vocab);
+            c.creature_power = Some(power);
+            c.creature_toughness = Some(toughness);
+            c
+        })
+        .collect();
+    let mut data = store_of(cards, &[1usize; FRACTIONAL_STATS.len()], vocab);
+    // store_of builds planes and sort permutations but leaves the postings indexes
+    // Default::default(); these three are the ones a power/toughness predicate can route through.
+    data.indexes.power = build_numeric_index(&data.cards, |c| c.creature_power);
+    data.indexes.toughness = build_numeric_index(&data.cards, |c| c.creature_toughness);
+    data.indexes.arith_tuple = build_arith_tuple_index(&data.cards);
+    data
+}
+
+/// End to end through `run_query`, in BOTH directions. `power=0.5` must find the half-power card,
+/// and `power=0` must NOT -- the second is the half an integer store gets wrong while still
+/// looking like it works.
+#[test]
+fn a_fractional_stat_is_not_truncated_to_its_floor() {
+    let data = fractional_stat_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let cases: [(NumField, CmpOp, f64, usize, &str); 8] = [
+        (NumField::Power, CmpOp::Eq, 0.5, 1, "power=0.5 finds the half-power card"),
+        (NumField::Power, CmpOp::Eq, 0.0, 1, "power=0 finds ONLY the zero card, not the 0.5 one"),
+        (NumField::Power, CmpOp::Eq, 2.0, 0, "power=2 matches nothing: 2.5 is not 2"),
+        (NumField::Power, CmpOp::Eq, 3.0, 0, "power=3 matches nothing: 3.5 is not 3"),
+        (NumField::Toughness, CmpOp::Eq, 0.0, 0, "toughness=0 matches nothing: both 0.5s stay 0.5"),
+        (NumField::Toughness, CmpOp::Lt, 1.0, 3, "toughness<1 is the -1 and BOTH halves"),
+        (NumField::Power, CmpOp::Gt, 2.0, 2, "power>2 is 2.5 and 3.5"),
+        (NumField::Power, CmpOp::Le, -1.0, 1, "the negative end is unmoved by any of this"),
+    ];
+    for (field, op, rhs, want, why) in cases {
+        let mut filter = FilterExpr::NumericCmp { lhs: NumExpr::Field(field), op, rhs: NumExpr::Const(rhs) };
+        let (total, _) = run_query(&QueryCtx::from(archived), &mut filter, None, "card", "default", "edhrec", "asc", 100, 0);
+        assert_eq!(total, want, "{why}");
+    }
+}
+
+/// The plane path is allowed to decline a fractional threshold (an off-lattice value stretches a
+/// bucket's observed range, so `bucket_verdict` says Ambiguous more often), but it is never
+/// allowed to DISAGREE. Same bit-for-bit parity contract as
+/// `fractional_cmc_plane_compilation_agrees_with_the_filter`, over the two columns that just
+/// changed type -- and here a fraction can be NEGATIVE, so the lo bucket is exercised too.
+#[test]
+fn fractional_stat_plane_compilation_agrees_with_the_filter() {
+    let data = fractional_stat_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let mut bitmap: Vec<u64> = Vec::new();
+    let mut compiled = 0;
+    let thresholds: [f64; 9] = [-1.5, -1.0, 0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.5];
+    for (label, field) in [("power", NumField::Power), ("toughness", NumField::Toughness)] {
+        for op in [CmpOp::Eq, CmpOp::Ne, CmpOp::Lt, CmpOp::Le, CmpOp::Gt, CmpOp::Ge] {
+            for &t in &thresholds {
+                let f = FilterExpr::NumericCmp { lhs: NumExpr::Field(field), op, rhs: NumExpr::Const(t) };
+                let Some(pe) = compile_plane(&f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words) else {
+                    continue;
+                };
+                compiled += 1;
+                eval_planes(&pe, &archived.indexes.planes, &mut bitmap);
+                for (cid, card) in archived.cards.iter().enumerate() {
+                    let want = f.eval_card(card, &archived.strings) == Tri::True;
+                    assert_eq!(bitmap_contains(&bitmap, cid as u32), want, "{label} {op:?} {t}: plane disagrees at card {cid}");
+                }
+            }
+        }
+    }
+    // Parity is vacuous if nothing compiled -- see the cmc twin's note. "Declines everything"
+    // would be a silent loss of the whole plane fast path for these two columns, which none of
+    // the assertions above could ever notice.
+    assert!(compiled > 0, "every stat threshold declined -- the plane path for power/toughness is gone, not just narrower");
+}
+
+/// The arith-tuple route (#743) interns power and toughness into a HashMap key, which is why the
+/// key holds `f32::to_bits` for them rather than the values. A truncating key would collapse
+/// (0.5, 0.5) onto (0, 0) and lose a combination; a key that failed to normalize -0.0 would
+/// invent one.
+#[test]
+fn fractional_stats_survive_the_arith_tuple_route() {
+    let data = fractional_stat_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    assert_eq!(
+        archived.indexes.arith_tuple.keys.len(),
+        FRACTIONAL_STATS.len(),
+        "each distinct (power, toughness) pair must intern as its own combination -- a truncating key would collapse (0, 0.5) and (0.5, 0.5)"
+    );
+
+    // `power>toughness` is true for exactly (1.5, 1.0) and (3.5, 2.0). Under truncation the first
+    // reads (1, 1) and ties, which is the whole failure in one predicate.
+    let field_vs_field = || FilterExpr::NumericCmp {
+        lhs: NumExpr::Field(NumField::Power),
+        op: CmpOp::Gt,
+        rhs: NumExpr::Field(NumField::Toughness),
+    };
+    assert!(is_arith_tuple_route(&field_vs_field()), "power>toughness is a field-vs-field compare -- the tuple route owns it");
+    let mut filter = field_vs_field();
+    let (total, _) = run_query(&QueryCtx::from(archived), &mut filter, None, "card", "default", "edhrec", "asc", 100, 0);
+    assert_eq!(total, 2, "power>toughness is the 1.5/1 and 3.5/2 cards; truncation would tie the first");
+}
+
+/// A half step is a real position in the ordering, not a tie with its floor -- the sort
+/// permutation's own view of the question `fractional_cmc_orders_between_its_integer_neighbours`
+/// asks of cmc. Under an integer column cards 1 and 2 both read 0 and their order would fall to
+/// the sort's secondary key instead.
+#[test]
+fn fractional_stats_order_between_their_integer_neighbours() {
+    let data = fractional_stat_fixture_store();
+    let perms = build_sort_permutations(&data.cards);
+    let want: Vec<u32> = (0..FRACTIONAL_STATS.len() as u32).collect();
+    assert_eq!(perms.power[0], want, "asc: -1, 0, 0.5, 1.5, 2.5, 3.5 -- FRACTIONAL_STATS is in power order");
+    let reversed: Vec<u32> = want.iter().rev().copied().collect();
+    assert_eq!(perms.power[1], reversed, "desc: the exact reverse -- no ties to preserve");
 }
 
 // Ne is declined unconditionally, matching numeric_candidates' own choice
@@ -11491,7 +11655,7 @@ fn arith_tuple_key_budget_catches_a_blown_domain() {
         .map(|i| {
             let mut c = stub_card(i as u128, TYPE_CREATURE, &[], &mut vocab);
             c.cmc = Some((i % 251) as f32);
-            c.creature_power = Some((i / 251) as i8);
+            c.creature_power = Some((i / 251) as f32);
             c
         })
         .collect();


### PR DESCRIPTION
Scryfall types `cmc` Decimal, and one card in the corpus proves it is not a
formality:

```
$ curl -s 'https://api.scryfall.com/cards/named?exact=Little+Girl'
  "mana_cost": "{HW}",
  "cmc": 0.5,
  "power": ".5",
  "toughness": ".5",
```

`{HW}` is half a white mana. Little Girl's mana value is 0.5, and it is the
only card in all of Scryfall that has a fractional one -- `cmc<1 cmc>0` with
extras and variations included returns exactly one result. (Its power and
toughness are STRINGS in Scryfall's own schema and are already stored as text
here, so they need nothing.)

Every layer under `cmc` was integer-typed, and each rounded the value the same
way:

- `api/db/2025-09-29-great-reset.sql:181` -- `cmc integer`
- `api/card_processing.py` -- `maybe_int`, which is `int(float(val))`
- `card_engine`'s `OracleCard.cmc: Option<u8>`, carrying the comment
  "Un-set cards have fractional cmc, but we don't load those into the dataset"

That comment was true and is what this retires. It reasoned from the corpus to
a type, and the two failure modes it left behind are not symmetric: `cmc=0.5`
finding nothing is visible, but `cmc=0` silently gaining a half-mana card is
not.

## Scope: capability, not corpus

**This does not start importing funny sets.** `preprocess_card` still drops
`set_type == "funny"`, and Little Girl would be dropped one line earlier
anyway, by the legality filter -- Unhinged is legal in no format. After this
change every row in the table is still integral, and no query answer over the
real corpus moves.

What changes is that the type is no longer the thing that would lose the
fraction. Nothing in the maintainer's notes asks for the funny sets, and
importing them is a corpus decision with its own consequences (legality,
`is:` tags, the fuzzy-name index) that has no business riding along with a
column type. The engine's own `mana_cost` sub-object has read cmc as an `f32`
since it was written; this makes the card field agree with it.

## Schema: `real`, not `numeric`

`numeric` is the type that matches "Decimal" as a word. `real` is the type that
matches the data:

- **Exact over the whole domain.** Every value Scryfall publishes is a whole
  number or a half step. Halves are exact in binary floating point, and
  integers are exact in f32 to 2^24 -- which covers even Gleemax, the corpus
  maximum at `{1000000}`, itself exactly representable.
- **Same 4 bytes as `integer`**, so neither the row nor the three btree
  indexes carrying cmc grow. `numeric` is variable-width and would widen all
  three for precision the domain never uses.
- **Same type the reader stores.** The engine holds cmc as f32; a `numeric`
  column would be exact in Postgres and then round on the way into the engine.
  `real` also arrives from psycopg as a Python float, straight into `opt_f32`,
  where `numeric` arrives as a `decimal.Decimal`.
- The schema already uses `real` for the three price columns.

## Engine: what an f32 cmc touches

`Option<u8>` -> `Option<f32>` on `OracleCard` is the small part. Three
accelerator structures were built on the field being an integer, and each one
was a way to get a wrong answer, not a slow one:

**The numeric index** was `Vec<(i16, u32)>`, and `numeric_candidates` opened
with `if val.fract() != 0.0 { return Some(Vec::new()) }` -- sound while every
key was an integer, and precisely the line that answers `cmc=0.5` with nothing
once one isn't. The key is `f32` now and the shortcut is gone; a threshold no
card holds produces an empty range on its own. This costs no memory: `(i16,
u32)` was already padded to 8 bytes for the u32's alignment, and `(f32, u32)`
is 8 bytes with none. `estimator.rs`'s `numeric_count` had a copy of the same
shortcut and gets the same treatment -- an estimate of 0 for a predicate that
matches would misplan the query.

**The arith-tuple key** (#743) is a `HashMap` key, and f32 is neither `Eq` nor
`Hash`. It holds `f32::to_bits` instead. Bit equality and value equality differ
only at NaN and ±0.0, and neither reaches a mana value column.

**The bit planes** were the subtle one. The interior planes are a lattice of
single integer points -- there is a plane meaning "cmc == 0" and one meaning
"cmc == 1", and none that can hold 0.5. The old `v <= NUM_INTERIOR_HI` arm
would have put Little Girl on the "cmc == 0" plane, so `cmc=0` would match her
through the plane fast path while the index path said otherwise. Off-lattice
values now go to the hi bucket, which keeps only `[min, max]` and so declines
via `bucket_verdict` rather than guessing. `BucketBounds` had to widen to f32
with it, and not for tidiness: rounding an observation is unsound in one
direction, because a bucket holding only 16.5 whose max rounds to 16 reports
`cmc>16` FullyExcluded and drops the card that satisfies it.

The cost is that a store containing a fraction stretches the cmc hi bucket down
past the interior, so more thresholds resolve Ambiguous and fall back to the
index. On today's corpus -- no fractional card, and none coming -- nothing lands
there at all and the plane path is untouched.

## Archive format

`ARCHIVE_FORMAT_VERSION` 2026080601 -> 2026081201. The struct sizes in the
header do move here as it happens (`size_of::<AOracleCard>` measures 288 before
and 304 after), so an old store would be rejected regardless -- but only by luck
of the `OracleCard` change. The three index types are not measured by the header
at all, and a change confined to them would pass it. Reading an old store under
the new layout would reinterpret integer cmc bytes as float bits.

**Deployments need no action.** The archive is a derived cache, not durable
state: `get_mmap` rejects a header mismatch, treats the store as absent, and the
next reload rebuilds it from Postgres. The migration is the only thing that
touches real data.

## Query filters

`mv=0.5`, `mv<1` and `cmc>=0.5` must parse and compare correctly, and they
already did -- both parsers have always tokenized a literal with a decimal point
as a float, and `p_float_*` binding carried it through to SQL untouched. Nothing
tested it, which is worth fixing now rather than later: the storage change is
what makes those queries mean anything, so a future "cmc is an integer, coerce
it" shortcut on that path would become a silent regression instead of a no-op.
`api/parsing/tests/test_fractional_mana_value.py` pins it across both parsers
and all three aliases.

## Tests

Verified failing against the old behaviour, by reverting the source and
re-running: 3 of the 4 new Rust tests and 8 of the new Python tests fail, in
both directions -- `mv=0.5` finds nothing, and `mv=0` picks up the half-mana
card. The ones that still pass under the revert are the invariance checks
(a whole mana value stays whole) and the plane-parity check, whose job is the
soundness of the lattice change rather than detecting the rounding; that one
carries a `compiled > 0` assertion so it cannot pass vacuously by declining
everything.

The differential fuzzer now builds every 17th card as a half-mana card,
assigned from the card index rather than an rng draw so the stream -- and so
every existing fuzz store in the suite -- is unchanged. That puts a fractional
value under the row-identity, arith-tuple and force-plan differential
assertions on every seed, against the trusted per-printing scan.



---

# Follow-up in the same branch: a printed POWER is a half too

`b8f3b53` extends the change above from `cmc` to `creature_power` /
`creature_toughness`. It is carried here rather than opened separately because
the substrate this needs is the substrate the mana value change built:
`NumericIndex` is already `Vec<(f32, u32)>` with `numeric_candidates`'s
`val.fract()` shortcut removed, `BucketBounds` and `set_numeric_plane` are
already f32 with the whole-number condition on the interior lattice, and
`ArithTupleKey` already holds `cmc_bits`. Extending each from one column to
three is the same change to the same machinery.

## It is a DIFFERENT defect, not the same one restated

`cmc` was typed against Scryfall's own schema and typed wrong: Scryfall says
Decimal, the column said `integer`. Power and toughness are **strings** in
Scryfall's schema -- `creature_power_text` / `creature_toughness_text` hold them
verbatim -- and the numeric columns beside them are this project's own parse of
those strings. The parse was `maybe_int`, `int(float(val))`, and eleven cards
print a value it cannot hold:

```
$ curl -s 'https://api.scryfall.com/cards/named?exact=Little+Girl'
  "power": ".5",
  "toughness": ".5",
```

Little Girl `.5`/`.5`, Fraction Jackson `1`/`1.5`, Smart Ass `2.5`/`1`,
Stone-Cold Basilisk `2.5`/`5`, Vile Bile `2.5`/`2.5`, Assquatch `3.5`/`3.5`,
Bad Ass `3.5`/`1`, Dumb Ass `3.5`/`2`, Cheap Ass `1`/`3.5`, Fat Ass `2`/`3.5`,
Cardpecker `1.5`/`1` -- all Unhinged, and exactly those eleven. Checked against
the live API on 2026-08-17: `(power=.5 or power=1.5 or power=2.5 or power=3.5 or
toughness=.5 or toughness=1.5 or toughness=2.5 or toughness=3.5) include:extras`
returns 11.

## The failure direction, which is easy to get backwards

Truncation cannot make `toughness<1` **miss** a half-toughness card -- 0
satisfies that predicate exactly as 0.5 does. What it does is make
`toughness=0` and `power=2` **match** cards that print `.5` and `2.5`. The
rounding does not lose rows from a query, it adds them to the wrong one, and the
query it adds them to is the common one nobody would think to check. Same
asymmetry the mana value section describes, in the same direction: the visible
half (`power=2.5` finds nothing) is not the dangerous half.

## Scope: capability, not corpus

Unchanged and for the same reasons. `preprocess_card` still drops
`set_type == "funny"`; all eleven cards are Unhinged, legal in no format, so the
legality filter above would drop them anyway. **This corpus holds none of the
eleven cards**, so nothing in this repository's dataset exercises the fixed
path. After this, every row in the table is still integral and no query answer
over the real corpus moves.

## Sites

- **Schema** -- `api/db/2026-08-17-01-fractional-power-toughness.sql`, `integer`
  -> `real` on both columns in one statement so the table rewrites once. `real`
  over `numeric` for the reasons `2026-08-12-01` sets out and which hold
  unchanged here.
- **Import cast** -- `maybe_int` -> `maybe_float`, alongside cmc's. Non-numeric
  printings (`*`, `1+*`, `?`) still fall through to `None`: both helpers reject
  them identically via the same `@maybeify` catch, and the existing
  `test_preprocess_card_handles_non_numeric_power_toughness` pins that.
- **Engine** -- `Option<i8>` -> `Option<f32>` on `OracleCard` and `CardRow`,
  `opt_i8` -> `opt_f32` at the ingest boundary (`opt_i8` had exactly those two
  callers and is removed with them), and the numeric index / sort permutation /
  plane builders drop the widening conversions this makes into identities.
- **The arith-tuple key** holds `power_bits` / `toughness_bits` for the reason
  `cmc_bits` already exists: an f32 is neither `Hash` nor `Eq`. Unlike cmc it
  carries `+ 0.0` on the way in, because power is **signed** -- normalizing -0.0
  onto +0.0 keeps a value every comparison treats as equal from interning as two
  combinations and inflating the distinct-key budget.

## Archive format: this bump is load-bearing, cmc's was belt-and-braces

`ARCHIVE_FORMAT_VERSION` 2026081201 -> 2026081701. The mana value change noted
that the header's struct sizes happened to move too, so an old store would have
been rejected regardless. **That is not true here, and it was measured rather
than assumed:** `size_of::<AOracleCard>` is 304 both before and after -- padding
absorbs the 12 bytes the two columns gain -- `size_of::<APrinting>` is untouched
at 160, and `ArithTupleKey` is not measured by the header at all. Without the
bump, `get_mmap` would accept an archive written by the old build and read i8
power bytes as f32 bits. Deployments still need no action; the archive is a
derived cache.

## The card object does not move

`power` and `toughness` in the returned card JSON come from
`creature_power_text` / `creature_toughness_text` (see `api/api_resource.py`'s
field map), never from the numeric column. The printed string a reader sees was
never what this column held.

## Tests, and what was and was not verified

**Rust, run:** the full `card_engine` suite passes (165 passed, 38 ignored), and
`cargo clippy --all-targets -- -D warnings` is clean locally -- though local is
1.90 and CI pins 1.97.1, so CI is the authority on that.

Four new cases sit beside a `fractional_stat_fixture_store`, deliberately a
**separate** store from `numeric_plane_fixture_store` for the reason now recorded
there: one off-lattice value widens a bucket's observed range for the whole
fixture and would make `compile_plane` decline the thresholds those tests exist
to prove it accepts -- the same reason `fractional_cmc_fixture_store` stands
apart. They cover the end-to-end predicate in both directions, the plane/filter
parity contract (with the same non-vacuity assertion), the arith-tuple key, and
the sort permutation. The plane case includes a **negative** fractional
threshold, which cmc's cannot reach and which exercises the low-tail bucket.

The differential fuzzer now gives every 13th creature a half power and toughness,
assigned from the card index rather than an rng draw so the stream -- and every
existing fuzz store in the suite -- is unchanged. 13 and cmc's 17 are coprime, so
some cards carry a fractional mana value **and** fractional stats.

**Measured end to end, but not on this corpus.** Because this dataset holds none
of the eleven cards, the fix's effect cannot be observed here at all. It was
observed on a store built from a corpus that *does* import the funny sets, with
the same engine code, checked query-for-query against api.scryfall.com on
2026-08-17:

| query    | Scryfall | before | after |
| -------- | -------- | ------ | ----- |
| `tou=0`  | 432      | 433    | 432   |
| `pow=0`  | 1054     | 1055   | 1054  |
| `tou=1`  | 3758     | 3759   | 3758  |
| `pow=2`  | 5730     | 5733   | 5730  |
| `tou=0.5`| 1        | 0      | 1     |
| `pow=2.5`| 3        | 0      | 3     |

Every one exact after. Note again the direction the "before" column shows: the
integer columns answered too MANY, not too few, on the whole-number queries. That
measurement is offered as evidence the engine change is correct, not as something
reproducible against this repository's dataset -- here, by construction, all six
of those counts are unmoved.

**Python:** `test_card_processing.py` (fraction kept, floor not matched, whole
stats unchanged, negative power unchanged), `test_engine_unit.py` (a six-card
store through `run_query` under both aliases, including `pow>tou` and
`order=power`), and `test_upsert_cards.py` (the upsert path, reading the stored
columns back and asserting `information_schema` reports `real` for both -- a
round trip alone would not distinguish `real` from an `integer` column handed
whole numbers).

These were authored without a Postgres to hand and were **not** run locally; CI
ran them, and its containerized Postgres is what first executed the migration.
`test_the_columns_are_not_an_integer_type` passing there is the evidence that
`2026-08-17-01-fractional-power-toughness.sql` applies cleanly and leaves both
columns `real`. All checks on this push are green: 2584 passed, 19 xfailed on
python-test, and rust-test green under its pinned 1.97.1 clippy.

**Still not verified, and worth stating plainly:**

- **The migration has only ever run against an empty, freshly built database.**
  CI creates the schema from scratch, so `ALTER TABLE ... TYPE real` has never
  been executed against a table that already holds ~31.5k rows. The rewrite is
  reasoned about above, not measured: nothing here has timed the lock it takes on
  a populated table.
- **No corpus-level count was measured against this repository's dataset**,
  because it cannot be -- this corpus imports no funny sets and so holds none of
  the eleven cards. The `include:extras` count of 11 and the table above are
  measurements of *Scryfall* and of a funny-set-importing store respectively,
  not of this dataset. Here, by construction, every count is unmoved.


---

## Third defect, same column family: the gate, not the value

The two changes above are about a column that could not **hold** a printed
value. This one is about a column that was not **allowed** to hold it.

`preprocess_card` reads `power`/`toughness` only when the parsed type line
names Creature, Vehicle or Spacecraft, and `magic.cards` enforces the same test
as `creature_attributes_null_for_non_creatures`. Both encode the claim that a
printed stat implies a modern creature type line. Eighteen printings disprove
it:

```
$ curl -s 'https://api.scryfall.com/cards/search' \
    --data-urlencode 'q=-t:creature -t:vehicle -t:spacecraft (pow>=0 or pow<0) include:extras' \
    --data-urlencode 'unique=prints'
    "total_cards": 18,
```

| card | type line | P/T | set type |
| --- | --- | --- | --- |
| Old Fogey (×4 printings) | `Summon — Dinosaur` | 7/7 | funny |
| Atinlay Igpay | `Eaturecray — Igpay` | 3/3 | funny |
| Throat Wolf (×2) | `Summon Wolf` | 3/1 | funny |
| Xyru Specter (×2) | `Summon — Specter` | 2/2 | funny |
| Flanking Licid | `Summon Licid` | 1/1 | masters |
| 1996 World Champion | `Summon Legend` | \*/\* | memorabilia |
| Shichifukujin Dragon | `Summon Dragon` | 0/0 | memorabilia |
| Aswan Jaguar (×2) | `Summon Jaguar` | 2/2 | memorabilia, box |
| Faerie Dragon | `Summon Dragon` | 1/3 | box |
| Prismatic Dragon | `Summon Dragon` | 2/3 | box |
| Goblin Polka Band | `Summon Goblin` | 1/1 | box |
| Rainbow Knights | `Summon Knights` | 2/1 | box |

Mostly the pre-Sixth-Edition `Summon` template, which Scryfall preserves
verbatim on the printings that used it rather than rewriting it to `Creature`;
Atinlay Igpay is the pig-latin one. Scryfall searches every one of them
**numerically** — `pow=3` and `tou=3` both count Atinlay Igpay, `tou>=3.5`
counts Old Fogey — so the printed keys, and not the parsed type, are what
decide whether a stat exists. A raw `power`/`toughness` key is now sufficient
on its own.

**The type parse is deliberately not widened.** Teaching `parse_type_line` to
read `Summon` and `Eaturecray` as `Creature` would have made the stat counts
agree too, and would have put eighteen printings into `t:creature` that print
no such word. `Summon` and `Eaturecray` stay the unrecognised words they are;
only the stat each printing actually prints becomes visible. Two tests assert
that negative directly, one in the import path and one on the stored row.

**Whole cards only, never a merged face.** `merged = card | face_data` lets a
face inherit the *card-level* `power`, and Scryfall publishes one there for
adventures: Obyra's Attendants is `3`/`4` at the top level while its Adventure
face prints neither. For a face the parsed type line is the only trustworthy
signal, and this costs nothing — all eighteen printings above are single-faced.
Pinned by a test that reads the fixture's own shape first.

### The migration relaxes the constraint rather than dropping it

`2026-08-17-02-printed-stats-on-any-type-line.sql` keeps the half of the old
rule that is still true: a stat on a non-creature row must be a **printed** one.
The numeric columns are this project's parse of
`creature_power_text`/`creature_toughness_text`, so a number with no printed
string beside it on a row whose type line claims no creature is a derived value
that arrived from somewhere it should not have, and the table still rejects it
with a `CheckViolation`. What the old rule asserted beyond that — that only a
modern creature type line may print a stat — is what the eighteen printings
disprove.

The `DROP` is a catalog update; the `ADD` validates the table once under a
`SHARE ROW EXCLUSIVE` lock, and every existing row passes it vacuously, because
the old constraint already guaranteed that a non-creature row has all four
columns `NULL`. `2025-09-29-great-reset.sql` is not edited — migrations stack on
top of it — so the drop is `IF EXISTS` for databases restored from a later dump.

### Verification for this change

**Run against the session's `postgres:18` testcontainer, locally and in CI.**
Five tests in `test_upsert_cards.py` go through the real `_upsert_cards` path:
the Old Fogey and Atinlay Igpay shapes store their stats, the stored row still
has no `Creature` in `card_types` while carrying both printed text columns,
`power=7` finds it while `power=7 t:creature` does not (conjoined so the
negative cannot pass by falling off a truncated result set), and a bare numeric
stat on a non-creature row is still rejected. **`creature_attributes_null_for_non_creatures`
would have rejected every insert in that class, so those tests passing is
itself the evidence that the migration applies and leaves the relaxed
constraint in place.** Six more in `test_card_processing.py` cover the import
gate, the `t:creature` negative, and the face-inheritance rule without a
database. All eleven ran green in CI on `659cc90` — 2595 passed, 19 xfailed on
python-test, `lint` green, and rust-test green under its pinned 1.97.1 clippy
(no Rust changed here; the type widening it covers landed in the commit above).

**Still not verified, and worth stating plainly:**

- **No corpus-level count was measured against this repository's dataset, and
  none can be.** All eighteen printings fail `preprocess_card`'s legality
  filter — not one is legal or restricted in any format — and most also fail the
  funny-set, playtest or paper-games rules. This corpus holds none of them, so
  every count here is unmoved by construction. The `total_cards: 18` above and
  the per-card stats in the table are measurements of **api.scryfall.com** on
  2026-08-17, not of this dataset.
- **The `pow=3` / `tou=3` / `tou>=3.5` counts that found this defect were
  measured elsewhere.** They come from a downstream store that *does* import
  funny sets, enumerated page by page against api.scryfall.com and diffed by
  Scryfall id: `pow=3` 4079, `tou=3` 4349, `tou>=3.5` 5878, each exactly one id
  short before the fix and exact after. Nothing in this repository reproduces
  those numbers or can be made to, and no test here asserts them.
- **The migration has still only ever run against an empty, freshly built
  database**, the same caveat the type change above carries. The `ADD
  CONSTRAINT` validation scan has never been executed against a table already
  holding ~31.5k rows; its cost is reasoned about, not measured.
