### PR TITLE
Scripts: Use the MB Constant in fmt_mb and limit_mb Instead of Spelling It Out

### DIFF
--- a/scripts/gen_postgres_conf.py
+++ b/scripts/gen_postgres_conf.py
@@ -79,7 +79,7 @@ def get_available_memory_bytes() -> int:
 
 def fmt_mb(n_bytes: int) -> str:
     """Format bytes as a PostgreSQL memory string in MB."""
-    return f"{n_bytes // (1024 * 1024)}MB"
+    return f"{n_bytes // MB}MB"
 
 
 def _compute_raw(total_bytes: int) -> dict[str, int]:
@@ -196,7 +196,7 @@ def main() -> None:
             print(f"  {key}: {val}")
 
     if args.env_output:
-        limit_mb = compute_pg_mem_limit_bytes(total_bytes) // (1024 * 1024)
+        limit_mb = compute_pg_mem_limit_bytes(total_bytes) // MB
         limit_str = f"{limit_mb}m"
         # A file of its own, and specifically not .env or the tracked envs/ directory.
         # POSTGRES_MEM_LIMIT has to agree with the shared_buffers in the postgresql.conf generated


### PR DESCRIPTION
## Summary
- `fmt_mb` and the `limit_mb` calculation in `main()` spelled out `1024 * 1024` instead of using the `MB` constant the file already defines for this purpose.
- No behavior change — same arithmetic, same output.

Closes #955.

## Test plan
- [x] `ruff check scripts/gen_postgres_conf.py` passes
- [x] Diff is a pure substitution of the literal for the constant