### PR TITLE
Search & Parsing: Four Cleanup Follow-Ups From the #909 Review

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -25,7 +25,7 @@ import uuid
 from collections.abc import Sequence  # noqa: TC003
 from datetime import timedelta
 from functools import lru_cache, wraps
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 from typing import cast as typecast
 
 import cachebox
@@ -120,6 +120,19 @@ def regex_error_reason(message_primary: str | None) -> str:
         The reason to show the user, e.g. "brackets [] not balanced".
     """
     return (message_primary or "").removeprefix(_PG_REGEX_ERROR_PREFIX).strip() or _FALLBACK_REGEX_ERROR_REASON
+
+
+def _raise_query_bad_request(*, exc_name: str, query: str, description: str, err: Exception) -> NoReturn:
+    """Log and re-raise a Postgres user-error exception as a 400, in the shape every such handler needs.
+
+    Args:
+        exc_name: The Postgres exception's name, for the info log (e.g. "DatatypeMismatch").
+        query: The raw search query string that triggered the error.
+        description: The user-facing description for the HTTPBadRequest.
+        err: The caught exception, chained onto the raised HTTPBadRequest via `from`.
+    """
+    logger.info("%s caught for query '%s', raising BadRequest", exc_name, query)
+    raise falcon.HTTPBadRequest(title="Invalid Search Query", description=description) from err
 
 
 _STATIC_DIR = pathlib.Path(__file__).parent / "static"
@@ -1604,24 +1617,25 @@ class APIResource:
             with timer("run_query"):
                 result_bag = self._run_query(query=query_sql, params=params, explain=False)
         except psycopg.errors.DatatypeMismatch as err:
-            # Raise BadRequest error for invalid query syntax
             # This happens with standalone arithmetic expressions like "cmc+1"
-            logger.info("DatatypeMismatch caught for query '%s', raising BadRequest", query)
-            raise falcon.HTTPBadRequest(
-                title="Invalid Search Query",
+            _raise_query_bad_request(
+                exc_name="DatatypeMismatch",
+                query=query,
                 description=f"The search query '{query}' contains invalid syntax. "
                 "Arithmetic expressions like 'cmc+1' need to be part of a comparison (e.g., 'cmc+1>3').",
-            ) from err
+                err=err,
+            )
         except psycopg.errors.InvalidRegularExpression as err:
             # The parser does not validate regex syntax, so Postgres is the first thing to see a bad
             # pattern. That is a user error, not a server error: typeahead balances a half-typed regex
             # into a complete one on every keystroke, so `o:/^[/` is an ordinary intermediate state.
-            logger.info("InvalidRegularExpression caught for query '%s', raising BadRequest", query)
             reason = regex_error_reason(err.diag.message_primary)
-            raise falcon.HTTPBadRequest(
-                title="Invalid Search Query",
+            _raise_query_bad_request(
+                exc_name="InvalidRegularExpression",
+                query=query,
                 description=f"The search query '{query}' contains an invalid regular expression: {reason}.",
-            ) from err
+                err=err,
+            )
 
         cards = result_bag.pop("result", [])
         count_row = cards.pop()

--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -28,7 +28,7 @@ from api.parsing.nodes import (
     TrueNode,
     flatten_nested_operations,
 )
-from api.parsing.spans import QUOTE_CHARS, brace_close_index, quote_close_index, regex_close_index, unescape
+from api.parsing.spans import QUOTE_CHARS, brace_close_index
 
 # ── Alias → parser-class lookup ──────────────────────────────────────────────
 
@@ -117,6 +117,61 @@ def _is_word_cont(c: str) -> bool:
 # ── Lexer ─────────────────────────────────────────────────────────────────────
 
 
+def _closed_quote(query: str, start: int, quote: str) -> tuple[int, str] | None:
+    """Find the *quote* closing a string opened before *start* and unescape its content in one walk.
+
+    A single-pass fusion of `spans.quote_close_index` + `spans.unescape`, since the lexer (unlike the
+    balancer, which only wants the boundary) needs both the index and the unescaped text, and finding
+    the boundary already means visiting every character `unescape` would need to inspect afterward.
+
+    Returns (close_index, unescaped_content), or None if the string is unterminated.
+    """
+    pos = start
+    length = len(query)
+    parts: list[str] = []
+    while pos < length:
+        ch = query[pos]
+        if ch == "\\":
+            if pos + 1 >= length:
+                return None
+            parts.append(query[pos + 1])
+            pos += 2
+        elif ch == quote:
+            return pos, "".join(parts)
+        else:
+            parts.append(ch)
+            pos += 1
+    return None
+
+
+def _closed_regex(query: str, start: int) -> tuple[int, str] | None:
+    r"""Find the '/' closing a regex opened before *start*, unescaping only '\\/' in the same walk.
+
+    A single-pass fusion of `spans.regex_close_index` + the `\\/` -> `/` unescape: every other
+    backslash sequence (e.g. `\\d`) is passed through untouched for the regex engine to interpret,
+    matching `hand_parser`'s previous two-pass `.replace("\\/", "/")` behavior.
+
+    Returns (close_index, unescaped_content), or None if the pattern is unterminated.
+    """
+    pos = start
+    length = len(query)
+    parts: list[str] = []
+    while pos < length:
+        ch = query[pos]
+        if ch == "\\":
+            if pos + 1 >= length:
+                return None
+            nxt = query[pos + 1]
+            parts.append(nxt if nxt == "/" else ch + nxt)
+            pos += 2
+        elif ch == "/":
+            return pos, "".join(parts)
+        else:
+            parts.append(ch)
+            pos += 1
+    return None
+
+
 class LexError(ValueError):
     """Raised when the lexer encounters an unexpected character or unclosed delimiter."""
 
@@ -153,15 +208,17 @@ def tokenize(src: str) -> list[Token]:  # noqa: C901, PLR0912, PLR0915
             tokens.append(Token(TT.MANA, src[start:pos], start, sb))
             continue
 
-        # Quoted string. quote_close_index is shared with the balancer in api.parsing.spans: both
-        # have to agree that a backslash escapes the next character, or the balancer reads the ' in
-        # 'don\'t' as the close and appends a quote the lexer never wanted (#905).
+        # Quoted string. The escape-skipping walk here has to agree with the balancer's
+        # `spans.quote_close_index`/`spans.find_close_index` that a backslash escapes the next
+        # character, or the balancer reads the ' in 'don\'t' as the close and appends a quote the
+        # lexer never wanted (#905).
         if c in QUOTE_CHARS:
-            close_index = quote_close_index(src, pos + 1, c)
-            if close_index is None:
+            closed = _closed_quote(src, pos + 1, c)
+            if closed is None:
                 msg = f"Unclosed quote at position {start}"
                 raise LexError(msg)
-            tokens.append(Token(TT.QUOTED, unescape(src[pos + 1 : close_index]), start, sb))
+            close_index, content = closed
+            tokens.append(Token(TT.QUOTED, content, start, sb))
             pos = close_index + 1
             continue
 
@@ -209,16 +266,17 @@ def tokenize(src: str) -> list[Token]:  # noqa: C901, PLR0912, PLR0915
         if c == "/":
             prev = tokens[-1] if tokens else None
             in_value_position = prev is not None and prev.type == TT.OP
-            # regex_close_index is shared with the balancer in api.parsing.spans: both have to agree
-            # on where the span ends, or one of them treats a quote as a delimiter that the other
-            # treats as pattern content (#905).
-            close_index = regex_close_index(src, pos + 1) if in_value_position else None
-            if close_index is None:
+            # The escape-skipping walk here has to agree with the balancer's
+            # `spans.regex_close_index`/`spans.find_close_index` on where the span ends, or one of
+            # them treats a quote as a delimiter that the other treats as pattern content (#905).
+            closed = _closed_regex(src, pos + 1) if in_value_position else None
+            if closed is None:
                 # Division, or an unterminated regex falling back to division.
                 tokens.append(Token(TT.SLASH, "/", start, sb))
                 pos += 1
             else:
-                tokens.append(Token(TT.REGEX, src[pos + 1 : close_index].replace("\\/", "/"), start, sb))
+                close_index, content = closed
+                tokens.append(Token(TT.REGEX, content, start, sb))
                 pos = close_index + 1
             continue
 

--- a/api/parsing/spans.py
+++ b/api/parsing/spans.py
@@ -87,24 +87,6 @@ def find_close_index(query: str, start: int, closer: str) -> tuple[int | None, b
     return None, False
 
 
-def has_dangling_escape(query: str, start: int) -> bool:
-    """Return True if the span opening at *start* runs to the end of *query* on an unfinished escape.
-
-    A trailing backslash has nothing to escape yet, so appending a closer would escape *that* instead
-    of ending the span. Callers completing a partial query have to escape the backslash first.
-    """
-    pos = start
-    length = len(query)
-    while pos < length:
-        if query[pos] == "\\":
-            if pos + 1 >= length:
-                return True
-            pos += 2
-        else:
-            pos += 1
-    return False
-
-
 def unescape(text: str) -> str:
     r"""Resolve backslash escapes in span content, so ``a\'b`` becomes ``a'b``."""
     return _ESCAPED_CHAR.sub(r"\1", text)

--- a/api/parsing/tests/test_spans.py
+++ b/api/parsing/tests/test_spans.py
@@ -11,7 +11,7 @@ from api.parsing import hand_parser
 from api.parsing.spans import (
     COMPARISON_TAIL_CHARS,
     brace_close_index,
-    has_dangling_escape,
+    find_close_index,
     opens_regex,
     quote_close_index,
     regex_close_index,
@@ -127,8 +127,12 @@ def test_quote_close_index(query: str, quote: str, expected: int | None) -> None
     ids=["no_backslash", "dangling", "escaped_backslash", "escape_consumed"],
 )
 def test_has_dangling_escape(query: str, expected: bool) -> None:
-    """A trailing backslash leaves an escape with nothing to apply to."""
-    assert has_dangling_escape(query, 1) is expected
+    """A trailing backslash leaves an escape with nothing to apply to.
+
+    `find_close_index`'s dangling-escape flag is what `has_dangling_escape` used to duplicate; none
+    of these queries contain an unescaped closer, so the closer char passed here doesn't matter.
+    """
+    assert find_close_index(query, 1, "'")[1] is expected
 
 
 @pytest.mark.parametrize(

--- a/api/static/app.js
+++ b/api/static/app.js
@@ -698,9 +698,11 @@ class CardSearch {
   }
 
   // Returns an error string if the query is structurally invalid, or null if it looks ok.
-  validateQuery(query) {
+  // alreadyBalanced lets a caller that just ran scanSpans itself (and knows the answer was not
+  // null) skip a second identical scan here, rather than re-discovering what it already knows.
+  validateQuery(query, { alreadyBalanced = false } = {}) {
     // A closing paren with no matching opener can't be balanced away.
-    if (this.balanceSuffix(query) === null) {
+    if (!alreadyBalanced && this.balanceSuffix(query) === null) {
       return `Failed to parse query: "${query}"`;
     }
 
@@ -756,7 +758,9 @@ class CardSearch {
     const balanced = suffix === null ? autocompleted : autocompleted + suffix;
     const normalizedQuery = this.collapseWhitespaceOutsideSpans(balanced).trim();
 
-    const validationError = this.validateQuery(normalizedQuery);
+    // suffix !== null means scanSpans already proved this string balanceable, so validateQuery
+    // doesn't need to run that same scan on normalizedQuery a second time to reach the same answer.
+    const validationError = this.validateQuery(normalizedQuery, { alreadyBalanced: suffix !== null });
     if (validationError) {
       this.showError(`Failed to search: Invalid Search Query: ${validationError}`);
       return;

--- a/api/static/app.test.js
+++ b/api/static/app.test.js
@@ -474,6 +474,13 @@ describe('CardSearch validateQuery', () => {
     expect(search.validateQuery('(t:)')).toBe('Failed to parse query: "(t:)"');
     expect(search.validateQuery('name:test and')).toBe('Failed to parse query: "name:test and"');
   });
+
+  it('alreadyBalanced skips the balance re-check, but not the other structural checks', () => {
+    // A caller vouching for balance it hasn't actually verified is a caller bug, not something
+    // validateQuery should paper over — the option exists for callers that just ran scanSpans.
+    expect(search.validateQuery('hello)', { alreadyBalanced: true })).toBeNull();
+    expect(search.validateQuery('t:', { alreadyBalanced: true })).toBe('Failed to parse query: "t:"');
+  });
 });
 
 // The backend runs this same fixture through both parsers in test_balance_parity.py, so the client
@@ -496,15 +503,16 @@ describe('CardSearch performSearch', () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  // performSearch used to call scanSpans twice per keystroke for the empty-span guard and again
-  // for balancing, before reusing one scan for both. validateQuery's own balanceSuffix check
-  // is a separate, intentional third call over the post-balance string, not part of this guard.
-  it('scans spans only once for the empty-span guard and balancing', async () => {
+  // performSearch used to call scanSpans up to three times per keystroke: once for the empty-span
+  // guard, again for balancing, and a third time inside validateQuery's own balanceSuffix check —
+  // even though performSearch already knows the string is balanceable by the time it calls
+  // validateQuery. All three now share the one scan performSearch runs up front.
+  it('scans spans only once for the empty-span guard, balancing, and validation', async () => {
     const spy = jest.spyOn(search, 'scanSpans');
 
     await search.performSearch('name:bolt');
 
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledTimes(1);
     spy.mockRestore();
   });
 


### PR DESCRIPTION
Four of the five cleanup/efficiency items from #942, surfaced while reviewing #909. Item E (`gen_postgres_conf.py`'s magic number) is out of scope here.

## A — copy-pasted exception-to-400 handler

`api_resource.py`'s `DatatypeMismatch` and `InvalidRegularExpression` handlers shared the same log-then-raise-`HTTPBadRequest` shape, spelled out twice. Factored into `_raise_query_bad_request(exc_name, query, description, err)`.

## B — redundant re-scan in the search hot path

`performSearch` already knows a query is balanceable (via its own `scanSpans` call) before it calls `validateQuery`, which re-ran the same scan to reach the same answer. `validateQuery` now takes an `alreadyBalanced` option so the caller can skip the repeat scan when it already has the answer; the one production call site passes `suffix !== null`.

## C — double-pass scan-then-unescape in the lexer

`hand_parser.tokenize` found each quoted string's and regex's closing delimiter, then re-scanned the same substring to unescape it. `_closed_quote`/`_closed_regex` fuse both into one walk. `spans.find_close_index`/`quote_close_index`/`regex_close_index` are untouched — the balancer still uses them as-is; only the lexer's own double-scan is removed.

## D — dead code

`spans.has_dangling_escape` had no production caller; `find_close_index` already returns the same flag in one pass, and every real caller uses that. Deleted, and its test repointed at `find_close_index`'s second return value.

## Tests

- Existing `test_spans.py` repointed, not narrowed (D)
- `app.test.js`'s scan-count assertion updated from 2 → 1 calls, plus a new test pinning `alreadyBalanced`'s contract (B)
- Full suite: 2938 Python tests + 19 xfail, 1832 JS tests, all passing
- `ruff check`/`ruff format --check`/`prettier --check` clean on touched files

No behavior changes — each item is a same-output refactor.
