### PR TITLE
Search & Parsing: Share the Close-Index Scan for Content, Too

### DIFF
--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -185,9 +185,8 @@ def tokenize(src: str) -> list[Token]:  # noqa: C901, PLR0912, PLR0915
             continue
 
         # Quoted string. The escape-skipping walk here has to agree with the balancer's
-        # `spans.quote_close_index`/`spans.find_close_index` that a backslash escapes the next
-        # character, or the balancer reads the ' in 'don\'t' as the close and appends a quote the
-        # lexer never wanted (#905).
+        # `spans.find_close_index` that a backslash escapes the next character, or the balancer
+        # reads the ' in 'don\'t' as the close and appends a quote the lexer never wanted (#905).
         if c in QUOTE_CHARS:
             closed = _closed_quote(src, pos + 1, c)
             if closed is None:
@@ -242,9 +241,9 @@ def tokenize(src: str) -> list[Token]:  # noqa: C901, PLR0912, PLR0915
         if c == "/":
             prev = tokens[-1] if tokens else None
             in_value_position = prev is not None and prev.type == TT.OP
-            # The escape-skipping walk here has to agree with the balancer's
-            # `spans.regex_close_index`/`spans.find_close_index` on where the span ends, or one of
-            # them treats a quote as a delimiter that the other treats as pattern content (#905).
+            # The escape-skipping walk here has to agree with the balancer's `spans.find_close_index`
+            # on where the span ends, or one of them treats a quote as a delimiter that the other
+            # treats as pattern content (#905).
             closed = _closed_regex(src, pos + 1) if in_value_position else None
             if closed is None:
                 # Division, or an unterminated regex falling back to division.

--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -121,31 +121,35 @@ def _closed_quote(query: str, start: int, quote: str) -> tuple[int, str] | None:
     """Find the *quote* closing a string opened before *start* and unescape its content.
 
     Delegates the boundary walk to `spans.find_close_index` — the same walk the balancer uses — so
-    the lexer and balancer can't drift on where an escaped quote ends (#905). Unescaping via
-    `spans.unescape`'s compiled regex is also faster in practice than a hand-rolled char loop.
+    the lexer and balancer can't drift on where an escaped quote ends (#905). `saw_escape` comes free
+    from that same walk, so the common case (no backslash anywhere in the string) skips `unescape`'s
+    regex pass entirely instead of running it over content that's already exactly what it should be.
 
     Returns (close_index, unescaped_content), or None if the string is unterminated.
     """
-    close_index, _ = find_close_index(query, start, quote)
+    close_index, _, saw_escape = find_close_index(query, start, quote)
     if close_index is None:
         return None
-    return close_index, unescape(query[start:close_index])
+    content = query[start:close_index]
+    return close_index, unescape(content) if saw_escape else content
 
 
 def _closed_regex(query: str, start: int) -> tuple[int, str] | None:
     r"""Find the '/' closing a regex opened before *start*, unescaping only '\\/' -> '/'.
 
     Delegates the boundary walk to `spans.find_close_index`, the same walk the balancer uses, so the
-    two can't drift on where an escaped '/' ends (#905). Every other backslash sequence (e.g. `\\d`)
-    is left untouched for the regex engine to interpret — this only ever collapses an escaped slash,
-    never a full general unescape.
+    two can't drift on where an escaped '/' ends (#905). `saw_escape` comes free from that same walk,
+    so a pattern with no backslash at all — the common case — skips the `.replace()` pass entirely.
+    Every other backslash sequence (e.g. `\\d`) is left untouched for the regex engine to interpret —
+    this only ever collapses an escaped slash, never a full general unescape.
 
     Returns (close_index, unescaped_content), or None if the pattern is unterminated.
     """
-    close_index, _ = find_close_index(query, start, "/")
+    close_index, _, saw_escape = find_close_index(query, start, "/")
     if close_index is None:
         return None
-    return close_index, query[start:close_index].replace("\\/", "/")
+    content = query[start:close_index]
+    return close_index, content.replace("\\/", "/") if saw_escape else content
 
 
 class LexError(ValueError):

--- a/api/parsing/parsing_f.py
+++ b/api/parsing/parsing_f.py
@@ -45,7 +45,7 @@ def balance_partial_query(query: str) -> str:
         # and the lexer cannot drift apart — where they disagree, the balancer "fixes" a quote the
         # lexer never saw (#905).
         if char in QUOTE_CHARS:
-            close_index, dangling_escape = find_close_index(query, pos, char)
+            close_index, dangling_escape, _ = find_close_index(query, pos, char)
             if close_index is None:
                 span_suffix = _closer_for_partial_span(dangling_escape, char)
                 break
@@ -55,7 +55,7 @@ def balance_partial_query(query: str) -> str:
         # A '/' in value position opens a regex; anywhere else it is division, an ordinary character.
         if char == "/":
             if opens_regex(query, pos - 1):
-                close_index, dangling_escape = find_close_index(query, pos, "/")
+                close_index, dangling_escape, _ = find_close_index(query, pos, "/")
                 if close_index is None:
                     # Still being typed. Close the regex rather than reading on, or the metacharacters
                     # the user has typed so far get balanced as query structure: `o:/[)` is a partial

--- a/api/parsing/spans.py
+++ b/api/parsing/spans.py
@@ -52,16 +52,6 @@ def brace_close_index(query: str, start: int) -> int | None:
     return None if index < 0 else index
 
 
-def regex_close_index(query: str, start: int) -> int | None:
-    """Return the index of the '/' closing a regex that opened before *start*, or None if unterminated."""
-    return find_close_index(query, start, "/")[0]
-
-
-def quote_close_index(query: str, start: int, quote: str) -> int | None:
-    """Return the index of the *quote* closing a string that opened before *start*, or None if unterminated."""
-    return find_close_index(query, start, quote)[0]
-
-
 def find_close_index(query: str, start: int, closer: str) -> tuple[int | None, bool]:
     """Return the index of the next unescaped *closer* at or after *start* and whether a dangling escape ended it.
 
@@ -69,9 +59,9 @@ def find_close_index(query: str, start: int, closer: str) -> tuple[int | None, b
     walk instead ran to the end of *query* on a dangling escape — both answers a single walk already has
     to compute.
 
-    A caller that only needs the index (the lexer, `regex_close_index`/`quote_close_index`) can ignore
-    the second value; a balancer completing an unterminated span needs both, and calling this once is
-    the only way to get them without walking the same tail of *query* twice.
+    A caller that only needs the index can ignore the second value; a balancer completing an
+    unterminated span needs both, and calling this once is the only way to get them without walking
+    the same tail of *query* twice.
     """
     pos = start
     length = len(query)

--- a/api/parsing/spans.py
+++ b/api/parsing/spans.py
@@ -52,29 +52,33 @@ def brace_close_index(query: str, start: int) -> int | None:
     return None if index < 0 else index
 
 
-def find_close_index(query: str, start: int, closer: str) -> tuple[int | None, bool]:
-    """Return the index of the next unescaped *closer* at or after *start* and whether a dangling escape ended it.
+def find_close_index(query: str, start: int, closer: str) -> tuple[int | None, bool, bool]:
+    """Return where the next unescaped *closer* is, whether a dangling escape ended the walk, and whether it saw one.
 
-    The first element is the index, or None if *closer* is never found; the second is True only when the
-    walk instead ran to the end of *query* on a dangling escape — both answers a single walk already has
-    to compute.
+    The first element is the index, or None if *closer* is never found. The second is True only when
+    the walk instead ran to the end of *query* on a dangling escape. The third is True if the walk
+    stepped over *any* backslash escape at all — a caller that wants the span's unescaped content can
+    skip the unescape pass entirely when this is False, since content is then just ``query[start:idx]``
+    unchanged. All three are already known once this one walk is done.
 
-    A caller that only needs the index can ignore the second value; a balancer completing an
-    unterminated span needs both, and calling this once is the only way to get them without walking
-    the same tail of *query* twice.
+    A caller that only needs the index can ignore the rest; a balancer completing an unterminated span
+    needs the second; a caller building unescaped content needs the third to avoid re-walking the same
+    text a second time just to learn it had nothing to unescape.
     """
     pos = start
     length = len(query)
+    saw_escape = False
     while pos < length:
         if query[pos] == "\\":
+            saw_escape = True
             if pos + 1 >= length:
-                return None, True
+                return None, True, saw_escape
             pos += 2
         elif query[pos] == closer:
-            return pos, False
+            return pos, False, saw_escape
         else:
             pos += 1
-    return None, False
+    return None, False, saw_escape
 
 
 def unescape(text: str) -> str:

--- a/api/parsing/tests/test_spans.py
+++ b/api/parsing/tests/test_spans.py
@@ -134,6 +134,22 @@ def test_has_dangling_escape(query: str, expected: bool) -> None:
 
 
 @pytest.mark.parametrize(
+    argnames=["query", "quote", "expected"],
+    argvalues=[
+        ("'abc'", "'", False),  # nothing to unescape: a caller can use the slice as-is
+        (r"'don\'t'", "'", True),
+        (r"'a\\'", "'", True),  # an escaped backslash still counts, even though it's not the closer
+        ("'abc", "'", False),  # unterminated, and still nothing escaped
+        ("'abc\\", "'", True),  # unterminated on a dangling escape, which is itself an escape seen
+    ],
+    ids=["no_escape", "escaped_quote", "escaped_backslash", "unterminated_no_escape", "unterminated_dangling"],
+)
+def test_find_close_index_reports_whether_it_saw_an_escape(query: str, quote: str, expected: bool) -> None:
+    """The third element lets a caller skip unescaping entirely when the walk saw no backslash at all."""
+    assert find_close_index(query, 1, quote)[2] is expected
+
+
+@pytest.mark.parametrize(
     argnames=["text", "expected"],
     argvalues=[
         ("abc", "abc"),

--- a/api/parsing/tests/test_spans.py
+++ b/api/parsing/tests/test_spans.py
@@ -13,8 +13,6 @@ from api.parsing.spans import (
     brace_close_index,
     find_close_index,
     opens_regex,
-    quote_close_index,
-    regex_close_index,
     unescape,
 )
 
@@ -93,9 +91,9 @@ def test_opens_regex(query: str, slash_index: int, expected: bool) -> None:
     ],
     ids=["simple", "first_close_wins", "escaped_delimiter", "unterminated", "trailing_backslash"],
 )
-def test_regex_close_index(query: str, start: int, expected: int | None) -> None:
+def test_find_close_index_for_regex(query: str, start: int, expected: int | None) -> None:
     """The close scan steps over escapes and returns None when the pattern never closes."""
-    assert regex_close_index(query, start) == expected
+    assert find_close_index(query, start, "/")[0] == expected
 
 
 @pytest.mark.parametrize(
@@ -111,9 +109,9 @@ def test_regex_close_index(query: str, start: int, expected: int | None) -> None
     ],
     ids=["plain", "escaped_quote", "escaped_backslash", "double_quoted", "other_quote_type", "unterminated", "escaped_close"],
 )
-def test_quote_close_index(query: str, quote: str, expected: int | None) -> None:
+def test_find_close_index_for_quote(query: str, quote: str, expected: int | None) -> None:
     """A backslash escapes the next character, so it cannot end the string."""
-    assert quote_close_index(query, 1, quote) == expected
+    assert find_close_index(query, 1, quote)[0] == expected
 
 
 @pytest.mark.parametrize(

--- a/docs/issues/00948-search-sql-user-error-exceptions-narrow.md
+++ b/docs/issues/00948-search-sql-user-error-exceptions-narrow.md
@@ -1,0 +1,67 @@
+# `_search_sql`'s Postgres-Error-to-400 Conversion Only Covers Two Exception Classes
+
+[#948](https://github.com/jbylund/sylvan_librarian/issues/948), filed during review of #909.
+
+`_search_sql`'s `except psycopg.errors.DatatypeMismatch` / `except psycopg.errors.InvalidRegularExpression`
+blocks convert exactly those two Postgres exceptions into a clean `falcon.HTTPBadRequest` via
+`_raise_query_bad_request` ([api/api_resource.py:1619-1638](../../api/api_resource.py#L1619-L1638)).
+Every other Postgres exception that a syntactically-valid-but-semantically-bad query can raise falls
+through uncaught, surfacing as an opaque 500.
+
+## Why
+
+The parser only checks grammar, not arithmetic semantics — a division, an out-of-range cast, anything
+Postgres itself has to evaluate is checked by Postgres alone. `power/0>1` is exactly this shape: it
+parses cleanly on both parsers and compiles to a literal `... / 0 ...` division, which Postgres raises
+as `psycopg.errors.DivisionByZero` (SQLSTATE `22012`, class `22` "data exception") once the query
+actually runs. That's the same "ordinary typo, not a server problem" case `DatatypeMismatch` and
+`InvalidRegularExpression` already exist to convert — it just wasn't one of the two exception classes
+anyone had hit yet when those handlers were written.
+
+Confirmed reachable: `parsing_f.parse_scryfall_query("power/0>1")` parses without error, so nothing
+upstream of Postgres rejects it. Other class-`22` siblings — `NumericValueOutOfRange`,
+`InvalidTextRepresentation` — are equally unhandled and equally reachable by an ordinary query typo
+(e.g. a numeric comparison against a value that overflows the column's type).
+
+This is the same one-class-at-a-time pattern #942 item A already flags for the *duplication* between
+the two existing handlers; this issue is about the *coverage gap* the pattern leaves behind — each
+new user-triggerable Postgres error needs its own bug report and its own handler before it stops
+500ing.
+
+## Fix
+
+Catch by SQLSTATE class instead of by exception class. `psycopg.errors` exceptions carry
+`.sqlstate`, and class `22` ("data exception") and class `42` ("syntax error or access rule
+violation") are the Postgres-defined groupings for "the input was bad," as opposed to `08`
+(connection), `53` (insufficient resources), `40` (transaction rollback), etc., which are genuine
+server-side failures that should keep 500ing.
+
+```python
+except psycopg.Error as err:
+    if (err.sqlstate or "")[:2] in {"22", "42"}:
+        _raise_query_bad_request(
+            exc_name=type(err).__name__,
+            query=query,
+            description=f"The search query '{query}' could not be executed: {err.diag.message_primary}.",
+            err=err,
+        )
+    raise
+```
+
+This also lets `_raise_query_bad_request` drop its `exc_name` parameter (already flagged as redundant
+state in the #909 review — always `type(err).__name__`) by computing it from `err` directly, since
+this handler no longer has a literal string to pass in per call site.
+
+The existing `DatatypeMismatch`/`InvalidRegularExpression` blocks keep their specific, better-worded
+`description` strings — this widens the catch, not the two specific messages already tuned for their
+cases. A generic fallback description covers everything else in the same class.
+
+## Tests
+
+`api/tests/test_datatype_mismatch.py` / `test_parsing_errors.py` (wherever the shared fixtures live):
+
+- `power/0>1` → 400 with a reasonable message, not a 500
+- confirm `DatatypeMismatch` and `InvalidRegularExpression` still get their specific descriptions
+  (a fallthrough handler must not swallow the two already-tuned messages)
+- a class-`08`/`53`/`40` exception (or a mock raising one) still propagates as a 500 — this is not a
+  catch-all for every Postgres error, only the user-input-shaped classes


### PR DESCRIPTION
Two small follow-ups from the #909 review, stacked on this branch like #943/#946.

## Commits

**1. Delete unused `regex_close_index`/`quote_close_index` wrappers**

Both were thin `find_close_index(...)[0]` wrappers with no production caller — the lexer and the balancer both call `find_close_index` directly. Only `test_spans.py` exercised them, now repointed at `find_close_index` itself. Also fixes two stale comments in `hand_parser.py` that named the wrappers instead of the function actually being agreed with.

**2. Skip the unescape pass when a span has no escape**

`_closed_quote`/`_closed_regex` (#946) delegate their boundary walk to `spans.find_close_index`, then unconditionally unescape the result even when it has no backslash at all — the common case for an ordinary quoted card name or plain regex. `find_close_index` already inspects every character looking for backslashes to find the closer, so it now reports whether it saw one, for free. Callers use that to skip `unescape()`/`.replace()` entirely and just slice the content instead.

This keeps the escape-walking rule in exactly one place (`spans.find_close_index`) while avoiding running the unescape pass over content that already needs no changes.

Measured head-to-head, same process, 3 repeated trials (stable, not noise):

| Span type | No escape (common case) | Has escape (rare case) |
|---|---|---|
| Quoted strings | **~103 ns/call saved (~20%)** | ~flat (+0.1%, noise) |
| Regex patterns | ~16 ns/call saved (~4%) | ~flat (+1.3%, noise) |

The quote win is real because `unescape` calls a compiled regex's `.sub()`, which carries per-call overhead beyond the character scan it's replacing. The regex win is smaller because `str.replace()` on a no-match string is already close to the cost of the slice it replaces, so there wasn't much overhead to remove there.

In absolute terms this is a minor cleanup, not a load-bearing perf fix: a full `tokenize()` call on a typical multi-field query runs ~2,100 ns end-to-end, so ~100 ns off one quoted value is a single-digit-percent shave on that call, not a headline number. Worth having since it falls out of a flag `find_close_index` already computes for free — no new pass, no new state to keep in sync.

## Docs

Also includes `docs/issues/00948-search-sql-user-error-exceptions-narrow.md`, filing #948 (found during the same review): `_search_sql` only converts `DatatypeMismatch`/`InvalidRegularExpression` to a 400, so other user-input-shaped Postgres errors (e.g. `DivisionByZero` from `power/0>1`) still 500. Deferred to its own issue rather than blocking this branch.

## Testing

- `api/parsing/tests/`: 2072 passed, 19 xfailed
- `api/tests/test_datatype_mismatch.py`, `test_parsing_errors.py`: 48 passed
- `ruff check`, `ruff format --check`: clean on touched files

No behavior changes in commits 1-2 — both are same-output refactors.
