### PR TITLE
Search: Two Follow-Ups From the #909 Review

### DIFF
--- a/api/static/app.js
+++ b/api/static/app.js
@@ -709,6 +709,14 @@ class CardSearch {
 
     const autocompleted = this.autoCompleteQuery(query);
 
+    // One scan of autocompleted serves both the empty-span guard below and the balancing that
+    // follows, instead of each independently re-scanning the same string on every keystroke
+    // (endsWithEmptySpan and balanceQuery both call scanSpans on their own). openSpanContentStart
+    // is a position in autocompleted, not in a trimmed copy of it, but that doesn't change what it
+    // means: trailing whitespace can't be a span closer, so the position a span was left open at
+    // is the same whether or not the string is trimmed first.
+    const { suffix, openSpanContentStart } = this.scanSpans(autocompleted);
+
     // Mid-span with nothing typed after the opener: wait rather than search. Balancing would turn
     // `o:/` into the empty pattern `o://`, which matches every card and cannot use an index, and
     // `mana:{` into the non-cost `mana:{}`. Neither is what the user is on their way to typing, so
@@ -719,12 +727,12 @@ class CardSearch {
     // lands here with the previous showLoading still on screen. Returning without touching the
     // status container left "Searching o:/a/…" over an empty grid until the next searchable
     // keystroke. Clearing converges on the same "nothing to show" state as an empty query.
-    if (this.endsWithEmptySpan(autocompleted)) {
+    if (openSpanContentStart !== null && autocompleted.slice(openSpanContentStart).trim() === '') {
       this.clearMessages();
       return;
     }
 
-    const normalizedQuery = this._balanceAndNormalize(autocompleted);
+    const normalizedQuery = (suffix === null ? autocompleted : autocompleted + suffix).trim().replace(/\s+/g, ' ');
 
     const validationError = this.validateQuery(normalizedQuery);
     if (validationError) {

--- a/api/static/app.test.js
+++ b/api/static/app.test.js
@@ -459,6 +459,18 @@ describe('CardSearch performSearch', () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
+  // performSearch used to call scanSpans twice per keystroke — once via endsWithEmptySpan, again
+  // via balanceQuery — before reusing one scan for both. validateQuery's own balanceSuffix check
+  // is a separate, intentional third call over the post-balance string, not part of this guard.
+  it('scans spans only once for the empty-span guard and balancing', async () => {
+    const spy = jest.spyOn(search, 'scanSpans');
+
+    await search.performSearch('name:bolt');
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    spy.mockRestore();
+  });
+
   // A span with nothing in it is not a query yet. Balancing would close it into something that is
   // valid but useless — `o://` matches every card with an unindexable empty pattern — so the request
   // waits for the next keystroke, and unlike an unbalance-able query this is not an error.

--- a/api/tests/test_datatype_mismatch.py
+++ b/api/tests/test_datatype_mismatch.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 import falcon
 import psycopg.errors
 import pytest
+from psycopg.pq import DiagnosticField
 
 from api.api_resource import APIResource, regex_error_reason
 from api.tests.helpers import search_kwargs
@@ -115,8 +116,12 @@ class TestInvalidRegularExpressionHandling:
         an ordinary intermediate state on the way to `o:/^[abc]/` — not something to alert on.
         """
         with patch.object(self.api_resource, "_run_query") as mock_run_query:
+            # `info=` populates .diag.message_primary the way a real connection would — the plain
+            # constructor string does not, so a test built on it can't tell whether
+            # `err.diag.message_primary` is actually wired through to the user-facing description.
             mock_run_query.side_effect = psycopg.errors.InvalidRegularExpression(
                 "invalid regular expression: brackets [] not balanced",
+                info={DiagnosticField.MESSAGE_PRIMARY: b"invalid regular expression: brackets [] not balanced"},
             )
 
             with pytest.raises(falcon.HTTPBadRequest) as exc_info:
@@ -124,7 +129,9 @@ class TestInvalidRegularExpressionHandling:
 
             assert exc_info.value.title == "Invalid Search Query"
             assert "o:/^[/" in exc_info.value.description
-            assert "invalid regular expression" in exc_info.value.description.lower()
+            # The Postgres prefix must be stripped exactly once, not left in twice.
+            assert "brackets [] not balanced" in exc_info.value.description
+            assert exc_info.value.description.count("invalid regular expression") == 1
             assert mock_run_query.call_count == 1
 
 


### PR DESCRIPTION
Two small follow-ups from reviewing #909, stacked on it the same way #909 stacks on main.

## Regex-error test couldn't catch broken diag wiring

`test_search_sql_handles_invalid_regular_expression` built `psycopg.errors.InvalidRegularExpression` from a plain string, but a manually-constructed psycopg error only gets `.diag.message_primary` from the `info=` kwarg — the constructor string alone leaves it `None`. So the test's only content assertion passed against static template text in `api_resource.py`'s f-string, not anything derived from the mocked exception; a later typo reading the wrong diag attribute would go unnoticed.

Verified by reverting the wiring locally (`regex_error_reason(None)` instead of `regex_error_reason(err.diag.message_primary)`) and confirming the test now fails.

## performSearch scanned spans twice per keystroke

`endsWithEmptySpan` and `balanceQuery` each independently called `scanSpans` over the same `autocompleted` string, so every debounced keystroke re-scanned it twice for the same information. Now `scanSpans` runs once and both the empty-span guard and the balance suffix are derived from that one result.

`validateQuery`'s own `balanceSuffix` call on the post-balance string is a separate, intentional check for a genuinely unbalance-able query and is left alone — this only removes the redundancy between the guard and the balancer.

Verified by reverting `app.js` and confirming a new spy-based test (`scans spans only once for the empty-span guard and balancing`) fails against the old code (3 `scanSpans` calls total in the flow) and passes against the new code (2).

- `python -m pytest api/tests/test_datatype_mismatch.py`: 9 passed
- `npx jest api/static/app.test.js`: 1909 passed
- `ruff check`, `prettier --check` clean