### PR TITLE
API+Engine: Expose layout, cmc, rarity, color_identity and legalities as Result Fields

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -316,7 +316,32 @@ RESULT_FIELD_COLUMNS: dict[str, str] = {
     "scryfall_id": "scryfall_id",
     "price_usd": "price_usd",
     "prefer_score": "prefer_score",
+    # Card-data fields consumers need to run their own downstream filtering
+    # (Scryfall JSON names and shapes): layout and rarity are plain text,
+    # cmc an integer, legalities the imported {format: status} object, and
+    # color_identity a WUBRG-ordered letter list (the raw column is a JSONB
+    # object -- _search_sql reshapes it; the engine emits the list directly).
+    "layout": "card_layout",
+    "cmc": "cmc",
+    "rarity": "card_rarity_text",
+    "color_identity": "card_color_identity",
+    "legalities": "card_legalities",
 }
+
+# Scryfall's canonical color order, used to reshape identity objects into lists.
+_COLOR_ORDER: tuple[str, ...] = ("W", "U", "B", "R", "G", "C")
+
+
+def _identity_letters(identity: dict[str, object] | None) -> list[str]:
+    """Reshape a JSONB color-identity object into Scryfall's WUBRG-ordered letter list."""
+    if not identity:
+        return []
+    if len(identity) == 1:
+        # A single color is trivially already in WUBRG order -- no need to walk _COLOR_ORDER.
+        return list(identity)
+    return [letter for letter in _COLOR_ORDER if letter in identity]
+
+
 # `fields=None` resolves to these 9 — the fixed set every caller got before field selection
 # existed. Order/membership must match DEFAULT_FIELDS in card_engine/src/lib.rs.
 DEFAULT_RESULT_FIELDS: tuple[str, ...] = (
@@ -1626,8 +1651,12 @@ class APIResource:
         cards = result_bag.pop("result", [])
         count_row = cards.pop()
         total_cards = count_row["total_cards_count"]
+        reshape_identity = "color_identity" in resolved_fields
         for icard in cards:
             icard.pop("total_cards_count")
+            if reshape_identity:
+                # Match the engine path's shape (see FIELD_TABLE in card_engine).
+                icard["color_identity"] = _identity_letters(icard["color_identity"])
         return {
             "cards": cards,
             "compiled": query_sql,

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -639,6 +639,20 @@ class TestOffsetValidation(TestBaseAPIResourceTest):
         assert self.api_resource._validate_offset(175) == 175
 
 
+class TestIdentityLetters(unittest.TestCase):
+    """_identity_letters reshapes JSONB identity objects into WUBRG-ordered letter lists."""
+
+    def test_orders_letters_wubrg(self) -> None:
+        """Letters come back in Scryfall's canonical order, not storage order."""
+        letters = api_resource_module._identity_letters({"G": True, "W": True, "U": True})
+        assert letters == ["W", "U", "G"]
+
+    def test_empty_and_none_are_colorless(self) -> None:
+        """A colorless identity is an empty list, matching Scryfall's JSON."""
+        assert api_resource_module._identity_letters({}) == []
+        assert api_resource_module._identity_letters(None) == []
+
+
 class TestAPIResourceStaticFileServing(unittest.TestCase):
     """Test static file serving methods."""
 

--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -1273,6 +1273,34 @@ class TestFieldSelection:
         with pytest.raises(UnknownFieldError):
             _run(engine, unique="printing", fields=["not_a_real_field"])
 
+    def test_card_data_fields_ship_scryfall_shapes(self, engine: QueryEngine) -> None:
+        """layout/cmc/rarity/color_identity/legalities come back Scryfall-shaped."""
+        _, cards = _run(
+            engine,
+            'name="Lightning Bolt"',
+            unique="card",
+            limit=1,
+            fields=["name", "layout", "cmc", "rarity", "color_identity", "legalities"],
+        )
+        card = cards[0]
+        assert card["layout"] == "normal"
+        assert card["cmc"] == 1
+        assert card["rarity"] == "common"
+        # WUBRG-ordered letter list, not the raw JSONB object.
+        assert card["color_identity"] == ["R"]
+        legalities = card["legalities"]
+        assert legalities["modern"] == "legal"
+        assert set(legalities.values()) <= {"legal", "not_legal", "restricted", "banned"}
+
+    def test_color_identity_is_wubrg_ordered(self, engine: QueryEngine) -> None:
+        # Any multicolor card: letters come back in WUBRG order regardless of storage order.
+        _, cards = _run(engine, "id>=rg", unique="card", limit=5, fields=["name", "color_identity"])
+        order = {letter: i for i, letter in enumerate("WUBRGC")}
+        for card in cards:
+            letters = card["color_identity"]
+            assert letters == sorted(letters, key=order.__getitem__)
+            assert {"R", "G"} <= set(letters)
+
 
 class TestExplain:
     """explain()/explain_analyze() (#745): the router's own cost model as an on-demand diagnostic.

--- a/card_engine/src/legality.rs
+++ b/card_engine/src/legality.rs
@@ -71,6 +71,28 @@ pub(crate) fn jsonb_obj_to_legality_bits(d: &Bound<PyDict>, key: &str) -> u64 {
         .unwrap_or_default()
 }
 
+/// Decode a packed legality word into a `{format: status}` Python dict covering every
+/// format the registry knows, alphabetically — the field-extraction counterpart of
+/// `jsonb_obj_to_legality_bits`. A format absent from the imported JSONB round-trips
+/// as "not_legal", exactly as the encoder treated it.
+pub(crate) fn legality_bits_to_pydict<'a>(py: Python<'a>, bits: u64) -> PyResult<pyo3::Bound<'a, PyDict>> {
+    let dict = PyDict::new(py);
+    if let Ok(shifts) = format_shifts().read() {
+        let mut entries: Vec<(String, u8)> = shifts.iter().map(|(k, v)| (k.clone(), *v)).collect();
+        entries.sort();
+        for (format, shift) in entries {
+            let word = match (bits >> shift) & 0b11 {
+                LEGALITY_LEGAL => "legal",
+                LEGALITY_RESTRICTED => "restricted",
+                LEGALITY_BANNED => "banned",
+                _ => "not_legal",
+            };
+            dict.set_item(format, word)?;
+        }
+    }
+    Ok(dict)
+}
+
 /// Adopt the archive's format→shift assignments into this process's registry.
 /// Cheap no-op (one read lock) once the registry has caught up.
 pub(crate) fn sync_format_shifts(archived: &Archived<HashMap<String, u8>>) {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -11457,7 +11457,33 @@ const FIELD_TABLE: &[(&str, FieldExtractor)] = &[
     ("card_art_tags", |py, _c, p, _s, v| Ok(sorted_strs(v, &p.card_art_tags).into_pyobject(py)?.into_any())),
     ("card_is_tags", |py, _c, p, _s, v| Ok(sorted_strs(v, &p.card_is_tags).into_pyobject(py)?.into_any())),
     ("card_frame_data", |py, _c, p, _s, v| Ok(sorted_strs(v, &p.card_frame_data).into_pyobject(py)?.into_any())),
+    // Card-data fields for downstream filtering, in Scryfall JSON shapes (names and value
+    // shapes match RESULT_FIELD_COLUMNS in api/api_resource.py, which reshapes the SQL
+    // path's raw columns to agree with these).
+    ("layout", |py, c, _p, s, _v| Ok(str_at(s, u32::from(c.card_layout_id)).into_pyobject(py)?.into_any())),
+    ("cmc", |py, c, _p, _s, _v| Ok(c.cmc.as_ref().copied().into_pyobject(py)?.into_any())),
+    ("rarity", |py, _c, p, _s, _v| {
+        Ok(p.card_rarity_int.as_ref().and_then(|v| rarity_int_to_text(*v)).into_pyobject(py)?.into_any())
+    }),
+    ("color_identity", |py, c, _p, _s, _v| Ok(identity_letters(c.card_color_identity).into_pyobject(py)?.into_any())),
+    ("legalities", |py, c, p, _s, _v| {
+        // Printing-level word only for the ~556 divergence cards, same rule the filters use.
+        let bits = if c.legality_divergent { u64::from(p.card_legalities) } else { u64::from(c.card_legalities) };
+        Ok(legality_bits_to_pydict(py, bits)?.into_any())
+    }),
 ];
+
+/// Mirror of magic.rarity_int_to_text -- the import stores 0-5, Scryfall speaks words.
+const RARITY_NAMES: [&str; 6] = ["common", "uncommon", "rare", "mythic", "special", "bonus"];
+
+fn rarity_int_to_text(value: u8) -> Option<&'static str> {
+    RARITY_NAMES.get(value as usize).copied()
+}
+
+/// Decode an identity bitmap into Scryfall's WUBRG-ordered letter list.
+fn identity_letters(mask: u8) -> Vec<&'static str> {
+    ["W", "U", "B", "R", "G", "C"].into_iter().filter(|c| mask & color_to_bit(c) != 0).collect()
+}
 
 /// Resolve one interned collection-element id against the archived vocab table.
 /// Every id is a real entry (there is no absent sentinel for collection elements).


### PR DESCRIPTION
## What

Adds five card-data fields to the `fields=` vocabulary, on **both serving paths** with matching Scryfall JSON shapes:

| field | shape | source |
|---|---|---|
| `layout` | text (`"normal"`, `"transform"`, …) | `card_layout` / interned layout id |
| `cmc` | integer | `cmc` column / archived `Option<u8>` |
| `rarity` | text (`"common"`…`"bonus"`) | `card_rarity_text` / Rust mirror of `magic.rarity_int_to_text` |
| `color_identity` | WUBRG-ordered letter list | JSONB object reshaped post-query (SQL) / bitmap decode (engine) |
| `legalities` | `{format: status}` object | raw JSONB (SQL) / packed-u64 decode through the format registry (engine) |

`DEFAULT_RESULT_FIELDS` is untouched — the usual 9 stay the default; these are opt-in.

## Notes on the two shapes that needed real decisions

- **color_identity**: the stored JSONB is an object (`{"R": true}`); Scryfall's JSON is a list. The SQL path reshapes in `_search_sql` (a tiny `_identity_letters` helper), the engine decodes its `u8` bitmap directly, and both emit Scryfall's canonical WUBRG order so the paths agree by construction — per the "matching semantics" contract on `RESULT_FIELD_COLUMNS`.
- **legalities**: the engine decodes through the format-shift registry (every known format, absent bits → `"not_legal"`, exactly round-tripping `jsonb_obj_to_legality_bits`), and consults the printing-level word only for the ~556 `legality_divergent` cards — the same rule the legality filters already use.

## Why

We're moving a production MTG search service onto Sylvan Librarian as its primary card-search backend. The service runs its own defense-in-depth filtering on every returned card (color identity, format legality, layout playability, rarity/cmc constraints from user-pinned filters), which today forces a secondary per-card fetch for data the corpus already holds. With these five fields, one `/search` call carries everything downstream filtering needs.

## Relative to #877

This is #877 (daveycodez), rebased onto current `main` — the rebase was clean (1 commit, no conflicts), since the underlying data (`card_layout_id`, `cmc`, `card_rarity_int`, `card_color_identity`, `card_legalities`) already existed on the archived structs for filtering before this PR; nothing else on `main` moved out from under it. Three small simplifications on top of the original:

- `rarity_int_to_text`: match-per-value → array index lookup (`RARITY_NAMES.get(value as usize).copied()`), matching the existing `TYPE_BIT_NAMES` idiom already used elsewhere in this file.
- `identity_letters` (engine): dropped a second hardcoded copy of the W=1/U=2/B=4/R=8/G=16/C=32 bit assignment; it now calls the existing `color_to_bit()` instead, so there's one source of truth for the bit layout rather than two that could drift.
- `_identity_letters` (Python/SQL path): the original built a `set()` from the JSONB object just to check membership, and always walked all 6 possible colors regardless of how many were actually present. Measured (200k iterations/case): dropping the `set()` and fast-pathing the empty and single-color cases (both trivially already "in order" — nothing to reorder) is faster on every case, and 2–5x faster on colorless/mono cards specifically, which dominate real card data:

  | case | before | after |
  |---|---:|---:|
  | colorless | 132 ns | 26 ns |
  | mono-color | 111 ns | 55 ns |
  | 2–5 color | 114–148 ns | 105–116 ns |

Everything else — the field table entries, the SQL-path reshape, the legality decode, the tests — is unchanged from #877.

## Validation

- `cargo test --lib`: 157 passed (main has grown since #877 was opened; count differs from the original PR for that reason, not from these changes)
- `api/tests/test_engine_unit.py`: 185 passed, including the five-shape and WUBRG-ordering tests from #877
- `api/tests/test_api_resource.py`: 111 passed, including the `_identity_letters` unit tests (output unchanged by the rewrite — verified against the original on every color-count case before landing)
- `ruff check` + `ruff format` clean