### PR TITLE
Parsing: Three Follow-Ups From the #915 Review

### DIFF
--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -18,7 +18,7 @@ from api.parsing.db_info import (
     FieldType,
     ParserClass,
 )
-from api.parsing.mana_symbols import MANA_COST_ATOMS, ZERO_COST_ATOMS
+from api.parsing.mana_symbols import MANA_COST_ATOMS, ZERO_COST_ATOMS, mana_atom_char_class
 from api.parsing.nodes import (
     AndNode,
     AttributeNode,
@@ -386,7 +386,7 @@ def get_legality_comparison_object(val: str, attr: str) -> dict[str, str]:
 
 
 # A run of digits, or one non-generic atom, in the unbraced part of a mana value.
-_UNBRACED_MANA_TOKEN = re.compile(r"\d+|[" + re.escape("".join(sorted(MANA_COST_ATOMS))) + r"]")
+_UNBRACED_MANA_TOKEN = re.compile(r"\d+|[" + mana_atom_char_class() + r"]")
 
 
 def mana_cost_str_to_dict(mana_cost_str: str) -> dict:

--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -443,13 +443,13 @@ def calculate_cmc(mana_cost_str: str) -> int:
             # Generic mana symbols add to CMC
             cmc += int(mana_symbol)
         except ValueError:
-            # X costs count as 0 for CMC calculation
-            if mana_symbol == "X":
+            # The variables (X, Y, Z) count as 0 for CMC calculation
+            if mana_symbol in ZERO_COST_ATOMS:
                 continue
             # Colored mana symbols (W, U, B, R, G, etc.) each count as 1
             # Handle hybrid symbols like {W/U} as 1
             # Handle Phyrexian symbols like {W/P} as 1
-            # For simplicity, any non-numeric, non-X symbol counts as 1
+            # For simplicity, any non-numeric, non-variable symbol counts as 1
             cmc += 1
 
     # Then, process unbraced part (after removing braced sections)

--- a/api/parsing/mana_symbols.py
+++ b/api/parsing/mana_symbols.py
@@ -44,6 +44,27 @@ _HALF_SYMBOL_LENGTH = 2  # the 'H' and the colour it applies to
 _BRACED_SYMBOL = re.compile(r"\{([^}]*)\}")
 
 
+def mana_atom_char_class(*, include_digits: bool = False, include_lower: bool = False) -> str:
+    r"""Return a regex character-class body (the text that goes between '[' and ']') for MANA_COST_ATOMS.
+
+    The two regex-building callers each need a slightly different class from the same vocabulary, and
+    used to build it separately — one adding digits via a '0-9' literal and the other via a '\\d+'
+    alternation instead, one folding in lowercase and the other not, both re-deriving the escaping and
+    sort order by hand. Centralising the class itself, not just the set it is built from, means an
+    atom added to MANA_COST_ATOMS only needs verifying against one regex-construction site.
+
+    Args:
+        include_digits: Add '0-9', for a caller matching a mana value one character at a time.
+            Leave False for a caller that matches a run of digits as a separate alternative
+            (e.g. r"\\d+|[...]"), since digits inside this class would only ever match one at a time.
+        include_lower: Add the lower-cased form of every atom, for a caller reading raw query text
+            that has not already been upper-cased.
+    """
+    atoms = MANA_COST_ATOMS | ({char.lower() for char in MANA_COST_ATOMS} if include_lower else set())
+    prefix = "0-9" if include_digits else ""
+    return prefix + re.escape("".join(sorted(atoms)))
+
+
 def _is_atom(part: str) -> bool:
     """Return True if *part* is one side of a symbol: generic mana, a single atom, or half mana."""
     if part and all(char in _DIGITS for char in part):

--- a/api/parsing/mana_symbols.py
+++ b/api/parsing/mana_symbols.py
@@ -70,12 +70,23 @@ def first_invalid_mana_symbol(value: str) -> str | None:
     those readers used to *drop* any character they did not recognise, so 'mana:snow' kept the 'W' and
     silently answered 'mana:w', and 'mana:hello' kept nothing and matched every card in the corpus
     (an empty cost dict is a subset of every cost). Dropping quietly is worse than refusing.
+
+    Bare and braced symbols can appear side by side in one value, e.g. 'T{Q}' from a stray marker
+    next to a braced one, so the two notations are walked in the order they actually occur rather
+    than braced-then-bare, or an invalid bare character after a valid braced run would report the
+    later, braced offender as "first".
     """
-    for symbol in _BRACED_SYMBOL.findall(value):
+    pos = 0
+    for match in _BRACED_SYMBOL.finditer(value):
+        for char in value[pos : match.start()]:
+            if char not in _DIGITS and char not in MANA_COST_ATOMS:
+                return char
+        symbol = match.group(1)
         if not is_valid_mana_symbol(symbol):
             return f"{{{symbol}}}"
+        pos = match.end()
 
-    for char in _BRACED_SYMBOL.sub("", value):
+    for char in value[pos:]:
         if char not in _DIGITS and char not in MANA_COST_ATOMS:
             return char
 

--- a/api/parsing/mana_symbols.py
+++ b/api/parsing/mana_symbols.py
@@ -30,8 +30,9 @@ _COLORS = frozenset("WUBRG")
 # different ways. 'S' and 'P' missing from those copies is what made 'mana:s' match every card.
 MANA_COST_ATOMS = _COLORS | frozenset("CSXYZP∞")
 
-# Variables contribute nothing to mana value; every other non-generic atom counts as one pip.
-ZERO_COST_ATOMS = frozenset("X")
+# The variables (X, Y, Z) contribute nothing to mana value; every other non-generic atom counts as
+# one pip.
+ZERO_COST_ATOMS = frozenset("XYZ")
 
 _ATOMS = MANA_COST_ATOMS
 

--- a/api/parsing/pyparsing_based.py
+++ b/api/parsing/pyparsing_based.py
@@ -29,7 +29,7 @@ from api.parsing.db_info import (
     PARSER_CLASS_TO_FIELD_INFOS,
     ParserClass,
 )
-from api.parsing.mana_symbols import MANA_COST_ATOMS, first_invalid_mana_symbol
+from api.parsing.mana_symbols import first_invalid_mana_symbol, mana_atom_char_class
 from api.parsing.nodes import (
     AndNode,
     BinaryOperatorNode,
@@ -69,7 +69,7 @@ _FP_TERM_END_OPS = frozenset("><=!:-")
 # One bare mana atom, either case. Built from the shared vocabulary rather than hand-listed: this
 # pattern used to read "[0-9WUBRGCXYZwubrgcxyz]", which left out 'S' and 'P', so a bare 'mana:s' fell
 # out of the mana branch entirely and matched as a plain string instead.
-_SIMPLE_MANA_SYMBOL_PATTERN = r"[0-9" + re.escape("".join(sorted(MANA_COST_ATOMS | {c.lower() for c in MANA_COST_ATOMS}))) + r"]"
+_SIMPLE_MANA_SYMBOL_PATTERN = "[" + mana_atom_char_class(include_digits=True, include_lower=True) + "]"
 
 
 def make_regex_pattern(words: Iterable[str]) -> Regex:

--- a/api/parsing/tests/test_mana_symbols.py
+++ b/api/parsing/tests/test_mana_symbols.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
-from api.parsing.mana_symbols import first_invalid_mana_symbol, is_valid_mana_symbol
+from api.parsing.mana_symbols import MANA_COST_ATOMS, first_invalid_mana_symbol, is_valid_mana_symbol, mana_atom_char_class
 
 # Every distinct symbol the card corpus uses in mana_cost_text — 48 of them, via
 # `regexp_matches(mana_cost_text, '[{]([^}]*)[}]', 'g')` over magic.cards — plus generic values no
@@ -118,3 +120,28 @@ def test_junk_is_rejected(symbol: str) -> None:
 def test_first_invalid_mana_symbol(value: str, expected: str | None) -> None:
     """Both notations are checked, and the first offender is named so the message can say which."""
     assert first_invalid_mana_symbol(value) == expected
+
+
+class TestManaAtomCharClass:
+    """The two regex-building call sites (card_query_nodes, pyparsing_based) share this builder."""
+
+    def test_bare_class_covers_every_atom_and_nothing_else(self) -> None:
+        """Default arguments: no digits, no lowercase — every atom matches, its lowercase does not."""
+        pattern = re.compile(f"[{mana_atom_char_class()}]")
+        for atom in MANA_COST_ATOMS:
+            assert pattern.fullmatch(atom), f"{atom!r} should match"
+        assert not pattern.fullmatch("0")
+        assert not pattern.fullmatch("w")
+
+    def test_include_digits_adds_0_through_9_only(self) -> None:
+        r"""include_digits matches single digit characters, not a run — callers alternate '\d+' for that."""
+        pattern = re.compile(f"[{mana_atom_char_class(include_digits=True)}]")
+        for digit in "0123456789":
+            assert pattern.fullmatch(digit)
+        assert not pattern.fullmatch("w")
+
+    def test_include_lower_adds_the_lowercase_form_of_every_atom(self) -> None:
+        pattern = re.compile(f"[{mana_atom_char_class(include_lower=True)}]")
+        for atom in MANA_COST_ATOMS:
+            assert pattern.fullmatch(atom.lower()), f"{atom.lower()!r} should match"
+        assert not pattern.fullmatch("0")

--- a/api/parsing/tests/test_mana_symbols.py
+++ b/api/parsing/tests/test_mana_symbols.py
@@ -93,6 +93,8 @@ def test_junk_is_rejected(symbol: str) -> None:
         ("S", None),  # snow, dropped by the old charset
         ("P", None),  # phyrexian, likewise
         ("2WWS", None),
+        ("T{Q}", "T"),  # an invalid bare marker before an invalid braced symbol: bare wins, left to right
+        ("{W}T{Q}", "T"),  # valid braced, then invalid bare, then invalid braced: the bare one is still first
     ],
     ids=[
         "braced",
@@ -109,6 +111,8 @@ def test_junk_is_rejected(symbol: str) -> None:
         "bare_snow",
         "bare_phyrexian",
         "bare_mixed",
+        "bare_before_braced",
+        "bare_between_braced",
     ],
 )
 def test_first_invalid_mana_symbol(value: str, expected: str | None) -> None:

--- a/api/parsing/tests/test_pyparsing_parser.py
+++ b/api/parsing/tests/test_pyparsing_parser.py
@@ -911,6 +911,12 @@ def test_mana_cost_sql_generation() -> None:
         ("{W/U/P}", 1),
         # Test X costs (X counts as 0 for CMC calculation)
         ("{X}{X}{W}", 1),
+        # Y and Z are variables too, same as X
+        ("{Y}", 0),
+        ("{Z}", 0),
+        ("Y", 0),
+        ("Z", 0),
+        ("{X}{Y}{Z}{W}", 1),
         # Test unbraced format
         ("1WU", 3),  # 1 generic + W + U
         ("2RRG", 5),  # 2 generic + R + R + G


### PR DESCRIPTION
Three follow-ups from reviewing #915, stacked on it the same way #915 stacks on #909.

## ZERO_COST_ATOMS omitted Y and Z

`ZERO_COST_ATOMS` only exempted `X` from CMC contribution, but `MANA_COST_ATOMS`'s own comment treats X, Y, and Z as "the variables." A regression for the bare form specifically: the old unbraced regex (`[WUBRGC]`) didn't match Y/Z at all, so they silently contributed 0; the widened charset now matches them and counted each as a full pip. Added Y and Z to `ZERO_COST_ATOMS`, and switched `calculate_cmc`'s braced branch from a hardcoded `== "X"` to `in ZERO_COST_ATOMS` so both branches read the same vocabulary.

Verified: reverted the fix and confirmed `calculate_cmc('{X}{Y}{Z}{W}') == 3` (should be 1) before the fix, `== 1` after.

## first_invalid_mana_symbol reported the wrong offending symbol

Scanned every braced `{...}` symbol before any bare character, regardless of where each actually sits. For `T{Q}` — an invalid bare marker immediately before an invalid braced one — this reported `{Q}` instead of the leftmost `T`, contradicting the function's own "first symbol, scanning left to right" contract. The query was still correctly rejected either way; only the 400's named symbol was wrong. Now walks the value once, interleaving both notations in the order they occur.

Verified: the new `T{Q}` / `{W}T{Q}` test cases fail against the old two-pass implementation, pass against the new one.

## Mana atom char-class built twice, differently

`card_query_nodes.py` and `pyparsing_based.py` each independently rebuilt a regex character class from `MANA_COST_ATOMS` — one via a `\d+` alternation with no lowercase, the other via a literal `0-9` plus lower-cased atoms — duplicating exactly the "one vocabulary" logic `mana_symbols.py`'s docstring says should be centralized (it only centralized the atom *set*, not the regex built from it). Added `mana_atom_char_class(include_digits=, include_lower=)` to `mana_symbols.py`; both call sites now build their pattern from it.

Verified the generated patterns are byte-identical to the originals before switching either site over — construction-only, no parsing behavior change.

- `python -m pytest api/parsing/tests/ api/tests/`: 2693 passed, 21 xfailed
- `npx jest api/static/app.test.js`: 1908 passed
- `ruff check`, `ruff format --check` clean