### PR TITLE
Parsing: Validate Bare Mana Characters, Not Just Braced Ones

### DIFF
--- a/api/parsing/mana_symbols.py
+++ b/api/parsing/mana_symbols.py
@@ -56,6 +56,13 @@ _PART_SHAPES = frozenset(
 # A braced symbol anywhere in a mana value, e.g. the '2' and 'W' of '{2}{W}'.
 _BRACED_SYMBOL = re.compile(r"\{([^}]*)\}")
 
+# What card_query_nodes.mana_cost_str_to_dict/calculate_cmc actually count outside braces: a colour,
+# colourless, or X (its own real pip, per those two functions' comments). Digits are generic mana and
+# always fine bare, no matter the value. Nothing else bare — not even a single-character atom that's
+# only ever real inside braces, like 's' or 'p' — is one those two add up: they silently drop it
+# instead of erroring, which is exactly the gap this module exists to close.
+_BARE_ATOMS = frozenset("WUBRGCX")
+
 
 def _is_atom(part: str) -> bool:
     """Return True if *part* is a whole one-part symbol: generic mana or a single atom."""
@@ -81,14 +88,18 @@ def is_valid_mana_symbol(symbol: str) -> bool:
 
 
 def first_invalid_mana_symbol(value: str) -> str | None:
-    """Return the first braced symbol in *value* that no mana cost could contain, or None if every one can.
+    """Return the first symbol in *value* that no mana cost could contain, or None if every one can.
 
-    Braced symbols only, for now. A mana value may also be written bare — '2WW' for '{2}{W}{W}' — but
-    the two parsers do not agree on what a bare value is: pyparsing's mana pattern does not match
-    'hello', so 'mana:hello' takes a different branch there and never becomes a mana value at all.
-    Checking bare text here would reject on one side and not the other. '{...}' has no such ambiguity.
+    Braced symbols are checked as a whole (see `is_valid_mana_symbol`); bare characters are checked
+    one at a time against `_BARE_ATOMS`, the exact alphabet `mana_cost_str_to_dict`/`calculate_cmc`
+    count outside braces. Without this, a bare character neither function recognises — 'Q' in
+    '2WWQ', or all of 'hello' — is silently dropped by both instead of rejected: 'mana:2WWQ' would
+    quietly run as 'mana:2WW', matching cards the query never named.
     """
     for symbol in _BRACED_SYMBOL.findall(value):
         if not is_valid_mana_symbol(symbol):
             return f"{{{symbol}}}"
+    for char in _BRACED_SYMBOL.sub("", value):
+        if char not in _DIGITS and char not in _BARE_ATOMS:
+            return char
     return None

--- a/api/parsing/tests/test_mana_symbols.py
+++ b/api/parsing/tests/test_mana_symbols.py
@@ -105,8 +105,11 @@ def test_junk_is_rejected(symbol: str) -> None:
         ("{Q}{W}", "{Q}"),  # the first one, scanning left to right
         ("{W}{}", "{}"),
         ("{ AND O:BOLT)}", "{ AND O:BOLT)}"),  # what a swallowed stray brace balances to
-        ("HELLO", None),  # bare text is left alone: the two parsers disagree about what it is
-        ("{W}T", None),  # ... including a bare marker alongside a braced symbol
+        ("HELLO", "H"),  # bare text is checked one character at a time, not as a word
+        ("{W}T", "T"),  # ... including a bare marker alongside a braced symbol
+        ("2WWQ", "Q"),  # the bug this exists to close: silently dropped by calculate_cmc, not rejected
+        ("2WWX", None),  # X is bare notation's own real pip, not a leftover from a braced check
+        ("2WWS", "S"),  # 'S' is a real atom braced ({S}), but calculate_cmc never counts it bare
     ],
     ids=[
         "braced",
@@ -117,10 +120,13 @@ def test_junk_is_rejected(symbol: str) -> None:
         "invalid_first",
         "empty_symbol",
         "swallowed_brace",
-        "bare_word_untouched",
-        "bare_marker_untouched",
+        "bare_word_rejected",
+        "bare_marker_rejected",
+        "bare_extra_char_rejected",
+        "bare_x_accepted",
+        "bare_atom_not_bare_valid",
     ],
 )
 def test_first_invalid_mana_symbol(value: str, expected: str | None) -> None:
-    """Only braced symbols are checked, and the first offender is named so the message can say which."""
+    """Braced symbols are checked as a whole; bare characters are checked one at a time."""
     assert first_invalid_mana_symbol(value) == expected


### PR DESCRIPTION
Follow-up from review of #909.

## The gap

`first_invalid_mana_symbol` only scanned `{...}` spans — a bare mana value
(no braces at all) passed through completely unchecked, whatever it
contained. That's not just a missed 400: `card_query_nodes.mana_cost_str_to_dict`/
`calculate_cmc`, the functions that actually consume a bare value once it's
past the parser, silently ignore any character outside `WUBRGCX`. So
`mana:2WWQ` didn't 400, and it didn't return an empty result set either —
it silently ran as `mana:2WW`, matching cards the query never named. Traced
this end-to-end via `generate_sql_query`; confirmed the SQL produced for
`mana:2WWQ` and `mana:2WW` is identical.

## The fix

`first_invalid_mana_symbol` now checks bare characters one at a time
against exactly the alphabet `mana_cost_str_to_dict`/`calculate_cmc`
recognize. Digits are still unconditionally fine (any run is generic mana);
anything bare that isn't a digit or in `WUBRGCX` — including a
single-character atom that's only ever real *inside* braces, like bare `s`
or `p` — is now the reported offender instead of silently vanishing.

Since the function is shared between both parsers, this also closes the
same gap in pyparsing wherever its grammar already routes a bare value
through it (bare `y`/`z` — previously silently accepted there too, now
correctly rejected in both).

It does *not* close the separate, pre-existing, already-documented gap
where pyparsing's grammar doesn't recognize a bare value as mana-shaped at
all (e.g. `mana:hello`, `mana:s`) and falls back to a plain string
comparison instead of ever calling the shared validator. Fixing that would
mean widening that grammar, a bigger change than tightening validation —
and it's the test-only reference parser, not the one serving traffic
(`parsing_f.py` wires `parse_query` to `hand_parser`, not `pyparsing_based`).
The live parser now correctly 400s on all of these shapes, which is the
one that matters for production.

## Verification

- `api/parsing/tests/test_mana_symbols.py`: updated with the exact bug
  scenario (`2WWQ` → rejects on `Q`) plus coverage for the digit/bare-atom
  boundary.
- Full `api/parsing/tests/` suite: 2060 passed, 19 xfailed (unchanged xfail
  count — no new parser-parity divergence pinned or needed; the existing
  `test_parser_parity.py` fixture is driven by a real wild-query corpus
  sweep, and this shape doesn't appear in it).
- `api/tests/test_datatype_mismatch.py`, `test_parsing_errors.py`: 46 passed.
- `ruff check` / `ruff format --check`: clean.
- Manually verified end-to-end: `mana:2WWQ`, `mana:y`, `mana:z` now reject
  in both parsers (previously silently accepted or silently mismatched);
  `mana:2WWX`, `mana:2WW` unaffected.