### PR TITLE
Search & Parsing: Fix performSearch Whitespace, and More Follow-Ups From #909

### DIFF
--- a/api/parsing/mana_symbols.py
+++ b/api/parsing/mana_symbols.py
@@ -21,7 +21,9 @@ from api.parsing.card_query_nodes import BRACED_MANA_SYMBOL as _BRACED_SYMBOL
 
 _DIGITS = frozenset("0123456789")
 
-_COLORS = frozenset("WUBRG")
+# The five colours, derived from _BARE_ATOMS rather than retyped, so the two can't silently disagree
+# about which letters they are.
+_COLORS = _BARE_ATOMS - frozenset("CX")
 
 # Single-character atoms: a colour, colourless, snow, the variables, and phyrexian. Grounded in the 48
 # distinct symbols the card corpus uses in mana_cost_text, plus generic values no printing has used
@@ -87,11 +89,22 @@ def first_invalid_mana_symbol(value: str) -> str | None:
     count outside braces. Without this, a bare character neither function recognises — 'Q' in
     '2WWQ', or all of 'hello' — is silently dropped by both instead of rejected: 'mana:2WWQ' would
     quietly run as 'mana:2WW', matching cards the query never named.
+
+    One pass over `value`: `_BRACED_SYMBOL.finditer` walks it once, and the bare characters between
+    (and after) the matches it finds are checked as that single walk goes, left to right — rather than
+    a first pass collecting every braced symbol and a second re-deriving the bare characters by
+    stripping them back out.
     """
-    for symbol in _BRACED_SYMBOL.findall(value):
+    pos = 0
+    for match in _BRACED_SYMBOL.finditer(value):
+        for char in value[pos : match.start()]:
+            if char not in _DIGITS and char not in _BARE_ATOMS:
+                return char
+        symbol = match.group(1)
         if not is_valid_mana_symbol(symbol):
             return f"{{{symbol}}}"
-    for char in _BRACED_SYMBOL.sub("", value):
+        pos = match.end()
+    for char in value[pos:]:
         if char not in _DIGITS and char not in _BARE_ATOMS:
             return char
     return None

--- a/api/parsing/parsing_f.py
+++ b/api/parsing/parsing_f.py
@@ -6,26 +6,19 @@ from typing import TYPE_CHECKING
 
 from api.parsing.hand_parser import parse_query as _parse_query
 from api.parsing.rewrite import rewrite_query
-from api.parsing.spans import (
-    QUOTE_CHARS,
-    brace_close_index,
-    has_dangling_escape,
-    opens_regex,
-    quote_close_index,
-    regex_close_index,
-)
+from api.parsing.spans import QUOTE_CHARS, brace_close_index, find_close_index, opens_regex
 
 if TYPE_CHECKING:
     from api.parsing.nodes import Query
 
 
-def _closer_for_partial_span(query: str, content_start: int, closer: str) -> str:
-    """Return the suffix that closes a span whose content starts at *content_start* and runs to the end.
+def _closer_for_partial_span(dangling_escape: bool, closer: str) -> str:
+    """Return the suffix that closes a span left open on a *dangling_escape* or not.
 
     A trailing backslash has nothing to escape yet, so appending *closer* on its own would escape
     *that* instead of ending the span — escape the backslash first.
     """
-    return ("\\" if has_dangling_escape(query, content_start) else "") + closer
+    return ("\\" if dangling_escape else "") + closer
 
 
 def balance_partial_query(query: str) -> str:
@@ -52,9 +45,9 @@ def balance_partial_query(query: str) -> str:
         # and the lexer cannot drift apart — where they disagree, the balancer "fixes" a quote the
         # lexer never saw (#905).
         if char in QUOTE_CHARS:
-            close_index = quote_close_index(query, pos, char)
+            close_index, dangling_escape = find_close_index(query, pos, char)
             if close_index is None:
-                span_suffix = _closer_for_partial_span(query, pos, char)
+                span_suffix = _closer_for_partial_span(dangling_escape, char)
                 break
             pos = close_index + 1
             continue
@@ -62,12 +55,12 @@ def balance_partial_query(query: str) -> str:
         # A '/' in value position opens a regex; anywhere else it is division, an ordinary character.
         if char == "/":
             if opens_regex(query, pos - 1):
-                close_index = regex_close_index(query, pos)
+                close_index, dangling_escape = find_close_index(query, pos, "/")
                 if close_index is None:
                     # Still being typed. Close the regex rather than reading on, or the metacharacters
                     # the user has typed so far get balanced as query structure: `o:/[)` is a partial
                     # `o:/[)]/`, not a stray ')'.
-                    span_suffix = _closer_for_partial_span(query, pos, "/")
+                    span_suffix = _closer_for_partial_span(dangling_escape, "/")
                     break
                 pos = close_index + 1
             continue

--- a/api/parsing/spans.py
+++ b/api/parsing/spans.py
@@ -54,26 +54,37 @@ def brace_close_index(query: str, start: int) -> int | None:
 
 def regex_close_index(query: str, start: int) -> int | None:
     """Return the index of the '/' closing a regex that opened before *start*, or None if unterminated."""
-    return _close_index(query, start, "/")
+    return find_close_index(query, start, "/")[0]
 
 
 def quote_close_index(query: str, start: int, quote: str) -> int | None:
     """Return the index of the *quote* closing a string that opened before *start*, or None if unterminated."""
-    return _close_index(query, start, quote)
+    return find_close_index(query, start, quote)[0]
 
 
-def _close_index(query: str, start: int, closer: str) -> int | None:
-    """Return the index of the next unescaped *closer* at or after *start*, or None if there is none."""
+def find_close_index(query: str, start: int, closer: str) -> tuple[int | None, bool]:
+    """Return the index of the next unescaped *closer* at or after *start* and whether a dangling escape ended it.
+
+    The first element is the index, or None if *closer* is never found; the second is True only when the
+    walk instead ran to the end of *query* on a dangling escape — both answers a single walk already has
+    to compute.
+
+    A caller that only needs the index (the lexer, `regex_close_index`/`quote_close_index`) can ignore
+    the second value; a balancer completing an unterminated span needs both, and calling this once is
+    the only way to get them without walking the same tail of *query* twice.
+    """
     pos = start
     length = len(query)
     while pos < length:
-        if query[pos] == "\\" and pos + 1 < length:
+        if query[pos] == "\\":
+            if pos + 1 >= length:
+                return None, True
             pos += 2
         elif query[pos] == closer:
-            return pos
+            return pos, False
         else:
             pos += 1
-    return None
+    return None, False
 
 
 def has_dangling_escape(query: str, start: int) -> bool:

--- a/api/parsing/tests/test_mana_symbols.py
+++ b/api/parsing/tests/test_mana_symbols.py
@@ -110,6 +110,8 @@ def test_junk_is_rejected(symbol: str) -> None:
         ("2WWQ", "Q"),  # the bug this exists to close: silently dropped by calculate_cmc, not rejected
         ("2WWX", None),  # X is bare notation's own real pip, not a leftover from a braced check
         ("2WWS", "S"),  # 'S' is a real atom braced ({S}), but calculate_cmc never counts it bare
+        ("H{Q}", "H"),  # the bare 'H' comes before '{Q}' in the string, so it is the true first offender
+        ("{Q}H", "{Q}"),  # here the braced symbol genuinely is first
     ],
     ids=[
         "braced",
@@ -125,6 +127,8 @@ def test_junk_is_rejected(symbol: str) -> None:
         "bare_extra_char_rejected",
         "bare_x_accepted",
         "bare_atom_not_bare_valid",
+        "bare_before_braced",
+        "braced_before_bare",
     ],
 )
 def test_first_invalid_mana_symbol(value: str, expected: str | None) -> None:

--- a/api/static/app.js
+++ b/api/static/app.js
@@ -433,6 +433,28 @@ class CardSearch {
     return this.collapseWhitespaceOutsideSpans(this.balanceQuery(autocompleted)).trim();
   }
 
+  // Returns the index closing the quoted string, /regex/, or {mana symbol} that opens at i, or null if
+  // `query[i]` doesn't open one there, or it never closes — callers that only act on a *closed* span
+  // treat both cases identically, so they don't need to tell them apart. scanSpans doesn't use this: it
+  // has to act on the unterminated case too (closing the span, reporting where its content started),
+  // so it calls quoteCloseIndex/regexCloseIndex/braceCloseIndex directly.
+  // The JS counterpart of no single Python function — spans.py's callers each make this same
+  // three-way dispatch themselves, since hand_parser's lexer and parsing_f's balancer need the
+  // unterminated case too.
+  closedSpanEnd(query, i) {
+    const char = query[i];
+    if (char === '"' || char === "'") {
+      return this.quoteCloseIndex(query, i + 1, char);
+    }
+    if (char === '/' && this.opensRegex(query, i)) {
+      return this.regexCloseIndex(query, i + 1);
+    }
+    if (char === '{') {
+      return this.braceCloseIndex(query, i + 1);
+    }
+    return null;
+  }
+
   // Collapses runs of whitespace to a single space, except inside a quoted string or /regex/ (mana
   // symbols never contain whitespace, so they need no protection here). A plain `.replace(/\s+/g, ' ')`
   // over the whole query would silently rewrite `o:/a  b/` to `o:/a b/` and `o:"draw  a  card"` to
@@ -441,24 +463,14 @@ class CardSearch {
     let out = '';
 
     for (let i = 0; i < query.length; i++) {
-      const char = query[i];
-
-      if (char === '"' || char === "'") {
-        const closeIndex = this.quoteCloseIndex(query, i + 1, char);
-        if (closeIndex !== null) {
-          out += query.slice(i, closeIndex + 1);
-          i = closeIndex;
-          continue;
-        }
-      } else if (char === '/' && this.opensRegex(query, i)) {
-        const closeIndex = this.regexCloseIndex(query, i + 1);
-        if (closeIndex !== null) {
-          out += query.slice(i, closeIndex + 1);
-          i = closeIndex;
-          continue;
-        }
+      const closeIndex = this.closedSpanEnd(query, i);
+      if (closeIndex !== null) {
+        out += query.slice(i, closeIndex + 1);
+        i = closeIndex;
+        continue;
       }
 
+      const char = query[i];
       if (/\s/.test(char)) {
         if (!out.endsWith(' ')) {
           out += ' ';
@@ -525,27 +537,33 @@ class CardSearch {
     return i >= 0 && ':=><'.includes(query[i]);
   }
 
-  // Returns the index of the next unescaped closer at or after start, or null when there is none.
-  // A backslash escapes the character after it, so /a\/b/ is one pattern and 'don\'t' is one string
-  // — the lexer reads them that way, so everything here has to as well (#905).
-  // The JS counterpart of _close_index in api/parsing/spans.py.
-  closeIndex(query, start, closer) {
+  // Returns { closeIndex, danglingEscape } from a single walk: closeIndex is the index of the next
+  // unescaped closer at or after start, or null if it never closes; danglingEscape is true only when
+  // the walk instead ran off the end of query on an unfinished backslash escape. A caller that only
+  // needs the index (regexCloseIndex/quoteCloseIndex, and every closed-span check) can ignore the
+  // second value; scanSpans, completing an unterminated span, needs both — computing them in one walk
+  // is the only way to get both without reading the same tail of query twice.
+  // The JS counterpart of find_close_index in api/parsing/spans.py.
+  findCloser(query, start, closer) {
     for (let i = start; i < query.length; i++) {
-      if (query[i] === '\\' && i + 1 < query.length) {
+      if (query[i] === '\\') {
+        if (i + 1 >= query.length) {
+          return { closeIndex: null, danglingEscape: true };
+        }
         i++;
       } else if (query[i] === closer) {
-        return i;
+        return { closeIndex: i, danglingEscape: false };
       }
     }
-    return null;
+    return { closeIndex: null, danglingEscape: false };
   }
 
   regexCloseIndex(query, start) {
-    return this.closeIndex(query, start, '/');
+    return this.findCloser(query, start, '/').closeIndex;
   }
 
   quoteCloseIndex(query, start, quote) {
-    return this.closeIndex(query, start, quote);
+    return this.findCloser(query, start, quote).closeIndex;
   }
 
   // Returns the index of the '}' closing a mana symbol whose content starts at start, or null when
@@ -556,27 +574,12 @@ class CardSearch {
     return index < 0 ? null : index;
   }
 
-  // True when the span opening at start runs to the end of the query on an unfinished escape, so a
-  // closer appended now would be escaped instead of ending the span.
-  // The JS counterpart of has_dangling_escape in api/parsing/spans.py.
-  hasDanglingEscape(query, start) {
-    for (let i = start; i < query.length; i++) {
-      if (query[i] === '\\') {
-        if (i + 1 >= query.length) {
-          return true;
-        }
-        i++;
-      }
-    }
-    return false;
-  }
-
-  // Returns the suffix that closes a span whose content starts at contentStart and runs to the end of
-  // the query. A trailing backslash has nothing to escape yet, so appending the closer on its own
+  // Returns the suffix that closes a span left open on a danglingEscape or not.
+  // A trailing backslash has nothing to escape yet, so appending the closer on its own
   // would escape that instead of ending the span — escape the backslash first.
   // The JS counterpart of _closer_for_partial_span in api/parsing/parsing_f.py.
-  closerForPartialSpan(query, contentStart, closer) {
-    return (this.hasDanglingEscape(query, contentStart) ? '\\' : '') + closer;
+  closerForPartialSpan(danglingEscape, closer) {
+    return (danglingEscape ? '\\' : '') + closer;
   }
 
   // One pass over the query's spans and parens, reporting both things callers need:
@@ -602,9 +605,9 @@ class CardSearch {
       // A quoted string, a /regex/ and a {mana symbol} are all opaque: the quotes and parens inside
       // them are content, not delimiters.
       if (quoteChars.has(char)) {
-        const closeIndex = this.quoteCloseIndex(query, i + 1, char);
+        const { closeIndex, danglingEscape } = this.findCloser(query, i + 1, char);
         if (closeIndex === null) {
-          spanSuffix = this.closerForPartialSpan(query, i + 1, char);
+          spanSuffix = this.closerForPartialSpan(danglingEscape, char);
           openSpanContentStart = i + 1;
           break;
         }
@@ -615,12 +618,12 @@ class CardSearch {
       // A '/' in value position opens a regex; anywhere else it is division, an ordinary character.
       if (char === '/') {
         if (this.opensRegex(query, i)) {
-          const closeIndex = this.regexCloseIndex(query, i + 1);
+          const { closeIndex, danglingEscape } = this.findCloser(query, i + 1, '/');
           if (closeIndex === null) {
             // Still being typed. Close the regex rather than reading on, or the metacharacters the
             // user has typed so far get balanced as query structure: `o:/[)` is a partial `o:/[)]/`,
             // not a stray ')'.
-            spanSuffix = this.closerForPartialSpan(query, i + 1, '/');
+            spanSuffix = this.closerForPartialSpan(danglingEscape, '/');
             openSpanContentStart = i + 1;
             break;
           }
@@ -670,36 +673,21 @@ class CardSearch {
 
   // Blanks the body of every quoted string, closed /regex/ span, and {mana symbol}, keeping the
   // delimiters, so the structural checks in validateQuery cannot fire on a ':' or ')' that is
-  // really string, pattern, or mana content. Built on the same opensRegex/regexCloseIndex/
-  // braceCloseIndex primitives as balanceSuffix and the lexer, because a fourth opinion about
-  // where a span starts is a fourth way to reject a query the parser accepts (o:/x:)/).
+  // really string, pattern, or mana content. Built on the same closedSpanEnd dispatch as
+  // collapseWhitespaceOutsideSpans, because a fourth opinion about where a span starts is a fourth way
+  // to reject a query the parser accepts (o:/x:)/).
   blankOpaqueSpans(query) {
     let out = '';
 
     for (let i = 0; i < query.length; i++) {
       const char = query[i];
-
-      if (char === '"' || char === "'") {
-        const closeIndex = this.quoteCloseIndex(query, i + 1, char);
-        if (closeIndex !== null) {
-          out += char + char;
-          i = closeIndex;
-          continue;
-        }
-      } else if (char === '/' && this.opensRegex(query, i)) {
-        const closeIndex = this.regexCloseIndex(query, i + 1);
-        if (closeIndex !== null) {
-          out += '//';
-          i = closeIndex;
-          continue;
-        }
-      } else if (char === '{') {
-        const closeIndex = this.braceCloseIndex(query, i + 1);
-        if (closeIndex !== null) {
-          out += '{}';
-          i = closeIndex;
-          continue;
-        }
+      const closeIndex = this.closedSpanEnd(query, i);
+      if (closeIndex !== null) {
+        // '""'/"''" for a quote and '//' for a regex share their open and close character; a mana
+        // symbol doesn't, so '{}' can't come from doubling char.
+        out += char === '{' ? '{}' : char + char;
+        i = closeIndex;
+        continue;
       }
 
       // An unterminated quote, regex, or mana symbol is not a span yet, so it stays an ordinary character.
@@ -761,7 +749,12 @@ class CardSearch {
       return;
     }
 
-    const normalizedQuery = (suffix === null ? autocompleted : autocompleted + suffix).trim().replace(/\s+/g, ' ');
+    // collapseWhitespaceOutsideSpans, not a plain `.replace(/\s+/g, ' ')`: the latter would collapse
+    // whitespace inside a quote or regex too, silently rewriting what the user typed (see that
+    // function's docstring). balanced reuses the suffix scanSpans already found above, rather than
+    // letting balanceQuery re-scan the same string for it.
+    const balanced = suffix === null ? autocompleted : autocompleted + suffix;
+    const normalizedQuery = this.collapseWhitespaceOutsideSpans(balanced).trim();
 
     const validationError = this.validateQuery(normalizedQuery);
     if (validationError) {

--- a/docs/issues/done/00938-mana-symbol-error-wrong-offender.md
+++ b/docs/issues/done/00938-mana-symbol-error-wrong-offender.md
@@ -1,5 +1,8 @@
 # `first_invalid_mana_symbol` Can Name the Wrong Offending Symbol
 
+**DONE — fixed in [#940](https://github.com/jbylund/sylvan_librarian/pull/940)**, via the exact
+single-pass rewrite this doc proposed below.
+
 [#938](https://github.com/jbylund/sylvan_librarian/issues/938), filed alongside the #936 review follow-ups.
 
 [`first_invalid_mana_symbol`](../../api/parsing/mana_symbols.py#L82) checks every braced symbol


### PR DESCRIPTION
Follow-ups from another #909 review round, stacked the same way as #931/#933/#934/#935/#936.

Closes #938.

## performSearch was mangling whitespace inside a span

`performSearch` built its actual outgoing query with a plain `.replace(/\s+/g, ' ')`, instead of the `collapseWhitespaceOutsideSpans` helper this branch already introduced (and wired into `_balanceAndNormalize`/`_processQuery`) for exactly this reason. A query like `o:/a  b/` reached the server as `o:/a b/` — the user's regex silently rewritten before it was ever sent. It also broke `handleSearch`'s in-flight-request comparison, since the URL it derived from and `_processQuery`'s own answer permanently disagreed for such queries, causing spurious aborts/refires on every keystroke.

## Two double-scans over the same characters

- `spans.py`'s `_close_index` (now `find_close_index`) and `has_dangling_escape` both walked the same unterminated span from scratch — one to fail to find a closer, the other immediately after to check for a trailing backslash. Merged into one function that returns both answers from a single walk; `parsing_f.py`'s balancer uses it directly instead of calling both. Mirrored in `app.js` (`closeIndex`/`hasDanglingEscape` → `findCloser`).
- `mana_symbols.py`'s `first_invalid_mana_symbol` did the same thing to find braced vs. bare characters: one regex pass via `findall`, then a second via `sub` to strip the braced parts back out and get the bare ones. Rewritten as a single `finditer` walk that checks the bare characters between (and after) each braced match as it goes. Left to right, this also closes #938 (`first_invalid_mana_symbol` naming the wrong offender on mixed input like `H{Q}`) exactly as that issue's own design doc describes — checking bare-before-braced by position rather than by which loop ran first was the fix either way.

## Duplicated span-walk loops, within app.js only

`app.js` had three near-identical loops (`collapseWhitespaceOutsideSpans`, `blankOpaqueSpans`, and `scanSpans`) each re-deriving "does a quote, regex, or mana symbol close here." Extracted the closed-span dispatch shared by the first two into `closedSpanEnd`; `scanSpans` keeps its own, since it is the one caller that also needs the *unterminated* case (to report where the still-open span's content starts).

The mana-alphabet duplication flagged in the same review round is Python-only, not JS: `mana_symbols.py`'s `_COLORS`, `card_query_nodes.py`'s `BARE_MANA_ATOMS`, and `hand_parser.py`'s `_COLOR_LETTERS` are three separate constants across three files. Only the first was a clean dedup (derived `_COLORS` from `_BARE_ATOMS`, already imported into `mana_symbols.py`, instead of retyping `"WUBRG"`) — `hand_parser.py`'s `_COLOR_LETTERS` validates a different field (`c:`/`id:` color-identity letters, case-insensitive, no `X`) and isn't the same alphabet, so merging it in would trade a real semantic difference for a false-looking dedup.

## Tests

- `python -m pytest api/parsing/`: 2067 passed, 19 xfailed
- `npx jest api/static/app.test.js`: 1831 passed
- Added a live probe confirming `performSearch`'s actual fetch URL now preserves `o:/a  b/` verbatim, matching `_processQuery`
- `ruff check` / `ruff format --check` / `prettier --check`: clean