### PR TITLE
Parsing: Stop Accepting Mana Symbols No Real Cost Ever Has

### DIFF
--- a/api/parsing/mana_symbols.py
+++ b/api/parsing/mana_symbols.py
@@ -32,34 +32,33 @@ _ATOMS = _COLORS | frozenset("CSXYZP")
 # The generic side of generic-hybrid mana is always specifically '2' ({2/W}, never {1/W} or {3/W}).
 _GENERIC_HYBRID_VALUE = "2"
 
-_TWO_PARTS = 2
-_THREE_PARTS = 3
+# Colourless joins colour on the "which side does this go on" ambiguity a hybrid pair has — a user
+# typing {C/W} from memory has as little reason to know it isn't printed {W/C} as they do for two
+# colours — so both share one permutation-generated set of ordered pairs. Generic and phyrexian don't:
+# every printing has the generic side first and the phyrexian side last, so those two are one-directional.
+_HYBRID_ATOMS = _COLORS | frozenset("C")
 
-# A multi-part symbol's sides can appear in either order — a user typing from memory has no reason to
-# know Scryfall prints hybrid as '{W/U}' rather than '{U/W}', and the two name the same symbol — so
-# each shape is stored as a frozenset of its sides, not a tuple. What a *set* can't capture is a side
-# repeating itself: '{W/W}' and '{2/2}' aren't symbols even though 'W' and '2' are each legal alone, so
-# duplicate-side combinations are rejected before this table is ever consulted.
-_TWO_PART_SHAPES = frozenset(
-    frozenset(pair)
-    for pair in (
-        *itertools.combinations(_COLORS, 2),  # hybrid: any two colours, e.g. {W/U}
-        *((c, "C") for c in _COLORS),  # colourless hybrid: {C/W}
-        *((c, _GENERIC_HYBRID_VALUE) for c in _COLORS),  # generic hybrid: {2/W}
-        *((c, "P") for c in _COLORS),  # phyrexian: {W/P}
+# Every valid 2- or 3-part shape, as the exact ordered tuple `symbol.split("/")` must produce. Rule- not
+# corpus-derived: a colour pair or hybrid-phyrexian triple is valid because the game defines that shape,
+# whether or not a card has ever been printed with it (real corpus printings only cover 4 of the 10
+# possible hybrid-phyrexian colour pairs, but {U/B/P} is exactly as valid a request as the printed ones).
+# `itertools.permutations` never repeats an element in one draw, so {W/W}, {2/2} and {C/C} are excluded
+# for free — no separate duplicate-side check is needed.
+_PART_SHAPES = frozenset(
+    (
+        *itertools.permutations(_HYBRID_ATOMS, 2),  # hybrid & colourless hybrid, either order: {W/U}, {C/W}
+        *((_GENERIC_HYBRID_VALUE, c) for c in _COLORS),  # generic hybrid, generic first: {2/W}
+        *((c, "P") for c in _COLORS),  # phyrexian, colour first: {W/P}
+        *((a, b, "P") for a, b in itertools.permutations(_COLORS, 2)),  # hybrid-phyrexian, colours either order
     )
 )
-
-# Hybrid-phyrexian, e.g. {R/G/P}: corpus-grounded rather than every 2-colour combination + 'P', since
-# real printings don't cover all ten colour pairs for this one.
-_THREE_PART_SHAPES = frozenset(frozenset((*pair, "P")) for pair in (("G", "U"), ("G", "W"), ("R", "G"), ("R", "W")))
 
 # A braced symbol anywhere in a mana value, e.g. the '2' and 'W' of '{2}{W}'.
 _BRACED_SYMBOL = re.compile(r"\{([^}]*)\}")
 
 
 def _is_atom(part: str) -> bool:
-    """Return True if *part* is one side of a symbol: generic mana or a single atom."""
+    """Return True if *part* is a whole one-part symbol: generic mana or a single atom."""
     if part and all(char in _DIGITS for char in part):
         return True  # generic mana of any size: {0}, {16}, {1000000}
     return part in _ATOMS
@@ -68,23 +67,17 @@ def _is_atom(part: str) -> bool:
 def is_valid_mana_symbol(symbol: str) -> bool:
     """Return True if *symbol* — the text between the braces, upper-cased — can appear in a mana cost.
 
-    A symbol is either one atom, or two or three sides joined by '/' in either order: hybrid ({W/U} or
-    {U/W}), generic-hybrid ({2/W}), phyrexian ({W/P}) and hybrid-phyrexian ({R/G/P}). Repeating a side
-    is never real, even when the side is: {W/W} and {2/2} aren't symbols.
+    A symbol is either one atom, or two or three sides joined by '/'. See `_PART_SHAPES` for which
+    combinations, and in which order, are real: {W/U}/{U/W} are the same symbol, but {W/2} and {P/W}
+    are not — the generic and phyrexian sides never move — and a side never repeats: {W/W}, {2/2}
+    aren't symbols even though 'W' and '2' are each legal alone.
     """
     if not symbol:
         return False
-    parts = symbol.split("/")
+    parts = tuple(symbol.split("/"))
     if len(parts) == 1:
         return _is_atom(parts[0])
-    if len(set(parts)) != len(parts):
-        return False
-    combo = frozenset(parts)
-    if len(parts) == _TWO_PARTS:
-        return combo in _TWO_PART_SHAPES
-    if len(parts) == _THREE_PARTS:
-        return combo in _THREE_PART_SHAPES
-    return False
+    return parts in _PART_SHAPES
 
 
 def first_invalid_mana_symbol(value: str) -> str | None:

--- a/api/parsing/mana_symbols.py
+++ b/api/parsing/mana_symbols.py
@@ -14,42 +14,77 @@ than an empty result set.
 
 from __future__ import annotations
 
+import itertools
 import re
 
 _DIGITS = frozenset("0123456789")
 
 _COLORS = frozenset("WUBRG")
 
-# Single-character atoms: a colour, colourless, snow, the variables, phyrexian, and Gleemax's cost.
-# Grounded in the 48 distinct symbols the card corpus uses in mana_cost_text, plus the Un-set symbols
-# that corpus holds no cards for — '∞' is Gleemax's whole mana cost, and 'H' + a colour is half mana
-# ({HW} on Little Girl). The frontend already renders both, in the mana maps in app.js.
-_ATOMS = _COLORS | frozenset("CSXYZP∞")
+# Single-character atoms: a colour, colourless, snow, the variables, and phyrexian. Grounded in the 48
+# distinct symbols the card corpus uses in mana_cost_text, plus generic values no printing has used
+# yet. Deliberately excludes symbols that appear only on cards from "funny" (Un-)sets — '∞' (Gleemax's
+# whole cost) and 'H' + a colour (half mana, e.g. Little Girl's {HW}) — since `preprocess_card` filters
+# every `set_type == "funny"` card out of the corpus, so no mana cost these queries can ever match
+# contains them: they belong with the rest of `_REAL_BUT_NOT_A_COST` in test_mana_symbols.py, not here.
+_ATOMS = _COLORS | frozenset("CSXYZP")
 
-# Half mana is written as 'H' followed by a colour: {HW}, {HR}.
-_HALF_PREFIX = "H"
-_HALF_SYMBOL_LENGTH = 2  # the 'H' and the colour it applies to
+# The generic side of generic-hybrid mana is always specifically '2' ({2/W}, never {1/W} or {3/W}).
+_GENERIC_HYBRID_VALUE = "2"
+
+_TWO_PARTS = 2
+_THREE_PARTS = 3
+
+# A multi-part symbol's sides can appear in either order — a user typing from memory has no reason to
+# know Scryfall prints hybrid as '{W/U}' rather than '{U/W}', and the two name the same symbol — so
+# each shape is stored as a frozenset of its sides, not a tuple. What a *set* can't capture is a side
+# repeating itself: '{W/W}' and '{2/2}' aren't symbols even though 'W' and '2' are each legal alone, so
+# duplicate-side combinations are rejected before this table is ever consulted.
+_TWO_PART_SHAPES = frozenset(
+    frozenset(pair)
+    for pair in (
+        *itertools.combinations(_COLORS, 2),  # hybrid: any two colours, e.g. {W/U}
+        *((c, "C") for c in _COLORS),  # colourless hybrid: {C/W}
+        *((c, _GENERIC_HYBRID_VALUE) for c in _COLORS),  # generic hybrid: {2/W}
+        *((c, "P") for c in _COLORS),  # phyrexian: {W/P}
+    )
+)
+
+# Hybrid-phyrexian, e.g. {R/G/P}: corpus-grounded rather than every 2-colour combination + 'P', since
+# real printings don't cover all ten colour pairs for this one.
+_THREE_PART_SHAPES = frozenset(frozenset((*pair, "P")) for pair in (("G", "U"), ("G", "W"), ("R", "G"), ("R", "W")))
 
 # A braced symbol anywhere in a mana value, e.g. the '2' and 'W' of '{2}{W}'.
 _BRACED_SYMBOL = re.compile(r"\{([^}]*)\}")
 
 
 def _is_atom(part: str) -> bool:
-    """Return True if *part* is one side of a symbol: generic mana, a single atom, or half mana."""
+    """Return True if *part* is one side of a symbol: generic mana or a single atom."""
     if part and all(char in _DIGITS for char in part):
         return True  # generic mana of any size: {0}, {16}, {1000000}
-    if part in _ATOMS:
-        return True
-    return len(part) == _HALF_SYMBOL_LENGTH and part[0] == _HALF_PREFIX and part[1] in _COLORS
+    return part in _ATOMS
 
 
 def is_valid_mana_symbol(symbol: str) -> bool:
     """Return True if *symbol* — the text between the braces, upper-cased — can appear in a mana cost.
 
-    A symbol is either one atom or several joined by '/': hybrid ({W/U}), generic-hybrid ({2/W}),
-    phyrexian ({W/P}) and hybrid-phyrexian ({R/G/P}) all follow that one shape.
+    A symbol is either one atom, or two or three sides joined by '/' in either order: hybrid ({W/U} or
+    {U/W}), generic-hybrid ({2/W}), phyrexian ({W/P}) and hybrid-phyrexian ({R/G/P}). Repeating a side
+    is never real, even when the side is: {W/W} and {2/2} aren't symbols.
     """
-    return bool(symbol) and all(_is_atom(part) for part in symbol.split("/"))
+    if not symbol:
+        return False
+    parts = symbol.split("/")
+    if len(parts) == 1:
+        return _is_atom(parts[0])
+    if len(set(parts)) != len(parts):
+        return False
+    combo = frozenset(parts)
+    if len(parts) == _TWO_PARTS:
+        return combo in _TWO_PART_SHAPES
+    if len(parts) == _THREE_PARTS:
+        return combo in _THREE_PART_SHAPES
+    return False
 
 
 def first_invalid_mana_symbol(value: str) -> str | None:

--- a/api/parsing/tests/test_mana_symbols.py
+++ b/api/parsing/tests/test_mana_symbols.py
@@ -8,7 +8,9 @@ from api.parsing.mana_symbols import first_invalid_mana_symbol, is_valid_mana_sy
 
 # Every distinct symbol the card corpus uses in mana_cost_text — 48 of them, via
 # `regexp_matches(mana_cost_text, '[{]([^}]*)[}]', 'g')` over magic.cards — plus generic values no
-# printing has used yet. Every one of these has to stay searchable.
+# printing has used yet, plus every rule-valid hybrid-phyrexian colour pair (only 4 of the 10 have
+# actually been printed, but a mana search isn't limited to what's been printed — see mana_symbols.py).
+# Every one of these has to stay searchable.
 _VALID = (
     *[str(n) for n in (*range(21), 100, 1000000)],
     *"WUBRGCSXYZP",
@@ -16,10 +18,10 @@ _VALID = (
     *("W/U", "W/B", "U/B", "U/R", "B/R", "B/G", "R/G", "R/W", "G/W", "G/U"),
     *("C/W", "C/U", "C/B", "C/R", "C/G"),
     *("W/P", "U/P", "B/P", "R/P", "G/P"),
-    *("G/U/P", "G/W/P", "R/G/P", "R/W/P"),
-    # A side is a set, not a slot: whichever order a user types a real symbol's sides in, it's the
-    # same symbol. Only a sample of reversed forms — one per shape — not every pair reversed.
-    *("U/W", "W/C", "W/2", "P/W", "U/G/P"),
+    *("G/U/P", "G/W/P", "R/G/P", "R/W/P", "W/U/P", "W/B/P", "U/B/P", "U/R/P", "B/R/P", "B/G/P"),
+    # Hybrid and colourless hybrid are a set, not a slot: whichever order a user types a real symbol's
+    # colours in, it's the same symbol. Only a sample of reversed forms, not every pair reversed.
+    *("U/W", "W/C", "U/G/P"),
 )
 
 # Real Magic symbols that no mana cost can hold: tap, untap, energy, and the planar symbols. Searching
@@ -59,10 +61,11 @@ def test_symbols_that_cannot_appear_in_a_cost_are_rejected(symbol: str) -> None:
         ("2/2",),
         ("C/C",),
         ("W/U/B",),  # three plain colours: no 'P', so not a hybrid-phyrexian shape either
-        ("C/P",),  # colourless phyrexian mana was never printed
-        ("2/P",),  # nor generic phyrexian mana
+        ("C/P",),  # phyrexian mana is only ever a colour's, never colourless's
+        ("2/P",),  # nor generic's
         ("W/1",),  # generic-hybrid's generic side is always '2'
-        ("U/B/P",),  # a real colour pair, but this pairing has no hybrid-phyrexian printing
+        ("W/2",),  # ... and it's always first: {2/W}, never {W/2}
+        ("P/W",),  # phyrexian is always last: {W/P}, never {P/W}
     ],
     ids=[
         "empty",
@@ -82,7 +85,8 @@ def test_symbols_that_cannot_appear_in_a_cost_are_rejected(symbol: str) -> None:
         "colorless_phyrexian",
         "generic_phyrexian",
         "non_two_generic",
-        "unprinted_phyrexian_pair",
+        "generic_wrong_position",
+        "phyrexian_wrong_position",
     ],
 )
 def test_junk_is_rejected(symbol: str) -> None:

--- a/api/parsing/tests/test_mana_symbols.py
+++ b/api/parsing/tests/test_mana_symbols.py
@@ -8,24 +8,26 @@ from api.parsing.mana_symbols import first_invalid_mana_symbol, is_valid_mana_sy
 
 # Every distinct symbol the card corpus uses in mana_cost_text — 48 of them, via
 # `regexp_matches(mana_cost_text, '[{]([^}]*)[}]', 'g')` over magic.cards — plus generic values no
-# printing has used yet and the Un-set symbols the corpus holds no cards for ({HW} half mana on Little
-# Girl, {∞} as Gleemax's whole cost). Every one of these has to stay searchable.
+# printing has used yet. Every one of these has to stay searchable.
 _VALID = (
     *[str(n) for n in (*range(21), 100, 1000000)],
     *"WUBRGCSXYZP",
-    "∞",
-    "HW",
-    "HR",
     *("2/W", "2/U", "2/B", "2/R", "2/G"),
     *("W/U", "W/B", "U/B", "U/R", "B/R", "B/G", "R/G", "R/W", "G/W", "G/U"),
     *("C/W", "C/U", "C/B", "C/R", "C/G"),
     *("W/P", "U/P", "B/P", "R/P", "G/P"),
     *("G/U/P", "G/W/P", "R/G/P", "R/W/P"),
+    # A side is a set, not a slot: whichever order a user types a real symbol's sides in, it's the
+    # same symbol. Only a sample of reversed forms — one per shape — not every pair reversed.
+    *("U/W", "W/C", "W/2", "P/W", "U/G/P"),
 )
 
 # Real Magic symbols that no mana cost can hold: tap, untap, energy, and the planar symbols. Searching
-# mana for one of these can never match, which is the whole reason this check exists.
-_REAL_BUT_NOT_A_COST = ("T", "Q", "E", "A", "CHAOS", "PW", "TK")
+# mana for one of these can never match, which is the whole reason this check exists. '∞' (Gleemax's
+# whole cost) and half mana ({HW}, {HR}, ...) belong here too, not in _VALID: both are real printed
+# symbols, but only on cards from "funny" (Un-)sets, which `preprocess_card` filters out of the corpus
+# entirely — so a mana cost containing them can never match a row either.
+_REAL_BUT_NOT_A_COST = ("T", "Q", "E", "A", "CHAOS", "PW", "TK", "∞", "HW", "HR")
 
 
 @pytest.mark.parametrize(argnames=["symbol"], argvalues=[(sym,) for sym in _VALID], ids=_VALID)
@@ -51,10 +53,16 @@ def test_symbols_that_cannot_appear_in_a_cost_are_rejected(symbol: str) -> None:
         ("W/",),  # trailing separator leaves an empty part
         ("/W",),
         ("W W",),
-        ("HX",),  # half mana only combines with a colour
-        ("HWW",),
         ("1.5",),
         ("-1",),
+        ("W/W",),  # a side never repeats, even though 'W' is legal alone
+        ("2/2",),
+        ("C/C",),
+        ("W/U/B",),  # three plain colours: no 'P', so not a hybrid-phyrexian shape either
+        ("C/P",),  # colourless phyrexian mana was never printed
+        ("2/P",),  # nor generic phyrexian mana
+        ("W/1",),  # generic-hybrid's generic side is always '2'
+        ("U/B/P",),  # a real colour pair, but this pairing has no hybrid-phyrexian printing
     ],
     ids=[
         "empty",
@@ -65,10 +73,16 @@ def test_symbols_that_cannot_appear_in_a_cost_are_rejected(symbol: str) -> None:
         "trailing_separator",
         "leading_separator",
         "inner_space",
-        "half_non_color",
-        "half_too_long",
         "decimal",
         "negative",
+        "repeated_color_side",
+        "repeated_generic_side",
+        "repeated_colorless_side",
+        "three_colors_no_phyrexian",
+        "colorless_phyrexian",
+        "generic_phyrexian",
+        "non_two_generic",
+        "unprinted_phyrexian_pair",
     ],
 )
 def test_junk_is_rejected(symbol: str) -> None:


### PR DESCRIPTION
Follow-up from review of #909.

## Two related gaps in `is_valid_mana_symbol`

**Compound symbols were validated side-by-side, not as a whole.** Splitting a
symbol on `/` and checking each side independently against the atom set means
any combination of individually-legal sides passes: `{W/W}`, `{2/2}`, `{C/C}`,
`{W/U/B}`, `{C/P}`. Confirmed these reach production SQL via `hand_parser`
(the live parser per `parsing_f.py`) and compile fine — they just can never
match a row, so the query silently returns zero results forever instead of
400ing the way a genuinely-nonexistent symbol like `{Q}` already does.

Fixed with a flat set of every valid 2- or 3-part shape, compared as the
exact tuple `symbol.split("/")` produces:

- **Hybrid** (`{W/U}`) and **colourless-hybrid** (`{C/W}`) sides can appear in
  either order — a user typing a real symbol from memory has no reason to
  know Scryfall prints `{W/U}` rather than `{U/W}`, and the two name the same
  symbol — generated as permutations of the six symbols `{W,U,B,R,G,C}`.
- **Generic-hybrid** and **phyrexian** don't move: every printing has generic
  first (`{2/W}`, never `{W/2}`) and phyrexian last (`{W/P}`, never `{P/W}`),
  so those two stay one-directional.
- **Hybrid-phyrexian** (`{R/G/P}`) is generated for all 10 colour pairs, not
  just the 4 the card corpus happens to have printed — the shape itself
  (two distinct colours + phyrexian) is what makes a request valid, not
  whether a specific pair has shipped on a card yet.
- A side never repeats (`itertools.permutations` never repeats an element in
  one draw, so `{W/W}`/`{2/2}`/`{C/C}` are excluded structurally, no separate
  check needed).
- Never valid, by rule rather than corpus: colourless combined with generic
  or phyrexian (`{C/P}`, `{2/C}`) — Phyrexian mana is only ever a colour's
  (comprehensive rules 107.4d), and generic-hybrid is only ever generic+colour.

**`∞` and half mana were accepted despite being un-searchable by
construction.** `_ATOMS` included `'∞'` (Gleemax's whole cost, from Unglued)
and half mana (`'H'` + a colour, from Unhinged/Unstable) as valid symbols.
Both are real printed symbols, but only on cards from `set_type == "funny"`
sets, which `preprocess_card` filters out of the corpus entirely (`api/card_processing.py:108`).
So a mana cost search for either one can never match a row, same failure
mode as the compound-symbol gap above — just for two specific symbols
instead of a shape. Moved them from "valid" to `_REAL_BUT_NOT_A_COST`,
alongside `{T}`/`{Q}`/`{CHAOS}` and the other real-but-uncostable symbols.

## Verification

- `api/parsing/tests/test_mana_symbols.py`, `test_spans.py`,
  `test_regex_patterns.py`, `test_parser_parity.py`: updated/passing.
- Full `api/parsing/tests/` suite: 2057 passed, 19 xfailed.
- `ruff check` / `ruff format --check`: clean.
- Manually verified both parsers agree, and every position/order rule
  behaves as designed: `{w/u}`/`{u/w}`, `{c/w}`/`{w/c}`, `{r/g/p}`/`{g/r/p}`,
  `{u/b/p}`/`{b/u/p}` all valid; `{w/2}`, `{p/w}`, `{w/w}`, `{2/2}`, `{c/c}`,
  `{c/p}`, `{2/p}`, `{w/u/b}` all rejected.