### PR TITLE
Search & Parsing: Four Follow-Ups From the #909 Review

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -73,6 +73,18 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class _EngineDeclinedQueryError(Exception):
+    """Raised by ``_search_engine`` when the engine cannot build a query that SQL can still answer.
+
+    Kept distinct from ``falcon.HTTPBadRequest``: ``_search``'s fallback handler used to tell a
+    decline apart from a real engine failure by ``isinstance(e, falcon.HTTPBadRequest)``, which is
+    only a reliable signal because nothing else in ``_search_engine`` happens to raise that type
+    today. A dedicated exception makes "this was a decline" true by construction instead of by
+    convention, so a future HTTPBadRequest raised anywhere else in that call chain for an unrelated
+    reason can't be silently downgraded to an info-level log with no traceback.
+    """
+
+
 def _rss_mb() -> str:
     """Return current RSS in MB as a string, or 'unknown' if /proc is unavailable."""
     try:
@@ -1356,16 +1368,16 @@ class APIResource:
                 # BaseExceptions that must still propagate are the ones that are not failures.
                 if isinstance(e, (KeyboardInterrupt, SystemExit)):
                     raise
-                # An HTTPBadRequest from _search_engine is a query the engine declined to build, not
-                # an engine that broke: _QueryError means "cannot be parsed or built", and
-                # _search_engine has already logged it at info. It reaches here for two different
-                # reasons, and the SQL path resolves both correctly on its own — a pattern that is
-                # invalid everywhere (o:/^[/) becomes the 400 raised below, and one the Rust regex
-                # crate rejects but Postgres accepts (backreferences, lookaround) simply gets
-                # answered. Re-logging it at warning with a stack trace turned every keystroke inside
-                # a character class into an alertable event for a user typo. Fall through quietly;
-                # anything else really is an engine failure and keeps its traceback.
-                declined = isinstance(e, falcon.HTTPBadRequest)
+                # An _EngineDeclinedQueryError from _search_engine is a query the engine declined to
+                # build, not an engine that broke: _QueryError means "cannot be parsed or built",
+                # and _search_engine has already logged it at info. It reaches here for two
+                # different reasons, and the SQL path resolves both correctly on its own — a
+                # pattern that is invalid everywhere (o:/^[/) becomes the 400 raised below, and one
+                # the Rust regex crate rejects but Postgres accepts (backreferences, lookaround)
+                # simply gets answered. Re-logging it at warning with a stack trace turned every
+                # keystroke inside a character class into an alertable event for a user typo. Fall
+                # through quietly; anything else really is an engine failure and keeps its traceback.
+                declined = isinstance(e, _EngineDeclinedQueryError)
                 logger.log(
                     logging.INFO if declined else logging.WARNING,
                     "Engine %s %r, falling back to SQL: %s",
@@ -1425,11 +1437,8 @@ class APIResource:
                     fields=fields,
                 )
         except _QueryError as err:
-            logger.info("QueryError caught for query '%s', raising BadRequest", query)
-            raise falcon.HTTPBadRequest(
-                title="Invalid Search Query",
-                description=f'Failed to parse query: "{query}"',
-            ) from err
+            logger.info("QueryError caught for query '%s', declining to SQL", query)
+            raise _EngineDeclinedQueryError(str(err)) from err
         with timer("engine_collect"):
             cards = list(cards)
         return {

--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -642,24 +642,27 @@ class Parser:
         tok = self.peek()
         if tok.type == TT.QUOTED:
             self.consume()
-            return StringValueNode(str(tok.value))
-        parts: list[str] = []
-        while True:
-            t = self.peek()
-            if t.type == TT.MANA or t.type in (TT.WORD, TT.NUMBER):
-                if parts and t.space_before:
+            value = str(tok.value).upper()
+        else:
+            parts: list[str] = []
+            while True:
+                t = self.peek()
+                if t.type == TT.MANA or t.type in (TT.WORD, TT.NUMBER):
+                    if parts and t.space_before:
+                        break
+                    self.consume()
+                    parts.append(str(t.value))
+                else:
                     break
-                self.consume()
-                parts.append(str(t.value))
-            else:
-                break
-        if not parts:
-            msg = f"Expected mana value at position {self.peek().pos}"
-            raise ParseError(msg)
-        value = "".join(parts).upper()
+            if not parts:
+                msg = f"Expected mana value at position {self.peek().pos}"
+                raise ParseError(msg)
+            value = "".join(parts).upper()
         # A mana cost can only hold certain symbols, so anything else is a query that cannot match.
         # '{Q}' is a real symbol (untap) but never appears in a cost, which is why this asks what a
-        # cost may contain rather than what Magic prints.
+        # cost may contain rather than what Magic prints. Quoting a value is just an alternate way to
+        # type it (e.g. to protect spaces), not an opt-out of this check — a quoted 'mana:"q"' used to
+        # skip straight to StringValueNode, so it silently matched every card via an empty cost dict.
         invalid = first_invalid_mana_symbol(value)
         if invalid is not None:
             msg = f"Invalid mana symbol {invalid!r} at position {tok.pos}"

--- a/api/parsing/pyparsing_based.py
+++ b/api/parsing/pyparsing_based.py
@@ -270,7 +270,12 @@ def create_mana_parsers() -> dict[str, ParserElement]:
     def make_mana_value_node(tokens: list[str]) -> ManaValueNode:
         """Create a ManaValueNode for mana cost strings."""
         value = tokens[0].upper()
-        # Shared with hand_parser.parse_mana_value, so the two parsers reject the same symbols.
+        # Shared with hand_parser.parse_mana_value, so the two parsers reject the same symbols —
+        # for any value this grammar recognizes as mana-shaped in the first place. A bare value
+        # this pattern doesn't match (e.g. "hello") never reaches this parse action at all and
+        # falls through to a plain string comparison instead; that gap is pyparsing-only (this is
+        # the test-only reference parser, not the one serving traffic) and left unfixed, since
+        # closing it means widening the grammar rather than tightening this validator.
         # parse_search_query turns a ValueError from a parse action into a query-level parse error.
         invalid = first_invalid_mana_symbol(value)
         if invalid is not None:
@@ -280,8 +285,23 @@ def create_mana_parsers() -> dict[str, ParserElement]:
 
     mana_value = mixed_mana_pattern.set_parse_action(make_mana_value_node)
 
+    def make_mana_quoted_value_node(tokens: list[str]) -> ManaValueNode:
+        """Create a ManaValueNode for a quoted mana value.
+
+        Quoting a value is just an alternate way to type it, not an opt-out of
+        make_mana_value_node's alphabet check — the generic quoted_string element used by every
+        other attribute skips that check entirely, which let 'mana:"q"' through as an unvalidated
+        StringValueNode that resolved to an empty cost dict and matched every card.
+        """
+        return make_mana_value_node(tokens)
+
+    mana_quoted_value = (QuotedString('"', esc_char="\\") | QuotedString("'", esc_char="\\")).set_parse_action(
+        make_mana_quoted_value_node,
+    )
+
     return {
         "mana_value": mana_value,
+        "mana_quoted_value": mana_quoted_value,
         "mixed_mana_pattern": mixed_mana_pattern,
     }
 
@@ -320,6 +340,7 @@ def create_all_condition_parsers(basic_parsers: dict, mana_parsers: dict, color_
     lparen = basic_parsers["lparen"]
     rparen = basic_parsers["rparen"]
     mana_value = mana_parsers["mana_value"]
+    mana_quoted_value = mana_parsers["mana_quoted_value"]
     color_value = color_parsers["color_value"]
 
     numeric_attr_word = create_attribute_parser(ParserClass.NUMERIC)
@@ -349,7 +370,7 @@ def create_all_condition_parsers(basic_parsers: dict, mana_parsers: dict, color_
     unified_numeric_comparison = numeric_comparison_lhs + DEFAULT_OPERATORS + numeric_comparison_rhs
     unified_numeric_comparison.set_parse_action(make_binary_operator_node)
 
-    mana_value_or_string = mana_value | quoted_string | string_value_word
+    mana_value_or_string = mana_value | mana_quoted_value | string_value_word
     mana_condition = create_condition_parser(mana_attr_word, mana_value_or_string)
 
     color_condition = create_condition_parser(color_attr_word, color_value | quoted_string)

--- a/api/parsing/tests/test_parser_parity.py
+++ b/api/parsing/tests/test_parser_parity.py
@@ -45,6 +45,24 @@ def test_both_parsers_agree(query: str) -> None:
     assert_parsers_agree(query)
 
 
+@pytest.mark.parametrize(
+    argnames=["query"],
+    argvalues=[
+        ('mana:"2WW"',),
+        ('mana:"q"',),
+        ('mana:"2WWQ"',),
+    ],
+    ids=["quoted_valid", "quoted_invalid_bare_char", "quoted_invalid_trailing_char"],
+)
+def test_quoted_mana_value_parity(query: str) -> None:
+    """A quoted mana value is validated the same as bare/braced notation in both parsers.
+
+    'mana:"q"' used to skip the alphabet check entirely in both parsers, resolving to an empty
+    cost dict that matched every card instead of 400ing or matching nothing.
+    """
+    assert_parsers_agree(query)
+
+
 # Real queries from benchmarks/wild-queries/wild-corpus.jsonl on which the two parsers disagree
 # today, grouped by the root cause in #903. Sweeping that 14k-query corpus found exactly these.
 #

--- a/api/parsing/tests/test_pyparsing_parser.py
+++ b/api/parsing/tests/test_pyparsing_parser.py
@@ -781,6 +781,19 @@ def test_parse_combined_mana_queries() -> None:
     assert result2.root == expected2
 
 
+def test_parse_quoted_mana_value() -> None:
+    """A quoted mana value validates the same as an unquoted one, not an opt-out of that check."""
+    observed = parsing.parse_search_query('mana:"2WW"')
+    expected = BinaryOperatorNode(CardAttributeNode("mana", ParserClass.MANA), ":", parsing.ManaValueNode("2WW"))
+    assert observed.root == expected
+
+
+def test_quoted_invalid_mana_symbol_is_rejected() -> None:
+    """'mana:"q"' used to skip validation entirely and resolve to an empty cost, matching every card."""
+    with pytest.raises(ValueError, match="Failed to parse query"):
+        parsing.parse_search_query('mana:"q"')
+
+
 def test_mana_cost_with_comparison_operators() -> None:
     """Test that mana cost searches work with different operators."""
     # Test colon operator (most common)

--- a/api/static/app.js
+++ b/api/static/app.js
@@ -430,7 +430,45 @@ class CardSearch {
   // The second half of _processQuery, split out so performSearch can inspect the autocompleted query
   // before balancing hides whether a span was left empty.
   _balanceAndNormalize(autocompleted) {
-    return this.balanceQuery(autocompleted).trim().replace(/\s+/g, ' ');
+    return this.collapseWhitespaceOutsideSpans(this.balanceQuery(autocompleted)).trim();
+  }
+
+  // Collapses runs of whitespace to a single space, except inside a quoted string or /regex/ (mana
+  // symbols never contain whitespace, so they need no protection here). A plain `.replace(/\s+/g, ' ')`
+  // over the whole query would silently rewrite `o:/a  b/` to `o:/a b/` and `o:"draw  a  card"` to
+  // `o:"draw a card"`, changing what the user actually typed before it ever reaches the server.
+  collapseWhitespaceOutsideSpans(query) {
+    let out = '';
+
+    for (let i = 0; i < query.length; i++) {
+      const char = query[i];
+
+      if (char === '"' || char === "'") {
+        const closeIndex = this.quoteCloseIndex(query, i + 1, char);
+        if (closeIndex !== null) {
+          out += query.slice(i, closeIndex + 1);
+          i = closeIndex;
+          continue;
+        }
+      } else if (char === '/' && this.opensRegex(query, i)) {
+        const closeIndex = this.regexCloseIndex(query, i + 1);
+        if (closeIndex !== null) {
+          out += query.slice(i, closeIndex + 1);
+          i = closeIndex;
+          continue;
+        }
+      }
+
+      if (/\s/.test(char)) {
+        if (!out.endsWith(' ')) {
+          out += ' ';
+        }
+      } else {
+        out += char;
+      }
+    }
+
+    return out;
   }
 
   async fetchCommonCardTypes() {
@@ -645,11 +683,11 @@ class CardSearch {
     return suffix === null ? query : query + suffix;
   }
 
-  // Blanks the body of every quoted string and closed /regex/ span, keeping the delimiters, so the
-  // structural checks in validateQuery cannot fire on a ':' or ')' that is really string or pattern
-  // content. Built on the same opensRegex/regexCloseIndex primitives as balanceSuffix and the
-  // lexer, because a fourth opinion about where a regex starts is a fourth way to reject a query
-  // the parser accepts (o:/x:)/).
+  // Blanks the body of every quoted string, closed /regex/ span, and {mana symbol}, keeping the
+  // delimiters, so the structural checks in validateQuery cannot fire on a ':' or ')' that is
+  // really string, pattern, or mana content. Built on the same opensRegex/regexCloseIndex/
+  // braceCloseIndex primitives as balanceSuffix and the lexer, because a fourth opinion about
+  // where a span starts is a fourth way to reject a query the parser accepts (o:/x:)/).
   blankOpaqueSpans(query) {
     let out = '';
 
@@ -670,9 +708,16 @@ class CardSearch {
           i = closeIndex;
           continue;
         }
+      } else if (char === '{') {
+        const closeIndex = this.braceCloseIndex(query, i + 1);
+        if (closeIndex !== null) {
+          out += '{}';
+          i = closeIndex;
+          continue;
+        }
       }
 
-      // An unterminated quote or regex is not a span yet, so it stays an ordinary character.
+      // An unterminated quote, regex, or mana symbol is not a span yet, so it stays an ordinary character.
       out += char;
     }
 

--- a/api/static/app.test.js
+++ b/api/static/app.test.js
@@ -403,6 +403,43 @@ describe('CardSearch balanceQuery', () => {
   });
 });
 
+describe('CardSearch blankOpaqueSpans', () => {
+  it('blanks the body of a closed mana symbol the same way it blanks quotes and regexes', () => {
+    // Before this, only '"'/"'"/'/' were handled here, unlike scanSpans — a "fourth opinion" gap
+    // matching the exact bug class this blanking exists to prevent, just left open for braces.
+    expect(search.blankOpaqueSpans('mana:{2/W} and')).toBe('mana:{} and');
+  });
+
+  it('still blanks quotes and regexes', () => {
+    expect(search.blankOpaqueSpans('oracle:"and or"')).toBe('oracle:""');
+    expect(search.blankOpaqueSpans('o:/and:/')).toBe('o://');
+  });
+});
+
+describe('CardSearch collapseWhitespaceOutsideSpans', () => {
+  it('preserves internal whitespace inside a regex or quoted string', () => {
+    expect(search.collapseWhitespaceOutsideSpans('o:/a  b/')).toBe('o:/a  b/');
+    expect(search.collapseWhitespaceOutsideSpans('oracle:"draw  a  card"')).toBe('oracle:"draw  a  card"');
+  });
+
+  it('collapses runs of whitespace outside spans to a single space', () => {
+    expect(search.collapseWhitespaceOutsideSpans('t:elf   o:bolt')).toBe('t:elf o:bolt');
+  });
+});
+
+describe('CardSearch _balanceAndNormalize', () => {
+  // A plain `.replace(/\s+/g, ' ')` over the whole query would silently rewrite what a regex or
+  // quoted value actually matches before it ever reaches the server.
+  it('does not collapse whitespace inside a regex or quoted string', () => {
+    expect(search._balanceAndNormalize('o:/a  b/')).toBe('o:/a  b/');
+    expect(search._balanceAndNormalize('oracle:"draw  a  card"')).toBe('oracle:"draw  a  card"');
+  });
+
+  it('still trims and collapses whitespace outside spans', () => {
+    expect(search._balanceAndNormalize('  t:elf   o:bolt  ')).toBe('t:elf o:bolt');
+  });
+});
+
 describe('CardSearch createCardHTML no-JS parity', () => {
   // Keep in sync with normalize_card_html in api/tests/test_noscript_parity.py.
   // Strips the loading-hint attributes (fetchpriority/loading logic intentionally

--- a/api/tests/test_parsing_errors.py
+++ b/api/tests/test_parsing_errors.py
@@ -121,19 +121,21 @@ class TestSearchRouting:
     def test_engine_declining_a_query_falls_back_without_a_warning(self, caplog: pytest.LogCaptureFixture) -> None:
         """A query the engine cannot build is a user error, not an alertable engine failure.
 
-        _search_engine turns _QueryError into HTTPBadRequest and logs it at info. That reaches the
-        SQL fallback, which used to re-log it at warning with a stack trace — so every keystroke
-        inside a character class (`o:/^[`, balanced to `o:/^[/` by typeahead) produced an alertable
-        event. The Rust regex crate also rejects patterns Postgres accepts, so this path is reached
-        by working queries too; either way the SQL path decides the outcome.
+        _search_engine turns _QueryError into _EngineDeclinedQueryError and logs it at info. That
+        reaches the SQL fallback, which used to re-log it at warning with a stack trace — so every
+        keystroke inside a character class (`o:/^[`, balanced to `o:/^[/` by typeahead) produced an
+        alertable event. The Rust regex crate also rejects patterns Postgres accepts, so this path
+        is reached by working queries too; either way the SQL path decides the outcome.
         """
+        from api.api_resource import _EngineDeclinedQueryError  # noqa: PLC0415
+
         self.api_resource._engine.size.return_value = 87
         sentinel = {"cards": [], "total_cards": 0, "query": "o:/^[/"}
         with (
             patch.object(
                 self.api_resource,
                 "_search_engine",
-                side_effect=falcon.HTTPBadRequest(title="Invalid Search Query", description="nope"),
+                side_effect=_EngineDeclinedQueryError("nope"),
             ),
             patch.object(self.api_resource, "_search_sql", return_value=sentinel) as mock_sql,
             caplog.at_level("INFO"),
@@ -144,6 +146,36 @@ class TestSearchRouting:
         assert result is sentinel
         assert [r.levelname for r in caplog.records if "falling back to SQL" in r.getMessage()] == ["INFO"]
         assert not [r for r in caplog.records if r.exc_info]
+
+    def test_an_unrelated_bad_request_from_the_engine_still_warns_with_a_traceback(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Only _EngineDeclinedQueryError is a decline — a bare HTTPBadRequest from elsewhere is not.
+
+        Classifying by isinstance(e, falcon.HTTPBadRequest) used to treat any HTTPBadRequest raised
+        anywhere in _search_engine's call chain as a benign decline, purely because nothing else
+        happened to raise that type. A dedicated exception makes that true by construction: an
+        HTTPBadRequest raised for some other reason must still surface as an alertable failure.
+        """
+        self.api_resource._engine.size.return_value = 87
+        sentinel = {"cards": [], "total_cards": 0, "query": "name:opt"}
+        with (
+            patch.object(
+                self.api_resource,
+                "_search_engine",
+                side_effect=falcon.HTTPBadRequest(title="Invalid Search Query", description="nope"),
+            ),
+            patch.object(self.api_resource, "_search_sql", return_value=sentinel) as mock_sql,
+            caplog.at_level("INFO"),
+        ):
+            result = self.api_resource._search(query="name:opt", limit=10)
+
+        mock_sql.assert_called_once()
+        assert result is sentinel
+        warnings = [r for r in caplog.records if "falling back to SQL" in r.getMessage()]
+        assert [r.levelname for r in warnings] == ["WARNING"]
+        assert all(r.exc_info for r in warnings)
 
     def test_a_real_engine_failure_still_warns_with_a_traceback(self, caplog: pytest.LogCaptureFixture) -> None:
         """Quieting the declined-query case must not quiet an engine that actually broke."""
@@ -250,6 +282,14 @@ class TestSearchEngineDirect:
         self.api_resource._search_engine(**search_kwargs("name:opt", limit=5))
         call_kwargs = self.api_resource._engine.query.call_args.kwargs
         assert call_kwargs["limit"] == 5
+
+    def test_query_error_is_raised_as_engine_declined_query(self) -> None:
+        from api.api_resource import _EngineDeclinedQueryError  # noqa: PLC0415
+        from card_engine import QueryError  # noqa: PLC0415
+
+        self.api_resource._engine.query.side_effect = QueryError("cannot build")
+        with pytest.raises(_EngineDeclinedQueryError):
+            self.api_resource._search_engine(**search_kwargs("o:/^[/"))
 
 
 class TestResultFieldSelection:


### PR DESCRIPTION
Four gaps surfaced reviewing #909, stacked on it the same way #931/#933/#934 are.

## A quoted mana value skipped validation entirely

`parse_mana_value` (hand_parser) and the mana grammar's quoted-string branch (pyparsing_based) both returned a bare `StringValueNode` for a quoted token before `first_invalid_mana_symbol` ever ran. `mana:"q"` parsed successfully and resolved to an empty `mana_cost_jsonb` containment, silently matching every card — the same "matches everything" failure class #909/#933/#934 closed for bare and braced notation, just reachable again by wrapping the value in quotes. Fixed by routing the quoted branch through the same validation (and uppercasing) as the unquoted path in both parsers; pyparsing gets a small dedicated `mana_quoted_value` element since its generic `quoted_string` is shared by every other attribute.

`pyparsing_based.py`'s "shared with hand_parser" comment also overstated the parity it establishes — true only for values pyparsing's grammar recognizes as mana-shaped to begin with (a bare `mana:hello` never reaches the shared validator there). That gap is pyparsing-only and pre-existing; left it documented rather than widening the grammar to fix it.

## Engine-decline classification keyed on exception type, not origin

`_search`'s fallback handler told a benign engine decline apart from a real engine failure with `isinstance(e, falcon.HTTPBadRequest)` — reliable only because nothing else in `_search_engine` happens to raise that type today. Introduced `_EngineDeclinedQueryError`, raised only from the `_QueryError` catch, so "this was a decline" is true by construction instead of by convention: a future `HTTPBadRequest` raised anywhere else in that call chain now correctly surfaces as an alertable failure instead of being silently downgraded to an info-level log with no traceback.

## Two structural gaps in the frontend query balancer

`blankOpaqueSpans` handled quotes and `/regex/` but not `{mana symbols}`, unlike its sibling `scanSpans` — a "fourth opinion" gap matching the exact bug class that blanking exists to prevent, just left open for braces. And `_balanceAndNormalize`'s `.replace(/\s+/g, ' ')` ran over the whole query with no span awareness, silently collapsing meaningful double spaces inside a `/regex/` or `"quoted string"` before the request was ever sent.

## Verification

- `python -m pytest api/parsing/tests/ api/tests/ -k "not integration and not testcontainers"`: 2651 passed, 19 xfailed
- `npx jest api/static/app.test.js`: 1915 passed
- `ruff check`, `ruff format --check`, `prettier --check`: clean
- Manually verified against a throwaway Postgres 17 container that "regular expression is too complex" (SQLSTATE 2201B) is already handled by the existing `InvalidRegularExpression` catch — a suspected `ProgramLimitExceeded` gap from the review turned out not to exist.