### PR TITLE
Admin: Shrink the Parent/Child Shared Surface

### DIFF
--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -9,8 +9,8 @@ public method became a route, and the only lever was a leading underscore, which
 method's Python visibility. Mounting a separate resource replaces that lever with a boundary, and
 keeps the honest names.
 
-The child holds a reference to its parent for the small surface they genuinely share — four methods
-(`_reload_engine`, `_serve_static_file`, `_set_statement_timeout`, `_setup_complete`)
+The child holds a reference to its parent for the small surface they genuinely share — three methods
+(`_reload_engine`, `_serve_static_file`, `_setup_complete`)
 and four handles (`_conn_pool`, `_cache_generation`, `_last_import_time`, `_setup_complete_cache`).
 That is deliberately not a decoupling: the boundary here is about routing, and pretending otherwise
 would mean an `AppContext` refactor that the routing fix does not need.
@@ -384,7 +384,7 @@ class AdminResource:
 
         backfill_sql = db_utils.read_sql("backfill_prefer_scores")
         with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
-            self._parent._set_statement_timeout(cursor, settings.prefer_score_backfill_timeout_ms)
+            db_utils.set_statement_timeout(cursor, settings.prefer_score_backfill_timeout_ms)
             cursor.execute(backfill_sql)
             updated_count = cursor.rowcount
 
@@ -531,7 +531,7 @@ class AdminResource:
 
         backfill_sql = db_utils.read_sql("backfill_cubecobra_scores")
         with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
-            self._parent._set_statement_timeout(cursor, 600_000)
+            db_utils.set_statement_timeout(cursor, 600_000)
             cursor.execute(backfill_sql, weights)
             updated_count = cursor.rowcount
 
@@ -1089,7 +1089,7 @@ class AdminResource:
         try:
             with self._parent._conn_pool.connection() as conn:
                 with conn.cursor() as cursor:
-                    self._parent._set_statement_timeout(cursor, 30_000)
+                    db_utils.set_statement_timeout(cursor, 30_000)
 
                 class _CardStream:
                     """Preprocesses raw cards lazily, tracking stage counts."""

--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -9,8 +9,8 @@ public method became a route, and the only lever was a leading underscore, which
 method's Python visibility. Mounting a separate resource replaces that lever with a boundary, and
 keeps the honest names.
 
-The child holds a reference to its parent for the small surface they genuinely share — five methods
-(`_reload_engine`, `_run_query`, `_serve_static_file`, `_set_statement_timeout`, `_setup_complete`)
+The child holds a reference to its parent for the small surface they genuinely share — four methods
+(`_reload_engine`, `_serve_static_file`, `_set_statement_timeout`, `_setup_complete`)
 and four handles (`_conn_pool`, `_cache_generation`, `_last_import_time`, `_setup_complete_cache`).
 That is deliberately not a decoupling: the boundary here is about routing, and pretending otherwise
 would mean an `AppContext` refactor that the routing fix does not need.
@@ -914,13 +914,14 @@ class AdminResource:
         logger.info("Importing card by name: '%s'", card_name)
 
         # Check if card already exists in database for backward compatibility
-        existing_check = self._parent._run_query(
-            query="SELECT card_name FROM magic.cards WHERE card_name = %(card_name)s",
-            params={"card_name": card_name},
-            explain=False,
-        )
+        with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+            cursor.execute(
+                "SELECT card_name FROM magic.cards WHERE card_name = %(card_name)s",
+                {"card_name": card_name},
+            )
+            card_already_exists = cursor.fetchone() is not None
 
-        if existing_check["result"]:
+        if card_already_exists:
             return {
                 "card_name": card_name,
                 "status": "already_exists",

--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -9,8 +9,8 @@ public method became a route, and the only lever was a leading underscore, which
 method's Python visibility. Mounting a separate resource replaces that lever with a boundary, and
 keeps the honest names.
 
-The child holds a reference to its parent for the small surface they genuinely share — three methods
-(`_reload_engine`, `_serve_static_file`, `_setup_complete`)
+The child holds a reference to its parent for the small surface they genuinely share — two methods
+(`_reload_engine`, `_setup_complete`)
 and four handles (`_conn_pool`, `_cache_generation`, `_last_import_time`, `_setup_complete_cache`).
 That is deliberately not a decoupling: the boundary here is about routing, and pretending otherwise
 would mean an `AppContext` refactor that the routing fix does not need.
@@ -46,6 +46,7 @@ from api.tag_import import import_oracle_tags as _import_oracle_tags
 from api.utils import db_utils
 from api.utils.caching import cached
 from api.utils.http_utils import make_user_agent
+from api.utils.page_rendering import serve_static_file
 from api.utils.routing import route
 
 if TYPE_CHECKING:
@@ -355,7 +356,7 @@ class AdminResource:
             falcon_response (falcon.Response): The Falcon response to write to.
 
         """
-        self._parent._serve_static_file(filename="prefer_score_tuner.html", falcon_response=falcon_response)
+        serve_static_file(filename="prefer_score_tuner.html", falcon_response=falcon_response)
         falcon_response.content_type = "text/html"
 
     @route()

--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -10,10 +10,17 @@ method's Python visibility. Mounting a separate resource replaces that lever wit
 keeps the honest names.
 
 The child holds a reference to its parent for the small surface they genuinely share — two methods
-(`_reload_engine`, `_setup_complete`)
-and four handles (`_conn_pool`, `_cache_generation`, `_last_import_time`, `_setup_complete_cache`).
-That is deliberately not a decoupling: the boundary here is about routing, and pretending otherwise
-would mean an `AppContext` refactor that the routing fix does not need.
+(`_reload_engine`, `_setup_complete`) and three handles (`_cache_generation`, `_last_import_time`,
+`_setup_complete_cache`). All three of those handles are `multiprocessing` primitives: the actual
+mechanism by which one worker process tells every other worker "the corpus changed" or "check
+whether setup finished," not incidental references. That is deliberately not a decoupling: the
+boundary here is about routing, and pretending otherwise would mean an `AppContext` refactor that
+the routing fix does not need.
+
+The child keeps its own `_conn_pool` rather than sharing the parent's: nothing here needs the
+parent's query-result cache or EXPLAIN plumbing, only a connection, so a second pool removes that
+coupling for the price of a second `psycopg_pool.ConnectionPool` (and its own connections) per
+worker process.
 """
 
 from __future__ import annotations
@@ -54,6 +61,7 @@ if TYPE_CHECKING:
     from multiprocessing.synchronize import Event as EventType
     from multiprocessing.synchronize import RLock as LockType
 
+    import psycopg_pool
     from psycopg import Connection
 
     from api.api_resource import APIResource
@@ -184,6 +192,7 @@ class AdminResource:
             schema_setup_event: Set once the schema has been created.
         """
         self._parent = parent
+        self._conn_pool: psycopg_pool.ConnectionPool = db_utils.make_pool()
         self._import_guard = import_guard
         self._schema_setup_event = schema_setup_event
         self._session = requests.Session()
@@ -207,7 +216,7 @@ class AdminResource:
             # read migrations from the db dir...
             # if any already applied migrations differ from what we want
             # to apply then drop everything
-            with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+            with self._conn_pool.connection() as conn, conn.cursor() as cursor:
                 cursor.execute(
                     """CREATE TABLE IF NOT EXISTS migrations (
                         file_name text not null,
@@ -298,10 +307,10 @@ class AdminResource:
             # running the backfill ahead of the tag import scored every card as on-style on a
             # first boot, and nothing rescored until the next import. Oracle tags feed search
             # rather than scoring, so their position relative to the backfill does not matter.
-            _import_art_tags(self._parent._conn_pool, self._bulk_data_fetcher)
+            _import_art_tags(self._conn_pool, self._bulk_data_fetcher)
             self.backfill_prefer_scores()
             self.backfill_cubecobra_scores()
-            _import_oracle_tags(self._parent._conn_pool, self._bulk_data_fetcher)
+            _import_oracle_tags(self._conn_pool, self._bulk_data_fetcher)
             self._parent._reload_engine(force=True)
             self._clear_caches()
             self._parent._last_import_time.value = time.time()
@@ -384,7 +393,7 @@ class AdminResource:
         logger.info("Starting prefer score backfill")
 
         backfill_sql = db_utils.read_sql("backfill_prefer_scores")
-        with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
             db_utils.set_statement_timeout(cursor, settings.prefer_score_backfill_timeout_ms)
             cursor.execute(backfill_sql)
             updated_count = cursor.rowcount
@@ -479,7 +488,7 @@ class AdminResource:
             ]
         )
 
-        with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 """
                 WITH incoming AS (
@@ -531,7 +540,7 @@ class AdminResource:
         logger.info("Starting CubeCobra score backfill with weights: %s", weights)
 
         backfill_sql = db_utils.read_sql("backfill_cubecobra_scores")
-        with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
             db_utils.set_statement_timeout(cursor, 600_000)
             cursor.execute(backfill_sql, weights)
             updated_count = cursor.rowcount
@@ -571,7 +580,7 @@ class AdminResource:
         """
         logger.info("Starting CubeCobra ingest")
         # fetch the distinct, non-null oracle ids that are in the db
-        with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 "SELECT DISTINCT oracle_id FROM magic.cards WHERE oracle_id IS NOT NULL",
             )
@@ -657,7 +666,7 @@ class AdminResource:
         # Update cards in database with the new is: tag
         updated_count = 0
         new_tag = orjson.dumps({is_tag: True}).decode("utf-8")
-        with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
             # Use SQL update with jsonb concatenation to add the is: tag
             for card_name_batch in itertools.batched(sorted(card_names), 500):
                 cursor.execute(
@@ -739,7 +748,7 @@ class AdminResource:
         updated_count = 0
         new_tag = orjson.dumps({is_tag: True}).decode("utf-8")
         scryfall_ids = {p["id"] for p in printings}
-        with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
             # Use SQL update with jsonb concatenation to add the is: tag
             for scryfall_id_batch in itertools.batched(sorted(scryfall_ids), 500):
                 cursor.execute(
@@ -801,12 +810,12 @@ class AdminResource:
     @route()
     def import_oracle_tags(self, **_: object) -> dict[str, Any]:
         """Import oracle tags from Scryfall bulk data into oracle_tags, oracle_tag_relationships, and card_oracle_tags."""
-        return _import_oracle_tags(self._parent._conn_pool, self._bulk_data_fetcher)
+        return _import_oracle_tags(self._conn_pool, self._bulk_data_fetcher)
 
     @route()
     def import_art_tags(self, **_: object) -> dict[str, Any]:
         """Import art tags from Scryfall bulk data into art_tags, art_tag_relationships, and card_art_tags."""
-        return _import_art_tags(self._parent._conn_pool, self._bulk_data_fetcher)
+        return _import_art_tags(self._conn_pool, self._bulk_data_fetcher)
 
     @route()
     def import_all_is_tags(self, **_: object) -> dict[str, Any]:
@@ -915,7 +924,7 @@ class AdminResource:
         logger.info("Importing card by name: '%s'", card_name)
 
         # Check if card already exists in database for backward compatibility
-        with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 "SELECT card_name FROM magic.cards WHERE card_name = %(card_name)s",
                 {"card_name": card_name},
@@ -1088,7 +1097,7 @@ class AdminResource:
         self.setup_schema()
 
         try:
-            with self._parent._conn_pool.connection() as conn:
+            with self._conn_pool.connection() as conn:
                 with conn.cursor() as cursor:
                     db_utils.set_statement_timeout(cursor, 30_000)
 

--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -20,7 +20,9 @@ the routing fix does not need.
 The child keeps its own `_conn_pool` rather than sharing the parent's: nothing here needs the
 parent's query-result cache or EXPLAIN plumbing, only a connection, so a second pool removes that
 coupling for the price of a second `psycopg_pool.ConnectionPool` (and its own connections) per
-worker process.
+worker process. `APIResource.__init__` builds both pools and hands this one over at construction,
+rather than this module building its own — so a test can inject a mock in place of either without
+a real connection ever opening.
 """
 
 from __future__ import annotations
@@ -183,16 +185,26 @@ CARD_IS_TAGS = LAND_IS_TAGS + [  # noqa: RUF005
 class AdminResource:
     """Data-management routes, mounted behind a path prefix by APIResource."""
 
-    def __init__(self, parent: APIResource, *, import_guard: LockType, schema_setup_event: EventType) -> None:
+    def __init__(
+        self,
+        parent: APIResource,
+        *,
+        conn_pool: psycopg_pool.ConnectionPool,
+        import_guard: LockType,
+        schema_setup_event: EventType,
+    ) -> None:
         """Attach to the parent resource and take ownership of the admin-only handles.
 
         Args:
             parent: The resource this is mounted on, for the shared methods and handles.
+            conn_pool: This resource's own connection pool -- built by the caller (mirroring the
+                parent's own `_conn_pool`), so a test can inject a mock without a real pool ever
+                opening a connection.
             import_guard: Cross-process lock serialising imports.
             schema_setup_event: Set once the schema has been created.
         """
         self._parent = parent
-        self._conn_pool: psycopg_pool.ConnectionPool = db_utils.make_pool()
+        self._conn_pool = conn_pool
         self._import_guard = import_guard
         self._schema_setup_event = schema_setup_event
         self._session = requests.Session()

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -247,7 +247,7 @@ def _columnarize_cards(cards: list[dict[str, Any]]) -> dict[str, list[Any]]:
 class APIResource:
     """Class implementing request handling for our simple API."""
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         *,
         import_guard: LockType = multiprocessing_utils.DEFAULT_LOCK,
@@ -255,13 +255,28 @@ class APIResource:
         schema_setup_event: EventType = multiprocessing_utils.DEFAULT_EVENT,
         cache_generation: Synchronized | None = None,
         engine_reload_guard: LockType | None = None,
+        conn_pool: psycopg_pool.ConnectionPool | None = None,
+        admin_conn_pool: psycopg_pool.ConnectionPool | None = None,
     ) -> None:
         """Initialize an APIResource object, set up connection pool and action map.
 
         Sets up the database connection pool and action mapping for the API.
+
+        Args:
+            import_guard: Cross-process lock serialising imports.
+            last_import_time: Shared timestamp of the last completed import.
+            schema_setup_event: Set once the schema has been created.
+            cache_generation: Shared counter bumped to invalidate the query-result cache.
+            engine_reload_guard: Cross-process lock serialising engine reloads.
+            conn_pool: This resource's own connection pool. Built via `db_utils.make_pool()` if not
+                given, matching every other handle here -- a caller (a test, mainly) can inject one
+                without a real pool ever opening a connection.
+            admin_conn_pool: The connection pool handed to the mounted AdminResource. Built the same
+                way if not given; kept separate from `conn_pool` so a test can inject the two
+                independently.
         """
         self._critical_css: str = build_critical_css(STATIC_DIR / "styles.css")
-        self._conn_pool: psycopg_pool.ConnectionPool = db_utils.make_pool()
+        self._conn_pool: psycopg_pool.ConnectionPool = conn_pool or db_utils.make_pool()
         # Build the route table from methods marked with @route, scanning the class rather than this
         # instance so nothing assigned below can become a route. Each entry carries everything
         # dispatch needs — the wrapped handler, how many positional path segments it absorbs, and
@@ -285,7 +300,12 @@ class APIResource:
         # Mounted after the parent's own state exists, since the child reaches back for the handles
         # they share. advertise=False is set here rather than on each handler: forgetting it is then
         # a property of this one call, not a hole in one route.
-        self.admin = AdminResource(self, import_guard=import_guard, schema_setup_event=schema_setup_event)
+        self.admin = AdminResource(
+            self,
+            conn_pool=admin_conn_pool or db_utils.make_pool(),
+            import_guard=import_guard,
+            schema_setup_event=schema_setup_event,
+        )
         self.routes.update(build_route_table(self.admin, prefix=ADMIN_MOUNT_PREFIX, advertise=False))
         self._not_found_routes = build_routes_listing(self.routes)
 

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -37,7 +37,13 @@ from api.settings import settings
 from api.utils import db_utils, error_monitoring, multiprocessing_utils
 from api.utils.css_utils import build_critical_css
 from api.utils.generation_cache import GenerationCache
-from api.utils.page_rendering import SITE_NAME_PLACEHOLDER, STATIC_DIR, build_base_html, build_card_html
+from api.utils.page_rendering import (
+    SITE_NAME_PLACEHOLDER,
+    STATIC_DIR,
+    build_base_html,
+    build_card_html,
+    serve_static_file,
+)
 from api.utils.param_binding import ParamCoercionError
 from api.utils.routing import build_route_table, build_routes_listing, route
 from api.utils.site_name import hostname_to_site_name
@@ -1218,7 +1224,7 @@ class APIResource:
         """
         if falcon_response is None:
             return
-        self._serve_static_file(filename="styles.css", falcon_response=falcon_response)
+        serve_static_file(filename="styles.css", falcon_response=falcon_response)
         falcon_response.content_type = "text/css"
         set_cache_header(falcon_response, duration=timedelta(days=30))
 
@@ -1232,7 +1238,7 @@ class APIResource:
         """
         if falcon_response is None:
             return
-        self._serve_static_file(filename="app.js", falcon_response=falcon_response)
+        serve_static_file(filename="app.js", falcon_response=falcon_response)
         falcon_response.content_type = "application/javascript"
         # Cache JavaScript for 1 hour - it changes infrequently
         set_cache_header(falcon_response, duration=timedelta(hours=1))
@@ -1247,7 +1253,7 @@ class APIResource:
         """
         if falcon_response is None:
             return
-        self._serve_static_file(filename="app.min.js", falcon_response=falcon_response)
+        serve_static_file(filename="app.min.js", falcon_response=falcon_response)
         falcon_response.content_type = "application/javascript"
         set_cache_header(falcon_response, duration=timedelta(days=30))
 
@@ -1256,7 +1262,7 @@ class APIResource:
         """Return the robots.txt file."""
         if falcon_response is None:
             return
-        self._serve_static_file(filename="robots.txt", falcon_response=falcon_response)
+        serve_static_file(filename="robots.txt", falcon_response=falcon_response)
         falcon_response.content_type = "text/plain"
 
     @route(paths=("static/card.js",))
@@ -1269,7 +1275,7 @@ class APIResource:
         """
         if falcon_response is None:
             return
-        self._serve_static_file(filename="card.js", falcon_response=falcon_response)
+        serve_static_file(filename="card.js", falcon_response=falcon_response)
         falcon_response.content_type = "application/javascript"
         set_cache_header(falcon_response, duration=timedelta(hours=1))
 
@@ -1300,29 +1306,6 @@ class APIResource:
         falcon_response.text = html.replace(SITE_NAME_PLACEHOLDER, site_name)
         falcon_response.content_type = "text/html"
         set_cache_header(falcon_response, duration=timedelta(hours=1))
-
-    def _serve_static_file(self, *, filename: str, falcon_response: falcon.Response) -> None:
-        """Serve a static file to the Falcon response.
-
-        Args:
-        ----
-            filename (str): The file to serve.
-            falcon_response (falcon.Response): The Falcon response to write to.
-
-        """
-        full_filename = STATIC_DIR / filename
-        try:
-            with pathlib.Path(full_filename).open() as f:
-                falcon_response.text = f.read()
-        except FileNotFoundError:
-            falcon_response.status = falcon.HTTP_404
-            falcon_response.text = f"File not found: {filename}"
-        except PermissionError:
-            falcon_response.status = falcon.HTTP_403
-            falcon_response.text = f"Permission denied: {filename}"
-        except OSError as e:
-            falcon_response.status = falcon.HTTP_500
-            falcon_response.text = f"Error reading file {filename}: {e}"
 
     @route()
     def get_catalog(

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -26,7 +26,7 @@ import orjson
 import psycopg
 import psycopg_pool
 from cachebox import LRUCache, TTLCache
-from psycopg import Connection, Cursor
+from psycopg import Connection
 
 from api.admin_resource import ADMIN_MOUNT_PREFIX, AdminResource
 from api.enums import CardOrdering, PreferOrder, ResponseShape, SortDirection, UniqueOn
@@ -286,24 +286,6 @@ class APIResource:
         self.admin.setup_schema()
         self.admin.import_data()  # ensures that database is setup
 
-    def _set_statement_timeout(self, cursor: Cursor, statement_timeout: int) -> None:
-        """Validate and set the statement timeout for a database cursor.
-
-        PostgreSQL SET commands don't support parameterized values, so we must
-        validate the value before using it in string interpolation.
-
-        Args:
-            cursor: Database cursor to execute the SET command on
-            statement_timeout: The statement timeout value in milliseconds
-
-        Raises:
-            ValueError: If statement_timeout is not a non-negative integer
-        """
-        if not isinstance(statement_timeout, int) or statement_timeout < 0:
-            msg = f"statement_timeout must be a non-negative integer, got: {statement_timeout}"
-            raise ValueError(msg)
-        cursor.execute(f"set statement_timeout = {statement_timeout}")
-
     def _resolve_action(self, path: str) -> tuple[BoundRoute | None, list[str]]:
         """Map a request path to the route that answers it.
 
@@ -472,7 +454,7 @@ class APIResource:
         result: dict[str, Any] = {}
         with self._conn_pool.connection() as conn, conn.cursor() as cursor:
             # Validate and set statement timeout
-            self._set_statement_timeout(cursor, statement_timeout)
+            db_utils.set_statement_timeout(cursor, statement_timeout)
             if explain:
                 explain_query = f"EXPLAIN (FORMAT JSON) {query}"
                 cursor.execute(explain_query, params)

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -27,7 +27,7 @@ def engine_enabled_fixture() -> Generator[None]:
 
 @pytest.fixture(name="stub_api_resource")
 def stub_api_resource_fixture() -> Generator[APIResource]:
-    """A fresh APIResource per test, readiness stubbed, connection pool closed afterward.
+    """A fresh APIResource per test, readiness stubbed, both connection pools closed afterward.
 
     Function-scoped on purpose: it replaces per-class `setup_method` construction, and tests using it
     mutate the instance (`_engine`, feature gates), so sharing one across a module would couple them.
@@ -46,6 +46,7 @@ def stub_api_resource_fixture() -> Generator[APIResource]:
     override_attr(api, "_setup_complete", lambda: True)
     yield api
     api._conn_pool.close()
+    api.admin._conn_pool.close()
 
 
 @pytest.fixture(scope="module")
@@ -65,3 +66,4 @@ def api_resource(postgres_container: None) -> Generator[APIResource]:
     api.admin.setup_schema()
     yield api
     api._conn_pool.close()
+    api.admin._conn_pool.close()

--- a/api/tests/support.py
+++ b/api/tests/support.py
@@ -2,6 +2,35 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+if TYPE_CHECKING:
+    from api.api_resource import APIResource
+
+
+def stub_conn_pools(api_resource: APIResource) -> MagicMock:
+    """Close the real pools opened during construction and replace both with one mock.
+
+    APIResource.__init__ and the AdminResource it constructs each open a real
+    psycopg_pool.ConnectionPool immediately (min_size=1, open=True). A test that doesn't need a
+    real database must close both before dropping the reference, or the sockets and the pool's
+    background thread outlive the test. Returns one mock shared by both attributes, matching how
+    a single `_conn_pool` mock covered every code path before AdminResource had its own pool.
+
+    Args:
+        api_resource: An already-constructed APIResource whose pools should be replaced.
+
+    Returns:
+        The MagicMock now assigned to both `api_resource._conn_pool` and `api_resource.admin._conn_pool`.
+    """
+    api_resource._conn_pool.close()
+    api_resource.admin._conn_pool.close()
+    mock_pool = MagicMock()
+    api_resource._conn_pool = mock_pool
+    api_resource.admin._conn_pool = mock_pool
+    return mock_pool
+
 
 def override_attr(obj: object, name: str, value: object) -> None:
     """Replace an existing attribute on an instance, failing if it is not already there.

--- a/api/tests/support.py
+++ b/api/tests/support.py
@@ -2,34 +2,24 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
-if TYPE_CHECKING:
-    from api.api_resource import APIResource
 
+def mock_conn_pool_kwargs() -> tuple[MagicMock, dict[str, MagicMock]]:
+    """A mock pool plus the APIResource(...) kwargs that inject it as both `_conn_pool`s.
 
-def stub_conn_pools(api_resource: APIResource) -> MagicMock:
-    """Close the real pools opened during construction and replace both with one mock.
-
-    APIResource.__init__ and the AdminResource it constructs each open a real
-    psycopg_pool.ConnectionPool immediately (min_size=1, open=True). A test that doesn't need a
-    real database must close both before dropping the reference, or the sockets and the pool's
-    background thread outlive the test. Returns one mock shared by both attributes, matching how
-    a single `_conn_pool` mock covered every code path before AdminResource had its own pool.
-
-    Args:
-        api_resource: An already-constructed APIResource whose pools should be replaced.
+    APIResource.__init__ takes `conn_pool` and `admin_conn_pool` precisely so a test can hand it a
+    mock at construction time; passed the return value here as `**kwargs`, no real
+    psycopg_pool.ConnectionPool is ever opened, so there is nothing to close afterward. One mock
+    covers both attributes, matching how a single `_conn_pool` mock covered every code path before
+    AdminResource had its own pool.
 
     Returns:
-        The MagicMock now assigned to both `api_resource._conn_pool` and `api_resource.admin._conn_pool`.
+        The mock, and a `{"conn_pool": ..., "admin_conn_pool": ...}` dict to spread into the
+        APIResource(...) call.
     """
-    api_resource._conn_pool.close()
-    api_resource.admin._conn_pool.close()
     mock_pool = MagicMock()
-    api_resource._conn_pool = mock_pool
-    api_resource.admin._conn_pool = mock_pool
-    return mock_pool
+    return mock_pool, {"conn_pool": mock_pool, "admin_conn_pool": mock_pool}
 
 
 def override_attr(obj: object, name: str, value: object) -> None:

--- a/api/tests/test_admin_mount.py
+++ b/api/tests/test_admin_mount.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import multiprocessing
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import falcon
 import falcon.testing
@@ -59,14 +59,17 @@ EXPECTED_ADMIN_ROUTES = {
 
 @pytest.fixture(name="resource")
 def resource_fixture() -> APIResource:
-    """An APIResource with its child mounted, against mocked pools.
+    """An APIResource with its child mounted, against distinct mocked pools.
 
-    A fresh MagicMock per call (rather than a fixed return_value) so the parent's and the child's
-    pools are distinct objects, matching that AdminResource now opens its own pool instead of
-    sharing the parent's.
+    conn_pool and admin_conn_pool are injected separately (rather than left to default) so the
+    parent's and the child's pools are distinct objects, matching that AdminResource now opens its
+    own pool instead of sharing the parent's.
     """
-    with patch("api.api_resource.db_utils.make_pool", side_effect=MagicMock):
-        return APIResource(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
+    return APIResource(
+        last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+        conn_pool=MagicMock(),
+        admin_conn_pool=MagicMock(),
+    )
 
 
 class TestRouteTable:

--- a/api/tests/test_admin_mount.py
+++ b/api/tests/test_admin_mount.py
@@ -59,8 +59,13 @@ EXPECTED_ADMIN_ROUTES = {
 
 @pytest.fixture(name="resource")
 def resource_fixture() -> APIResource:
-    """An APIResource with its child mounted, against a mocked pool."""
-    with patch("api.api_resource.db_utils.make_pool", return_value=MagicMock()):
+    """An APIResource with its child mounted, against mocked pools.
+
+    A fresh MagicMock per call (rather than a fixed return_value) so the parent's and the child's
+    pools are distinct objects, matching that AdminResource now opens its own pool instead of
+    sharing the parent's.
+    """
+    with patch("api.api_resource.db_utils.make_pool", side_effect=MagicMock):
         return APIResource(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
 
 
@@ -148,5 +153,12 @@ class TestSharedSurface:
             assert not hasattr(resource, handle), f"{handle} should have moved to the child"
 
     def test_shared_handles_stay_on_the_parent(self, resource: APIResource) -> None:
-        for handle in ("_conn_pool", "_cache_generation", "_last_import_time"):
+        for handle in ("_cache_generation", "_last_import_time"):
             assert hasattr(resource, handle), handle
+
+    def test_admin_has_its_own_conn_pool(self, resource: APIResource) -> None:
+        # Not a shared handle: each side opens its own psycopg_pool.ConnectionPool, so nothing
+        # here reaches through the parent for a connection, its query cache, or EXPLAIN plumbing.
+        assert hasattr(resource, "_conn_pool")
+        assert hasattr(resource.admin, "_conn_pool")
+        assert resource.admin._conn_pool is not resource._conn_pool

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -659,19 +659,6 @@ class TestAPIResourceStaticFileServing(unittest.TestCase):
         )
         self.api_resource._conn_pool = self.mock_conn_pool
 
-    def test_serve_static_file_reads_file_content(self) -> None:
-        """Test _serve_static_file reads and serves file content."""
-        mock_response = MagicMock()
-
-        with patch("api.api_resource.pathlib.Path") as mock_path:
-            mock_file = MagicMock()
-            mock_file.open.return_value.__enter__.return_value.read.return_value = "file content"
-            mock_path.return_value = mock_file
-
-            self.api_resource._serve_static_file(filename="test.html", falcon_response=mock_response)
-
-            assert mock_response.text == "file content"
-
     def test_index_html_serves_static_file(self) -> None:
         """Test _root serves the index.html file."""
         mock_response = MagicMock()

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -20,7 +20,7 @@ from api.api_resource import INTERNAL_ERROR_DESCRIPTION, APIResource
 from api.enums import ResponseShape
 from api.middlewares.caching_middleware import CachingMiddleware
 from api.settings import settings
-from api.tests.support import stub_conn_pools
+from api.tests.support import mock_conn_pool_kwargs
 from api.utils.routing import BoundRoute, RouteSpec, route
 from api.utils.site_name import FALLBACK_SITE_NAME
 
@@ -134,27 +134,17 @@ def create_test_card(  # noqa: PLR0913, PLR0917
     return card
 
 
-@pytest.fixture(name="patch_conn_pool")
-def patch_conn_pool_fixture() -> MagicMock:
-    """Patch connection pool."""
-    mock_conn_pool = MagicMock()
-    with patch("api.api_resource.db_utils.make_pool") as mock_pool:
-        mock_pool.return_value = mock_conn_pool
-        yield mock_conn_pool
-
-
 class TestBaseAPIResourceTest:
     @pytest.fixture(autouse=True)
-    def setUp(self, request: pytest.FixtureRequest, patch_conn_pool: MagicMock) -> None:
+    def setUp(self, request: pytest.FixtureRequest) -> None:
         """Set up test fixtures."""
-        del patch_conn_pool
         self_reference = request.instance
 
-        self_reference.mock_conn_pool = MagicMock()
+        self_reference.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
         self_reference.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        self_reference.api_resource._conn_pool = self_reference.mock_conn_pool
 
 
 class TestAPIResourceInitializationNewStyle(TestBaseAPIResourceTest):
@@ -373,10 +363,11 @@ class TestAPIResourceCoreMethods(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
+        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        self.mock_conn_pool = stub_conn_pools(self.api_resource)
 
     def test_get_pid_returns_process_id(self) -> None:
         """Test that get_pid returns the current process ID."""
@@ -390,10 +381,11 @@ class TestAPIResourceRequestHandling(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
+        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        self.mock_conn_pool = stub_conn_pools(self.api_resource)
 
     def test_raise_not_found_raises_http_not_found(self) -> None:
         """Test _raise_not_found raises HTTPNotFound with route information."""
@@ -652,10 +644,11 @@ class TestAPIResourceStaticFileServing(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
+        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        self.mock_conn_pool = stub_conn_pools(self.api_resource)
 
     def test_index_html_serves_static_file(self) -> None:
         """Test _root serves the index.html file."""
@@ -782,10 +775,11 @@ class TestAPIResourceErrorHandling(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
+        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        self.mock_conn_pool = stub_conn_pools(self.api_resource)
 
     def test_import_card_by_name_validates_card_name_parameter(self) -> None:
         """Test import_card_by_name validates card_name parameter."""
@@ -814,10 +808,11 @@ class TestAPIResourceCaching(unittest.TestCase):
         # Enable caching for these tests
         settings.enable_cache = True
         # Now create the APIResource with caching enabled
+        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        self.mock_conn_pool = stub_conn_pools(self.api_resource)
 
     def tearDown(self) -> None:
         """Restore original cache setting."""
@@ -1008,10 +1003,11 @@ class TestRootSiteNameInjection(unittest.TestCase):
     """Tests that _root injects the derived site name into the HTML."""
 
     def setUp(self) -> None:
+        _, pool_kwargs = mock_conn_pool_kwargs()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        stub_conn_pools(self.api_resource)
 
     def test_valid_hostname_replaces_fallback_in_html(self) -> None:
         mock_response = MagicMock()
@@ -1029,10 +1025,11 @@ class TestCardSiteNameInjection(unittest.TestCase):
     """Tests that card() injects the derived site name into card page HTML."""
 
     def setUp(self) -> None:
+        _, pool_kwargs = mock_conn_pool_kwargs()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        stub_conn_pools(self.api_resource)
 
     def test_valid_hostname_replaces_fallback_in_card_html(self) -> None:
         mock_response = MagicMock()

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -20,6 +20,7 @@ from api.api_resource import INTERNAL_ERROR_DESCRIPTION, APIResource
 from api.enums import ResponseShape
 from api.middlewares.caching_middleware import CachingMiddleware
 from api.settings import settings
+from api.tests.support import stub_conn_pools
 from api.utils.routing import BoundRoute, RouteSpec, route
 from api.utils.site_name import FALLBACK_SITE_NAME
 
@@ -372,11 +373,10 @@ class TestAPIResourceCoreMethods(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool = MagicMock()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
         )
-        self.api_resource._conn_pool = self.mock_conn_pool
+        self.mock_conn_pool = stub_conn_pools(self.api_resource)
 
     def test_get_pid_returns_process_id(self) -> None:
         """Test that get_pid returns the current process ID."""
@@ -390,11 +390,10 @@ class TestAPIResourceRequestHandling(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool = MagicMock()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
         )
-        self.api_resource._conn_pool = self.mock_conn_pool
+        self.mock_conn_pool = stub_conn_pools(self.api_resource)
 
     def test_raise_not_found_raises_http_not_found(self) -> None:
         """Test _raise_not_found raises HTTPNotFound with route information."""
@@ -653,11 +652,10 @@ class TestAPIResourceStaticFileServing(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool = MagicMock()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
         )
-        self.api_resource._conn_pool = self.mock_conn_pool
+        self.mock_conn_pool = stub_conn_pools(self.api_resource)
 
     def test_index_html_serves_static_file(self) -> None:
         """Test _root serves the index.html file."""
@@ -784,11 +782,10 @@ class TestAPIResourceErrorHandling(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool = MagicMock()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
         )
-        self.api_resource._conn_pool = self.mock_conn_pool
+        self.mock_conn_pool = stub_conn_pools(self.api_resource)
 
     def test_import_card_by_name_validates_card_name_parameter(self) -> None:
         """Test import_card_by_name validates card_name parameter."""
@@ -817,11 +814,10 @@ class TestAPIResourceCaching(unittest.TestCase):
         # Enable caching for these tests
         settings.enable_cache = True
         # Now create the APIResource with caching enabled
-        self.mock_conn_pool = MagicMock()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
         )
-        self.api_resource._conn_pool = self.mock_conn_pool
+        self.mock_conn_pool = stub_conn_pools(self.api_resource)
 
     def tearDown(self) -> None:
         """Restore original cache setting."""
@@ -834,7 +830,8 @@ class TestAPIResourceCaching(unittest.TestCase):
         mock_cursor = MagicMock()
         mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
         with (
-            patch.object(self.api_resource, "_conn_pool") as mock_pool,
+            # _upsert_cards runs on AdminResource's own pool, not the parent's.
+            patch.object(self.api_resource.admin, "_conn_pool") as mock_pool,
             patch(
                 "api.admin_resource._bulk_upsert",
                 return_value={"inserted": 1, "updated": 0, "unchanged": 0},
@@ -1014,7 +1011,7 @@ class TestRootSiteNameInjection(unittest.TestCase):
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
         )
-        self.api_resource._conn_pool = MagicMock()
+        stub_conn_pools(self.api_resource)
 
     def test_valid_hostname_replaces_fallback_in_html(self) -> None:
         mock_response = MagicMock()
@@ -1035,7 +1032,7 @@ class TestCardSiteNameInjection(unittest.TestCase):
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
         )
-        self.api_resource._conn_pool = MagicMock()
+        stub_conn_pools(self.api_resource)
 
     def test_valid_hostname_replaces_fallback_in_card_html(self) -> None:
         mock_response = MagicMock()

--- a/api/tests/test_datatype_mismatch.py
+++ b/api/tests/test_datatype_mismatch.py
@@ -36,8 +36,9 @@ class TestDatatypeMismatchHandling:
     def teardown_method(self) -> None:
         """Clean up test fixtures."""
         if hasattr(self, "api_resource") and self.api_resource:
-            # Close the connection pool to prevent thread pool warnings
+            # Close both connection pools to prevent thread pool warnings
             self.api_resource._conn_pool.close()
+            self.api_resource.admin._conn_pool.close()
 
     def test_search_sql_handles_datatype_mismatch(self) -> None:
         """Test that DatatypeMismatch in _search_sql raises HTTPBadRequest."""
@@ -109,6 +110,7 @@ class TestInvalidRegularExpressionHandling:
         """Clean up test fixtures."""
         if hasattr(self, "api_resource") and self.api_resource:
             self.api_resource._conn_pool.close()
+            self.api_resource.admin._conn_pool.close()
 
     def test_search_sql_handles_invalid_regular_expression(self) -> None:
         """An unparseable regex is the user's error, so it must be a 400 and not a 500.
@@ -154,6 +156,7 @@ class TestDataErrorHandling:
         """Clean up test fixtures."""
         if hasattr(self, "api_resource") and self.api_resource:
             self.api_resource._conn_pool.close()
+            self.api_resource.admin._conn_pool.close()
 
     def test_search_sql_handles_division_by_zero(self) -> None:
         """power/0>1 parses cleanly but divides by zero at runtime — a 400, not a 500."""

--- a/api/tests/test_import_card_by_name.py
+++ b/api/tests/test_import_card_by_name.py
@@ -13,6 +13,7 @@ import requests
 
 from api.admin_resource import AdminResource
 from api.api_resource import APIResource
+from api.tests.support import stub_conn_pools
 
 
 class TestImportCardByName(unittest.TestCase):
@@ -20,16 +21,15 @@ class TestImportCardByName(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool = MagicMock()
+        self.api_resource = APIResource(
+            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+        )
+        self.mock_conn_pool = stub_conn_pools(self.api_resource)
         self.mock_cursor = MagicMock()
         self.mock_cursor.fetchone.return_value = None
         self.mock_conn_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = (
             self.mock_cursor
         )
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-        )
-        self.api_resource._conn_pool = self.mock_conn_pool
 
     def test_import_card_by_name_validates_input(self) -> None:
         """Test that import_card_by_name validates card_name parameter."""

--- a/api/tests/test_import_card_by_name.py
+++ b/api/tests/test_import_card_by_name.py
@@ -21,6 +21,11 @@ class TestImportCardByName(unittest.TestCase):
     def setUp(self) -> None:
         """Set up test fixtures."""
         self.mock_conn_pool = MagicMock()
+        self.mock_cursor = MagicMock()
+        self.mock_cursor.fetchone.return_value = None
+        self.mock_conn_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = (
+            self.mock_cursor
+        )
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
         )
@@ -83,11 +88,10 @@ class TestImportCardByName(unittest.TestCase):
         with pytest.raises(ValueError, match="Failed to fetch data from Scryfall API"):
             self.api_resource.admin._scryfall_search(query="name:'Lightning Bolt'")
 
-    @patch.object(APIResource, "_run_query")
-    def test_import_card_by_name_returns_already_exists_for_existing_card(self, mock_run_query: MagicMock) -> None:
+    def test_import_card_by_name_returns_already_exists_for_existing_card(self) -> None:
         """Test that import_card_by_name returns already_exists status for existing cards."""
-        # Mock _run_query to return existing card
-        mock_run_query.return_value = {"result": [{"card_name": "Lightning Bolt"}]}
+        # Mock the existence-check query to find a row
+        self.mock_cursor.fetchone.return_value = {"card_name": "Lightning Bolt"}
 
         result = self.api_resource.admin.import_card_by_name(card_name="Lightning Bolt")
 
@@ -95,17 +99,12 @@ class TestImportCardByName(unittest.TestCase):
         assert result["card_name"] == "Lightning Bolt"
         assert "already exists in database" in result["message"]
 
-    @patch.object(APIResource, "_run_query")
     @patch.object(AdminResource, "_scryfall_search")
     def test_import_card_by_name_returns_not_found_for_missing_card(
         self,
         mock_search: MagicMock,
-        mock_run_query: MagicMock,
     ) -> None:
         """Test that import_card_by_name returns not_found status when card doesn't exist in Scryfall."""
-        # Mock _run_query to return no existing card
-        mock_run_query.return_value = {"result": []}
-
         # Mock Scryfall API to return empty list (not found)
         mock_search.return_value = []
 
@@ -115,17 +114,12 @@ class TestImportCardByName(unittest.TestCase):
         assert result["search_query"] == '!"NonexistentCard"'
         assert "No cards found for search query" in result["message"]
 
-    @patch.object(APIResource, "_run_query")
     @patch.object(AdminResource, "_scryfall_search")
     def test_import_card_by_name_returns_error_for_scryfall_exceptions(
         self,
         mock_search: MagicMock,
-        mock_run_query: MagicMock,
     ) -> None:
         """Test that import_card_by_name returns error status for Scryfall API exceptions."""
-        # Mock _run_query to return no existing card
-        mock_run_query.return_value = {"result": []}
-
         # Mock Scryfall API to raise exception
         mock_search.side_effect = ValueError("API Error")
 
@@ -135,19 +129,14 @@ class TestImportCardByName(unittest.TestCase):
         assert result["search_query"] == '!"TestCard"'
         assert "Error fetching cards from Scryfall" in result["message"]
 
-    @patch.object(APIResource, "_run_query")
     @patch.object(AdminResource, "_scryfall_search")
     @patch("api.card_processing.preprocess_card")
     def test_import_card_by_name_returns_filtered_out_for_invalid_cards(
         self,
         mock_preprocess: MagicMock,
         mock_search: MagicMock,
-        mock_run_query: MagicMock,
     ) -> None:
         """Test that import_card_by_name returns filtered_out status for cards filtered during preprocessing."""
-        # Mock _run_query to return no existing card
-        mock_run_query.return_value = {"result": []}
-
         # Mock Scryfall API to return card data
         mock_search.return_value = [{"name": "TestCard", "legalities": {"standard": "not_legal"}}]
 

--- a/api/tests/test_import_card_by_name.py
+++ b/api/tests/test_import_card_by_name.py
@@ -13,7 +13,7 @@ import requests
 
 from api.admin_resource import AdminResource
 from api.api_resource import APIResource
-from api.tests.support import stub_conn_pools
+from api.tests.support import mock_conn_pool_kwargs
 
 
 class TestImportCardByName(unittest.TestCase):
@@ -21,10 +21,11 @@ class TestImportCardByName(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
+        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        self.mock_conn_pool = stub_conn_pools(self.api_resource)
         self.mock_cursor = MagicMock()
         self.mock_cursor.fetchone.return_value = None
         self.mock_conn_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = (

--- a/api/tests/test_import_cards_by_search.py
+++ b/api/tests/test_import_cards_by_search.py
@@ -11,6 +11,7 @@ import pytest
 
 from api.admin_resource import AdminResource
 from api.api_resource import APIResource
+from api.tests.support import stub_conn_pools
 
 
 class TestImportCardsBySearch(unittest.TestCase):
@@ -18,11 +19,10 @@ class TestImportCardsBySearch(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool = MagicMock()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
         )
-        self.api_resource._conn_pool = self.mock_conn_pool
+        self.mock_conn_pool = stub_conn_pools(self.api_resource)
 
     def test_import_cards_by_search_validates_input(self) -> None:
         """Test that import_cards_by_search validates search_query parameter."""

--- a/api/tests/test_import_cards_by_search.py
+++ b/api/tests/test_import_cards_by_search.py
@@ -11,7 +11,7 @@ import pytest
 
 from api.admin_resource import AdminResource
 from api.api_resource import APIResource
-from api.tests.support import stub_conn_pools
+from api.tests.support import mock_conn_pool_kwargs
 
 
 class TestImportCardsBySearch(unittest.TestCase):
@@ -19,10 +19,11 @@ class TestImportCardsBySearch(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
+        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        self.mock_conn_pool = stub_conn_pools(self.api_resource)
 
     def test_import_cards_by_search_validates_input(self) -> None:
         """Test that import_cards_by_search validates search_query parameter."""

--- a/api/tests/test_integration_testcontainers.py
+++ b/api/tests/test_integration_testcontainers.py
@@ -136,9 +136,11 @@ class TestContainerIntegration:
         # Yield the fully configured APIResource for tests to use
         yield api
 
-        # Clean up connection pool
+        # Clean up connection pools
         if hasattr(api, "_conn_pool"):
             api._conn_pool.close()
+        if hasattr(api.admin, "_conn_pool"):
+            api.admin._conn_pool.close()
 
     def test_query_parsing_with_database(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test query parsing and execution against real database."""

--- a/api/tests/test_page_rendering.py
+++ b/api/tests/test_page_rendering.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import falcon
 
 from api.api_resource import APIResource
+from api.tests.support import stub_conn_pools
 from api.utils import page_rendering
 
 
@@ -45,11 +46,10 @@ class TestHtmlMinification(unittest.TestCase):
     """
 
     def setUp(self) -> None:
-        self.mock_conn_pool = MagicMock()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
         )
-        self.api_resource._conn_pool = self.mock_conn_pool
+        self.mock_conn_pool = stub_conn_pools(self.api_resource)
 
     def test_minifies_whitespace_by_default(self) -> None:
         # minify_html also drops the redundant closing </p> (valid HTML5 tag-omission), hence

--- a/api/tests/test_page_rendering.py
+++ b/api/tests/test_page_rendering.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 import falcon
 
 from api.api_resource import APIResource
-from api.tests.support import stub_conn_pools
+from api.tests.support import mock_conn_pool_kwargs
 from api.utils import page_rendering
 
 
@@ -46,10 +46,11 @@ class TestHtmlMinification(unittest.TestCase):
     """
 
     def setUp(self) -> None:
+        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        self.mock_conn_pool = stub_conn_pools(self.api_resource)
 
     def test_minifies_whitespace_by_default(self) -> None:
         # minify_html also drops the redundant closing </p> (valid HTML5 tag-omission), hence

--- a/api/tests/test_page_rendering.py
+++ b/api/tests/test_page_rendering.py
@@ -7,8 +7,34 @@ import time
 import unittest
 from unittest.mock import MagicMock, patch
 
+import falcon
+
 from api.api_resource import APIResource
 from api.utils import page_rendering
+
+
+class TestServeStaticFile(unittest.TestCase):
+    """serve_static_file reads a file under STATIC_DIR and writes it to the response."""
+
+    def test_reads_file_content(self) -> None:
+        mock_response = MagicMock()
+
+        with patch("api.utils.page_rendering.pathlib.Path") as mock_path:
+            mock_file = MagicMock()
+            mock_file.open.return_value.__enter__.return_value.read.return_value = "file content"
+            mock_path.return_value = mock_file
+
+            page_rendering.serve_static_file(filename="test.html", falcon_response=mock_response)
+
+            assert mock_response.text == "file content"
+
+    def test_missing_file_serves_404(self) -> None:
+        mock_response = MagicMock()
+
+        page_rendering.serve_static_file(filename="does-not-exist.html", falcon_response=mock_response)
+
+        assert mock_response.status == falcon.HTTP_404
+        assert "does-not-exist.html" in mock_response.text
 
 
 class TestHtmlMinification(unittest.TestCase):

--- a/api/tests/test_prefer_order.py
+++ b/api/tests/test_prefer_order.py
@@ -26,8 +26,9 @@ class TestPreferOrder(unittest.TestCase):
         )
 
     def tearDown(self) -> None:
-        """Close the connection pool this test case opened."""
+        """Close the connection pools this test case opened."""
         self.api_resource._conn_pool.close()
+        self.api_resource.admin._conn_pool.close()
 
     def _search_sql(self, query: str, prefer: PreferOrder) -> dict:
         """Run _search_sql directly, bypassing engine dispatch."""

--- a/api/tests/test_upsert_cards.py
+++ b/api/tests/test_upsert_cards.py
@@ -16,7 +16,7 @@ from api.card_processing import preprocess_card
 from api.db.bulk_upsert import bulk_upsert
 from api.scryfall_bulk_data_fetcher import BulkDataKey
 from api.tests.helpers import make_raw_card
-from api.tests.support import stub_conn_pools
+from api.tests.support import mock_conn_pool_kwargs
 
 if TYPE_CHECKING:
     import pytest
@@ -238,10 +238,9 @@ class TestRunImportUnderLockStreaming:
     def _make_api(self) -> APIResource:
         # Patch out setup_schema and import_data during construction: __init__ calls both, and an
         # unpatched import_data with last_import_time=0.0 performs a real full Scryfall import.
+        _, pool_kwargs = mock_conn_pool_kwargs()
         with patch.object(AdminResource, "setup_schema"), patch.object(AdminResource, "import_data"):
-            api = APIResource(last_import_time=multiprocessing.Value("d", 0.0, lock=True))
-        stub_conn_pools(api)
-        return api
+            return APIResource(last_import_time=multiprocessing.Value("d", 0.0, lock=True), **pool_kwargs)
 
     def test_calls_stream_data_for_key(self) -> None:
         api = self._make_api()

--- a/api/tests/test_upsert_cards.py
+++ b/api/tests/test_upsert_cards.py
@@ -6,7 +6,7 @@ import logging
 import multiprocessing
 import uuid
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import psycopg
 
@@ -16,6 +16,7 @@ from api.card_processing import preprocess_card
 from api.db.bulk_upsert import bulk_upsert
 from api.scryfall_bulk_data_fetcher import BulkDataKey
 from api.tests.helpers import make_raw_card
+from api.tests.support import stub_conn_pools
 
 if TYPE_CHECKING:
     import pytest
@@ -239,8 +240,7 @@ class TestRunImportUnderLockStreaming:
         # unpatched import_data with last_import_time=0.0 performs a real full Scryfall import.
         with patch.object(AdminResource, "setup_schema"), patch.object(AdminResource, "import_data"):
             api = APIResource(last_import_time=multiprocessing.Value("d", 0.0, lock=True))
-        api._conn_pool.close()
-        api._conn_pool = MagicMock()
+        stub_conn_pools(api)
         return api
 
     def test_calls_stream_data_for_key(self) -> None:

--- a/api/utils/db_utils.py
+++ b/api/utils/db_utils.py
@@ -83,6 +83,25 @@ def configure_connection(conn: psycopg.Connection) -> None:
     conn.row_factory = psycopg.rows.dict_row
 
 
+def set_statement_timeout(cursor: psycopg.Cursor, statement_timeout: int) -> None:
+    """Validate and set the statement timeout for a database cursor.
+
+    PostgreSQL SET commands don't support parameterized values, so we must
+    validate the value before using it in string interpolation.
+
+    Args:
+        cursor: Database cursor to execute the SET command on
+        statement_timeout: The statement timeout value in milliseconds
+
+    Raises:
+        ValueError: If statement_timeout is not a non-negative integer
+    """
+    if not isinstance(statement_timeout, int) or statement_timeout < 0:
+        msg = f"statement_timeout must be a non-negative integer, got: {statement_timeout}"
+        raise ValueError(msg)
+    cursor.execute(f"set statement_timeout = {statement_timeout}")
+
+
 def make_pool() -> psycopg_pool.ConnectionPool:
     """Create and return a psycopg3 ConnectionPool for PostgreSQL connections."""
     creds = get_pg_creds()

--- a/api/utils/page_rendering.py
+++ b/api/utils/page_rendering.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import hashlib
 import pathlib
 
+import falcon
 import minify_html
 from cachebox import LRUCache
 
@@ -39,6 +40,30 @@ _PRECONNECTS_HTML = (_FRAGMENTS_DIR / "preconnects.html").read_text()
 _FONTS_HTML = (_FRAGMENTS_DIR / "fonts.html").read_text()
 _CSS_HTML = (_FRAGMENTS_DIR / "css.html").read_text()
 _FOOTER_HTML = (_FRAGMENTS_DIR / "footer.html").read_text()
+
+
+def serve_static_file(*, filename: str, falcon_response: falcon.Response) -> None:
+    """Serve a static file to the Falcon response.
+
+    Args:
+    ----
+        filename (str): The file to serve.
+        falcon_response (falcon.Response): The Falcon response to write to.
+
+    """
+    full_filename = STATIC_DIR / filename
+    try:
+        with pathlib.Path(full_filename).open() as f:
+            falcon_response.text = f.read()
+    except FileNotFoundError:
+        falcon_response.status = falcon.HTTP_404
+        falcon_response.text = f"File not found: {filename}"
+    except PermissionError:
+        falcon_response.status = falcon.HTTP_403
+        falcon_response.text = f"Permission denied: {filename}"
+    except OSError as e:
+        falcon_response.status = falcon.HTTP_500
+        falcon_response.text = f"Error reading file {filename}: {e}"
 
 
 def _static_hash(filename: str) -> str | None:


### PR DESCRIPTION
## Summary

Follow-up to #794's review: shrinks the parent/child shared surface that PR documents (five methods, four handles) down to two methods and three handles, plus AdminResource getting its own injected connection pool.

- Inline the existence check in `import_card_by_name` instead of going through the parent's cached, EXPLAIN-capable `_run_query` for a plain lookup.
- Extract `_set_statement_timeout` to `db_utils` — it never touched `self`.
- Extract `_serve_static_file` to `page_rendering` — fully stateless, and `page_rendering` already owns `STATIC_DIR`.
- Give `AdminResource` its own `psycopg_pool.ConnectionPool` instead of reaching into the parent's.
- Have `APIResource.__init__` build both pools and inject the admin one into `AdminResource`'s constructor, instead of `AdminResource` calling `db_utils.make_pool()` itself — mirrors the existing injectable handles (`import_guard`, `last_import_time`, ...) and lets tests hand in a mock at construction time instead of opening a real pool just to close it.

What's left in the shared surface (`_reload_engine`, `_setup_complete`, `_cache_generation`, `_last_import_time`, `_setup_complete_cache`) is the genuinely irreducible part: `multiprocessing` primitives that are the actual cross-worker-process signal for "the corpus changed" / "check whether setup finished," not incidental references.

## Test plan

- [x] `make test-unit` equivalent (full suite minus the docker integration file): 2994 passed
- [x] `test_integration_testcontainers.py` (docker): 22 passed
- [x] Full suite together: 3016 passed
- [x] `ruff check` / `ruff format --check` on all changed files