### PR TITLE
Search & Parsing: Share the Scan Instead of Re-Walking It

### DIFF
--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -28,7 +28,7 @@ from api.parsing.nodes import (
     TrueNode,
     flatten_nested_operations,
 )
-from api.parsing.spans import QUOTE_CHARS, brace_close_index
+from api.parsing.spans import QUOTE_CHARS, brace_close_index, find_close_index, unescape
 
 # ── Alias → parser-class lookup ──────────────────────────────────────────────
 
@@ -118,58 +118,34 @@ def _is_word_cont(c: str) -> bool:
 
 
 def _closed_quote(query: str, start: int, quote: str) -> tuple[int, str] | None:
-    """Find the *quote* closing a string opened before *start* and unescape its content in one walk.
+    """Find the *quote* closing a string opened before *start* and unescape its content.
 
-    A single-pass fusion of `spans.quote_close_index` + `spans.unescape`, since the lexer (unlike the
-    balancer, which only wants the boundary) needs both the index and the unescaped text, and finding
-    the boundary already means visiting every character `unescape` would need to inspect afterward.
+    Delegates the boundary walk to `spans.find_close_index` — the same walk the balancer uses — so
+    the lexer and balancer can't drift on where an escaped quote ends (#905). Unescaping via
+    `spans.unescape`'s compiled regex is also faster in practice than a hand-rolled char loop.
 
     Returns (close_index, unescaped_content), or None if the string is unterminated.
     """
-    pos = start
-    length = len(query)
-    parts: list[str] = []
-    while pos < length:
-        ch = query[pos]
-        if ch == "\\":
-            if pos + 1 >= length:
-                return None
-            parts.append(query[pos + 1])
-            pos += 2
-        elif ch == quote:
-            return pos, "".join(parts)
-        else:
-            parts.append(ch)
-            pos += 1
-    return None
+    close_index, _ = find_close_index(query, start, quote)
+    if close_index is None:
+        return None
+    return close_index, unescape(query[start:close_index])
 
 
 def _closed_regex(query: str, start: int) -> tuple[int, str] | None:
-    r"""Find the '/' closing a regex opened before *start*, unescaping only '\\/' in the same walk.
+    r"""Find the '/' closing a regex opened before *start*, unescaping only '\\/' -> '/'.
 
-    A single-pass fusion of `spans.regex_close_index` + the `\\/` -> `/` unescape: every other
-    backslash sequence (e.g. `\\d`) is passed through untouched for the regex engine to interpret,
-    matching `hand_parser`'s previous two-pass `.replace("\\/", "/")` behavior.
+    Delegates the boundary walk to `spans.find_close_index`, the same walk the balancer uses, so the
+    two can't drift on where an escaped '/' ends (#905). Every other backslash sequence (e.g. `\\d`)
+    is left untouched for the regex engine to interpret — this only ever collapses an escaped slash,
+    never a full general unescape.
 
     Returns (close_index, unescaped_content), or None if the pattern is unterminated.
     """
-    pos = start
-    length = len(query)
-    parts: list[str] = []
-    while pos < length:
-        ch = query[pos]
-        if ch == "\\":
-            if pos + 1 >= length:
-                return None
-            nxt = query[pos + 1]
-            parts.append(nxt if nxt == "/" else ch + nxt)
-            pos += 2
-        elif ch == "/":
-            return pos, "".join(parts)
-        else:
-            parts.append(ch)
-            pos += 1
-    return None
+    close_index, _ = find_close_index(query, start, "/")
+    if close_index is None:
+        return None
+    return close_index, query[start:close_index].replace("\\/", "/")
 
 
 class LexError(ValueError):

--- a/api/static/app.js
+++ b/api/static/app.js
@@ -582,12 +582,19 @@ class CardSearch {
     return (danglingEscape ? '\\' : '') + closer;
   }
 
-  // One pass over the query's spans and parens, reporting both things callers need:
+  // One pass over the query's spans and parens, reporting everything callers need:
   //   suffix — the closing text needed to balance it, or null when a ')' has no matching opener
   //            (the JS counterpart of balance_partial_query's ValueError in api/parsing/parsing_f.py)
   //   openSpanContentStart — index where an unterminated span's content begins, or null if every span
   //            is closed. Only used to tell an empty span from one with something in it.
-  // balanceSuffix and performSearch's empty-span guard both read this, so there is one scan and one set of rules.
+  //   blanked — query with every span's body blanked, the same output blankOpaqueSpans would produce
+  //            on `query + suffix` (computed here instead of by a second walk over the balanced
+  //            string — the boundaries are exactly what this scan already finds). An unterminated
+  //            span is blanked as though `suffix` had already closed it, since it always will be: per
+  //            the note above, nothing follows it in `query`, so its trailing ')'s (added once below,
+  //            the same way `suffix` itself is) reproduce what blanking `query + suffix` would give.
+  // balanceSuffix, performSearch's empty-span guard, and validateQuery's opaque-span check all read
+  // this, so there is one scan and one set of rules.
   scanSpans(query) {
     const quoteChars = new Set(["'", '"']);
 
@@ -598,6 +605,7 @@ class CardSearch {
     // open, and nothing after it to close. That is also why it can be appended before the parens: an
     // unterminated span is necessarily the innermost thing open.
     let spanSuffix = '';
+    let blanked = '';
 
     for (let i = 0; i < query.length; i++) {
       const char = query[i];
@@ -609,8 +617,10 @@ class CardSearch {
         if (closeIndex === null) {
           spanSuffix = this.closerForPartialSpan(danglingEscape, char);
           openSpanContentStart = i + 1;
+          blanked += char + char;
           break;
         }
+        blanked += char + char;
         i = closeIndex;
         continue;
       }
@@ -625,10 +635,14 @@ class CardSearch {
             // not a stray ')'.
             spanSuffix = this.closerForPartialSpan(danglingEscape, '/');
             openSpanContentStart = i + 1;
+            blanked += '//';
             break;
           }
+          blanked += '//';
           i = closeIndex;
+          continue;
         }
+        blanked += char;
         continue;
       }
 
@@ -641,8 +655,10 @@ class CardSearch {
         if (closeIndex === null) {
           spanSuffix = '}';
           openSpanContentStart = i + 1;
+          blanked += '{}';
           break;
         }
+        blanked += '{}';
         i = closeIndex;
         continue;
       }
@@ -651,13 +667,21 @@ class CardSearch {
         openParens++;
       } else if (char === ')') {
         if (openParens === 0) {
-          return { suffix: null, openSpanContentStart: null }; // ')' with no opener — nothing fixes this
+          return { suffix: null, openSpanContentStart: null, blanked: null }; // ')' with no opener — nothing fixes this
         }
         openParens--;
       }
+      blanked += char;
     }
 
-    return { suffix: spanSuffix + ')'.repeat(openParens), openSpanContentStart };
+    // The trailing ')'s are appended once here, the same way suffix's are — whether the loop broke
+    // on an unterminated span or ran to completion with parens still open, they're always the very
+    // last thing in `query + suffix`, and always outside any span at that point.
+    return {
+      suffix: spanSuffix + ')'.repeat(openParens),
+      openSpanContentStart,
+      blanked: blanked + ')'.repeat(openParens),
+    };
   }
 
   balanceSuffix(query) {
@@ -700,14 +724,16 @@ class CardSearch {
   // Returns an error string if the query is structurally invalid, or null if it looks ok.
   // alreadyBalanced lets a caller that just ran scanSpans itself (and knows the answer was not
   // null) skip a second identical scan here, rather than re-discovering what it already knows.
-  validateQuery(query, { alreadyBalanced = false } = {}) {
+  // blanked lets that same caller pass the scan's blanked-span output straight through too, rather
+  // than making blankOpaqueSpans re-walk the whole string to find the same span boundaries again.
+  validateQuery(query, { alreadyBalanced = false, blanked = null } = {}) {
     // A closing paren with no matching opener can't be balanced away.
     if (!alreadyBalanced && this.balanceSuffix(query) === null) {
       return `Failed to parse query: "${query}"`;
     }
 
     // Blank quoted strings and regex patterns so we don't match content inside them.
-    const q = this.blankOpaqueSpans(query);
+    const q = blanked ?? this.blankOpaqueSpans(query);
 
     // Trailing AND/OR with no right operand: "name:test and", "power>1 or"
     if (/(?:^|\s)(and|or)\s*$/i.test(q)) {
@@ -734,7 +760,7 @@ class CardSearch {
     // openSpanContentStart is a position in autocompleted, not in a trimmed copy of it, but that
     // doesn't change what it means: trailing whitespace can't be a span closer, so the position a
     // span was left open at is the same whether or not the string is trimmed first.
-    const { suffix, openSpanContentStart } = this.scanSpans(autocompleted);
+    const { suffix, openSpanContentStart, blanked } = this.scanSpans(autocompleted);
 
     // Mid-span with nothing typed after the opener: wait rather than search. Balancing would turn
     // `o:/` into the empty pattern `o://`, which matches every card and cannot use an index, and
@@ -758,9 +784,11 @@ class CardSearch {
     const balanced = suffix === null ? autocompleted : autocompleted + suffix;
     const normalizedQuery = this.collapseWhitespaceOutsideSpans(balanced).trim();
 
-    // suffix !== null means scanSpans already proved this string balanceable, so validateQuery
-    // doesn't need to run that same scan on normalizedQuery a second time to reach the same answer.
-    const validationError = this.validateQuery(normalizedQuery, { alreadyBalanced: suffix !== null });
+    // suffix !== null means scanSpans already proved this string balanceable, and its blanked output
+    // already reflects every span's boundaries (whitespace count and trimming don't change which
+    // structural checks fire, so it's as good a check-target as normalizedQuery's own blanked form)
+    // — so validateQuery doesn't need blankOpaqueSpans to re-walk the string a second time either.
+    const validationError = this.validateQuery(normalizedQuery, { alreadyBalanced: suffix !== null, blanked });
     if (validationError) {
       this.showError(`Failed to search: Invalid Search Query: ${validationError}`);
       return;


### PR DESCRIPTION
Two small follow-ups from the #909 review, stacked on this branch rather than blocking the larger PR — each is a same-output refactor with no behavior change, one commit per change.

## Commits

**1. Share the escape-skipping walk between the lexer and spans.py**

`hand_parser._closed_quote`/`_closed_regex` re-walked the same backslash-skipping logic `spans.find_close_index` already implements, so a future fix to escape handling there would not automatically reach the lexer's copy — the exact kind of drift `spans.py` exists to prevent (#905). Delegates the boundary walk to `find_close_index` and unescapes via a compiled regex (`spans.unescape` for quotes, a targeted `.replace` for regex's narrower `\/` -> `/` rule).

Also faster: ~1.2-1.3x on isolated quote/regex spans (benchmarked head-to-head against the old char-by-char walk), confirmed byte-for-byte identical output. Covers #942 item C.

**2. Have validateQuery reuse scanSpans' span boundaries**

`performSearch` already ran `scanSpans` once and passed `alreadyBalanced` through so `validateQuery` could skip its own `balanceSuffix` re-check — but `validateQuery` still called `blankOpaqueSpans`, an independent full re-walk of the same string to rediscover the same span boundaries `scanSpans` had just found. `scanSpans` now builds the blanked-span output alongside `suffix` in the same pass, so `performSearch` passes it straight through and `validateQuery` skips the second walk entirely on its hot path (every keystroke).

Verified with a 30-case adversarial suite (nested unclosed parens mixed with unterminated quotes/regexes/mana symbols, plus the "trailing and/or immediately before an appended closing paren" edge case) that `scanSpans().blanked` always matches `blankOpaqueSpans(query + suffix)` byte-for-byte, and that `validateQuery`'s verdict is unchanged whether it computes its own blank or reuses the passed-in one.

## Testing

- `api/parsing/tests/`: 2067 passed, 19 xfailed (unchanged)
- `npx jest api/static/app.test.js`: 1832 passed (unchanged)
- `ruff check`, `ruff format --check`, `prettier --check`: clean