### PR TITLE
Parsing: Make Bare Mana Characters Agree With Their Braced Form

### DIFF
--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -388,10 +388,11 @@ def get_legality_comparison_object(val: str, attr: str) -> dict[str, str]:
 # api.parsing.mana_symbols, which validates every symbol this finds.
 BRACED_MANA_SYMBOL = re.compile(r"{([^}]*)}")
 
-# Bare (unbraced) pip characters counted below: a colour, colourless, or X, confirmed against the
-# real Scryfall API (mana:x behaves identically to mana:{x}). Shared with api.parsing.mana_symbols,
-# which rejects any bare character outside this alphabet — see that module's docstring for why.
-BARE_MANA_ATOMS = frozenset("WUBRGCX")
+# Bare (unbraced) pip characters counted below: a colour, colourless, snow, or X, confirmed against
+# the real Scryfall API (mana:x behaves identically to mana:{x}, and mana:s to mana:{s}). Shared with
+# api.parsing.mana_symbols, which rejects any bare character outside this alphabet — see that
+# module's docstring for why.
+BARE_MANA_ATOMS = frozenset("WUBRGCXS")
 
 
 def mana_cost_str_to_dict(mana_cost_str: str) -> dict:
@@ -455,13 +456,13 @@ def calculate_cmc(mana_cost_str: str) -> int:
     # Then, process unbraced part (after removing braced sections)
     # Replace braced sections with a space to prevent adjacent digits from merging
     unbraced_part = BRACED_MANA_SYMBOL.sub(" ", mana_cost_upper)
-    # Match either: sequences of digits OR single color characters
-    for token in re.findall(r"\d+|[WUBRGC]", unbraced_part):
+    # Match either: sequences of digits OR single color/colourless/snow characters
+    for token in re.findall(r"\d+|[WUBRGCS]", unbraced_part):
         if token.isdigit():
             # Multi-digit generic mana (e.g., "11" in "11R")
             cmc += int(token)
-        elif token in "WUBRGC":
-            # Color character counts as 1
+        elif token in "WUBRGCS":
+            # Color (or snow) character counts as 1, same as its braced form
             cmc += 1
 
     return cmc

--- a/api/parsing/pyparsing_based.py
+++ b/api/parsing/pyparsing_based.py
@@ -264,18 +264,18 @@ def create_mana_parsers() -> dict[str, ParserElement]:
         Dictionary containing mana parser elements
     """
     curly_mana_symbol = Regex(r"\{[^}]+\}")
-    simple_mana_symbol = Regex(r"[0-9WUBRGCXYZwubrgcxyz]")
+    # Any letter or digit, not an enumerated subset of them: which bare characters are actually
+    # valid mana atoms is first_invalid_mana_symbol's call below, not this tokenizer's. A narrower
+    # charset here just means some bare values (e.g. "hello", "snow") never reach that validator at
+    # all and silently fall through to a plain string comparison instead (#954) — the grammar has to
+    # recognize a value as mana-shaped before it can be rejected as invalid mana.
+    simple_mana_symbol = Regex(r"[0-9A-Za-z]")
     mixed_mana_pattern = Combine(OneOrMore(curly_mana_symbol | simple_mana_symbol))
 
     def make_mana_value_node(tokens: list[str]) -> ManaValueNode:
         """Create a ManaValueNode for mana cost strings."""
         value = tokens[0].upper()
-        # Shared with hand_parser.parse_mana_value, so the two parsers reject the same symbols —
-        # for any value this grammar recognizes as mana-shaped in the first place. A bare value
-        # this pattern doesn't match (e.g. "hello") never reaches this parse action at all and
-        # falls through to a plain string comparison instead; that gap is pyparsing-only (this is
-        # the test-only reference parser, not the one serving traffic) and left unfixed, since
-        # closing it means widening the grammar rather than tightening this validator.
+        # Shared with hand_parser.parse_mana_value, so the two parsers reject the same symbols.
         # parse_search_query turns a ValueError from a parse action into a query-level parse error.
         invalid = first_invalid_mana_symbol(value)
         if invalid is not None:
@@ -370,7 +370,10 @@ def create_all_condition_parsers(basic_parsers: dict, mana_parsers: dict, color_
     unified_numeric_comparison = numeric_comparison_lhs + DEFAULT_OPERATORS + numeric_comparison_rhs
     unified_numeric_comparison.set_parse_action(make_binary_operator_node)
 
-    mana_value_or_string = mana_value | mana_quoted_value | string_value_word
+    # No string_value_word fallback: a mana/devotion condition's rhs is always a validated
+    # ManaValueNode, one of these two, never an unchecked StringValueNode (#954) — mirroring
+    # hand_parser.parse_mana_value, which has no plain-string case for this attribute class either.
+    mana_value_or_string = mana_value | mana_quoted_value
     mana_condition = create_condition_parser(mana_attr_word, mana_value_or_string)
 
     color_condition = create_condition_parser(color_attr_word, color_value | quoted_string)
@@ -628,7 +631,9 @@ def _get_implicit_and_tokenizer() -> ParserElement:
     string_value_tok = Regex(r"\w([\w.-]*[\w.])?").set_parse_action(lambda t: t[0])
 
     curly_mana_symbol = Regex(r"\{[^}]+\}")
-    simple_mana_symbol = Regex(r"[0-9WUBRGCXYZwubrgcxyz]")
+    # Mirrors create_mana_parsers' simple_mana_symbol (#954): any letter or digit, so a bare run
+    # mixed with braces (e.g. "s{w}") still tokenizes as one unit instead of splitting at the brace.
+    simple_mana_symbol = Regex(r"[0-9A-Za-z]")
     mana_tok = Combine(OneOrMore(curly_mana_symbol | simple_mana_symbol)).set_parse_action(lambda t: t[0])
 
     # A regex only opens in value position, so it is matched as a unit with the comparison operator

--- a/api/parsing/tests/test_mana_symbols.py
+++ b/api/parsing/tests/test_mana_symbols.py
@@ -112,7 +112,8 @@ def test_junk_is_rejected(symbol: str) -> None:
         ("{W}T", "T"),  # ... including a bare marker alongside a braced symbol
         ("2WWQ", "Q"),  # the bug this exists to close: silently dropped by calculate_cmc, not rejected
         ("2WWX", None),  # X is bare notation's own real pip, not a leftover from a braced check
-        ("2WWS", "S"),  # 'S' is a real atom braced ({S}), but calculate_cmc never counts it bare
+        ("2WWS", None),  # 'S' (snow) is bare-valid too — mana:s means the same as mana:{s} (#954)
+        ("SNOW", "N"),  # 'S' alone is valid, but 'N' isn't — same offender {s}{n}{o}{w} reports
         ("H{Q}", "H"),  # the bare 'H' comes before '{Q}' in the string, so it is the true first offender
         ("{Q}H", "{Q}"),  # here the braced symbol genuinely is first
         ("{P}", "{P}"),  # phyrexian never appears unpaired: {P} matches no real cost (#941)
@@ -130,7 +131,8 @@ def test_junk_is_rejected(symbol: str) -> None:
         "bare_marker_rejected",
         "bare_extra_char_rejected",
         "bare_x_accepted",
-        "bare_atom_not_bare_valid",
+        "bare_s_accepted",
+        "bare_snow_word_first_bad_char",
         "bare_before_braced",
         "braced_before_bare",
         "braced_phyrexian_unpaired",

--- a/api/parsing/tests/test_parser_parity.py
+++ b/api/parsing/tests/test_parser_parity.py
@@ -63,6 +63,27 @@ def test_quoted_mana_value_parity(query: str) -> None:
     assert_parsers_agree(query)
 
 
+@pytest.mark.parametrize(
+    argnames=["query"],
+    argvalues=[
+        ("mana:s",),
+        ("mana:snow",),
+        ("mana:p",),
+        ("mana:hello",),
+    ],
+    ids=["bare_snow_valid", "bare_snow_word_invalid", "bare_phyrexian_unpaired", "bare_junk_word"],
+)
+def test_bare_mana_character_parity(query: str) -> None:
+    """A bare mana character is validated the same as its braced form in both parsers (#954).
+
+    pyparsing's tokenizer used to only recognize a fixed subset of bare letters as mana-shaped at
+    all; anything outside it (including 's', valid braced as '{s}') fell through to a plain string
+    comparison and silently matched the wrong cards instead of 400ing or agreeing with the hand
+    parser's rejection.
+    """
+    assert_parsers_agree(query)
+
+
 # Real queries from benchmarks/wild-queries/wild-corpus.jsonl on which the two parsers disagree
 # today, grouped by the root cause in #903. Sweeping that 14k-query corpus found exactly these.
 #

--- a/api/parsing/tests/test_sql_gen.py
+++ b/api/parsing/tests/test_sql_gen.py
@@ -207,6 +207,17 @@ def test_full_sql_translation(parse_query, input_query: str, expected_sql: str, 
             r"(%(p_dict_eydYJzogWzFdLCAnUic6IFsxXX0)s <@ card.mana_cost_jsonb AND card.cmc >= %(p_int_MQ)s)",
             {"p_dict_eydYJzogWzFdLCAnUic6IFsxXX0": {"X": [1], "R": [1]}, "p_int_MQ": 1},
         ),
+        # Snow, likewise: bare 's' means the same thing as braced '{s}' (#954).
+        (
+            "mana:{S}",
+            r"(%(p_dict_eydTJzogWzFdfQ)s <@ card.mana_cost_jsonb AND card.cmc >= %(p_int_MQ)s)",
+            {"p_dict_eydTJzogWzFdfQ": {"S": [1]}, "p_int_MQ": 1},
+        ),
+        (
+            "mana:s",
+            r"(%(p_dict_eydTJzogWzFdfQ)s <@ card.mana_cost_jsonb AND card.cmc >= %(p_int_MQ)s)",
+            {"p_dict_eydTJzogWzFdfQ": {"S": [1]}, "p_int_MQ": 1},
+        ),
     ],
 )
 def test_full_sql_translation_jsonb_colors(parse_query, input_query: str, expected_sql: str, expected_parameters: dict) -> None:

--- a/docs/issues/00954-pyparsing-bare-mana-charset-drop.md
+++ b/docs/issues/00954-pyparsing-bare-mana-charset-drop.md
@@ -1,0 +1,57 @@
+# pyparsing Silently Drops Bare Mana Characters It Doesn't Recognize
+
+[#954](https://github.com/jbylund/sylvan_librarian/issues/954).
+
+Confirmed still live on current main (post-#909): `mana:s`, `mana:snow`, `mana:p`, and `mana:hello`
+all still silently produce wrong or empty results via the pyparsing parser, even though the hand
+parser correctly rejects every one of them.
+
+## Confirmed reachable, right now
+
+```python
+>>> generate_sql_query(parsing_f.parse_scryfall_query("mana:s"))
+ValueError: Failed to parse query: "mana:s"          # hand parser: correct
+>>> generate_sql_query(parse_search_query("mana:s"))
+(..., {'p_dict_e30': {}, 'p_int_MA': 0})              # pyparsing: {} matches every card with a cost
+>>> generate_sql_query(parse_search_query("mana:snow"))
+(..., {'p_dict_...': {'W': [1]}, 'p_int_MQ': 1})      # pyparsing: silently answers mana:w instead
+```
+
+## Why
+
+Two independent gaps compound:
+
+1. [`pyparsing_based.py`](../../api/parsing/pyparsing_based.py)'s mana tokenizer regex
+   (`simple_mana_symbol = Regex(r"[0-9WUBRGCXYZwubrgcxyz]")`, in two places) accepts `S` as a
+   mana-token character at the grammar level, so `mana:snow` becomes a `ManaValueNode` at all — the
+   hand parser's own bare-character alphabet doesn't include `S`, so the query never becomes a mana
+   value there in the first place.
+2. Once a `ManaValueNode` exists, nothing on the pyparsing path calls `first_invalid_mana_symbol` to
+   validate it the way `hand_parser.parse_mana_value` does, so
+   [`mana_cost_str_to_dict`](../../api/parsing/card_query_nodes.py) receives the raw, unvalidated
+   string. Its own character loop only recognizes `WUBRGCX`, silently dropping anything else: `S` in
+   `"snow"` vanishes, leaving `{'W': [1]}` from the trailing `w`; every character in
+   `"hello"`/`"s"`/`"p"` vanishes, leaving `{}` — a subset of every cost, so the query matches every
+   card that has one at all.
+
+## Prior art — do not just reopen or rebase #915
+
+[#915](https://github.com/jbylund/sylvan_librarian/pull/915) diagnosed this exact bug in detail
+(verified row counts, a "five copies of what is a cost symbol" table) and proposed unifying every
+copy under one shared, public `MANA_COST_ATOMS` constant. Closed rather than rebased: its branch
+predates [#941](done/00941-bare-phyrexian-and-variable-symbols.md) (merged), and its proposed
+`MANA_COST_ATOMS` value — `_COLORS | frozenset("CSXYZP∞")` — still includes bare `P`, `Y`, `Z` as
+valid atoms. #941 established that none of those three ever appears unpaired in a real (non-funny)
+mana cost and made `is_valid_mana_symbol("P")` etc. return `False`; reusing #915's constant as-is
+would silently regress that fix back in, since the same shared constant would flow into the
+bare-character validation this issue is about too.
+
+A fresh fix needs to unify the vocabulary (closing this issue's gap) while keeping #941's exclusions
+(not regressing that one) — read both before starting.
+
+## Reference
+
+#915's diagnosis is still a useful map: five separate copies of "what is a cost symbol" existed —
+`mana_cost_str_to_dict`, `calculate_cmc`, and `pyparsing_based`'s two `simple_mana_symbol` patterns
+each read their own hardcoded charset (all incomplete in different, overlapping ways), while
+`mana_symbols.py`'s (post-#941) `_ATOMS` is the one that's actually correct today.

--- a/docs/issues/done/00954-pyparsing-bare-mana-charset-drop.md
+++ b/docs/issues/done/00954-pyparsing-bare-mana-charset-drop.md
@@ -55,3 +55,35 @@ A fresh fix needs to unify the vocabulary (closing this issue's gap) while keepi
 `mana_cost_str_to_dict`, `calculate_cmc`, and `pyparsing_based`'s two `simple_mana_symbol` patterns
 each read their own hardcoded charset (all incomplete in different, overlapping ways), while
 `mana_symbols.py`'s (post-#941) `_ATOMS` is the one that's actually correct today.
+
+## Fix
+
+The "confirmed reachable" repro above says the hand parser "correctly rejects" `mana:s` — that
+framing turned out to be half right. `mana:{s}` (braced) already resolved correctly on both parsers
+to `{'S': [1]}`, `cmc >= 1`; `mana:s` (bare) should mean the same thing, per real Scryfall behavior,
+but both parsers rejected/mishandled it because `BARE_MANA_ATOMS` in `card_query_nodes.py` — the
+bare-character alphabet `mana_cost_str_to_dict`, `calculate_cmc`, and (via `mana_symbols.py`)
+`first_invalid_mana_symbol` all read — was `frozenset("WUBRGCX")`, missing `S`. Fixing that one
+constant fixed the hand parser and `first_invalid_mana_symbol` together (single source of truth), so
+`mana:s` now agrees with `mana:{s}` on both parsers, and `calculate_cmc`'s bare-character regex
+gained `S` too (a bare `S` now contributes 1 to cmc, same as its braced form).
+
+The other half — `mana:snow`/`mana:p`/`mana:hello` silently resolving to a plain string comparison
+on the pyparsing path — was the grammar gap from "Why" above. `pyparsing_based.py`'s two
+`simple_mana_symbol` regexes were widened from an enumerated letter subset to `[0-9A-Za-z]`: which
+bare characters are *valid* is `first_invalid_mana_symbol`'s call, not the tokenizer's — a narrower
+tokenizer charset just means some bare values never reach that validator and fall through to
+`string_value_word` instead. That fallback was also dropped from `mana_value_or_string` entirely
+(`mana_value | mana_quoted_value`, no more `| string_value_word`): a mana/devotion condition's rhs is
+now always a validated `ManaValueNode`, never an unchecked `StringValueNode`, mirroring
+`hand_parser.parse_mana_value`'s shape directly rather than relying on the tokenizer to always be
+wide enough.
+
+## Tests
+
+- `first_invalid_mana_symbol("2WWS")` → `None` (was `"S"`); `first_invalid_mana_symbol("SNOW")` →
+  `"N"` (the same offender `{s}{n}{o}{w}` reports as `"{N}"`)
+- `test_bare_mana_character_parity` (`test_parser_parity.py`): `mana:s`, `mana:snow`, `mana:p`,
+  `mana:hello` — hand and pyparsing parsers agree on all four
+- `test_full_sql_translation_jsonb_colors` (`test_sql_gen.py`): `mana:s` and `mana:{S}` produce
+  identical SQL/parameters, on both parsers


### PR DESCRIPTION
## Summary

Closes #954.

- `mana:s` now means the same as `mana:{s}` on both parsers. `S` (snow) was missing from `BARE_MANA_ATOMS` in `card_query_nodes.py` — the single alphabet `mana_cost_str_to_dict`, `calculate_cmc`, and (via `mana_symbols.py`) `first_invalid_mana_symbol` all share — even though `mana_symbols.py`'s braced-symbol validator already accepted `{s}`. Adding `S` there fixes bare-vs-braced parity for both parsers at once, and `calculate_cmc`'s bare-character handling now counts a bare `S` toward cmc the same way it already counted `{S}`.
- `mana:snow`, `mana:p`, and `mana:hello` now 400 on the pyparsing path the same way `mana:{s}{n}{o}{w}` already did, instead of silently falling through to a plain string comparison and matching the wrong cards. `pyparsing_based.py`'s `simple_mana_symbol` tokenizer regex was widened from an enumerated letter subset to any letter/digit — which characters are *valid* is `first_invalid_mana_symbol`'s job, not the tokenizer's; a narrow tokenizer charset just means some bare values never reach that validator at all. The `string_value_word` fallback was also dropped from the mana condition's grammar entirely, so a mana/devotion condition's rhs is now always a validated `ManaValueNode`, never an unchecked `StringValueNode` — mirroring `hand_parser.parse_mana_value`'s shape directly.

See `docs/issues/done/00954-pyparsing-bare-mana-charset-drop.md` for the full diagnosis and fix writeup.

## Test plan
- [x] `make test-unit` — 2978 passed, 19 xfailed (unchanged known-divergence xfails)
- [x] `make test-integration` — 22 passed
- [x] `make lint` — clean
- [x] New coverage: `test_bare_mana_character_parity` (parser parity for `mana:s`/`snow`/`p`/`hello`), `test_full_sql_translation_jsonb_colors` cases for `mana:s` vs `mana:{S}`, updated `test_mana_symbols.py` cases for bare `S`