### PR TITLE
Introduce AppContext, Remove AdminResource's Parent Reference

### DIFF
--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -9,20 +9,16 @@ public method became a route, and the only lever was a leading underscore, which
 method's Python visibility. Mounting a separate resource replaces that lever with a boundary, and
 keeps the honest names.
 
-The child holds a reference to its parent for the small surface they genuinely share — two methods
-(`_reload_engine`, `_setup_complete`) and three handles (`_cache_generation`, `_last_import_time`,
-`_setup_complete_cache`). All three of those handles are `multiprocessing` primitives: the actual
-mechanism by which one worker process tells every other worker "the corpus changed" or "check
-whether setup finished," not incidental references. That is deliberately not a decoupling: the
-boundary here is about routing, and pretending otherwise would mean an `AppContext` refactor that
-the routing fix does not need.
+`AdminResource` no longer holds a reference to `APIResource` at all. What it used to reach a parent
+for — `reload_engine`, `setup_complete`, `cache_generation`, `last_import_time`,
+`invalidate_setup_complete`, the connection pool — all live on the `AppContext` both resources take a
+reference to at construction (see `api/app_context.py`). Neither resource owns that state; both are
+peers that reach into a neutral shared object instead of into each other.
 
-The child keeps its own `_conn_pool` rather than sharing the parent's: nothing here needs the
-parent's query-result cache or EXPLAIN plumbing, only a connection, so a second pool removes that
-coupling for the price of a second `psycopg_pool.ConnectionPool` (and its own connections) per
-worker process. `APIResource.__init__` builds both pools and hands this one over at construction,
-rather than this module building its own — so a test can inject a mock in place of either without
-a real connection ever opening.
+`import_guard`/`schema_setup_event` are not part of `AppContext`: they're cross-worker-shared, but
+only *within* `AdminResource`'s own copies across processes (serialising concurrent import
+attempts) — nothing on the search side ever touches either one. They get their own small bundle,
+`AdminContext`, defined here since nothing outside this module needs it.
 """
 
 from __future__ import annotations
@@ -52,7 +48,7 @@ from api.scryfall_bulk_data_fetcher import BulkDataKey, ScryfallBulkDataFetcher
 from api.settings import settings
 from api.tag_import import import_art_tags as _import_art_tags
 from api.tag_import import import_oracle_tags as _import_oracle_tags
-from api.utils import db_utils
+from api.utils import db_utils, multiprocessing_utils
 from api.utils.caching import cached
 from api.utils.http_utils import make_user_agent
 from api.utils.page_rendering import serve_static_file
@@ -63,10 +59,9 @@ if TYPE_CHECKING:
     from multiprocessing.synchronize import Event as EventType
     from multiprocessing.synchronize import RLock as LockType
 
-    import psycopg_pool
     from psycopg import Connection
 
-    from api.api_resource import APIResource
+    from api.app_context import AppContext
 
 # Path prefix the child mounts under. Underscore-prefixed to match the convention API namespaces use
 # for internal routes (Elasticsearch _search, CouchDB _all_docs), and to stay clear of /admin, which
@@ -182,31 +177,44 @@ CARD_IS_TAGS = LAND_IS_TAGS + [  # noqa: RUF005
 ]
 
 
+class AdminContext:
+    """Cross-worker primitives private to AdminResource: not shared with any other resource."""
+
+    def __init__(
+        self,
+        *,
+        import_guard: LockType = multiprocessing_utils.DEFAULT_LOCK,
+        schema_setup_event: EventType = multiprocessing_utils.DEFAULT_EVENT,
+    ) -> None:
+        """Build the primitives, or accept ones a caller already built.
+
+        Args:
+            import_guard: Cross-process lock serialising imports.
+            schema_setup_event: Set once the schema has been created.
+        """
+        self.import_guard = import_guard
+        self.schema_setup_event = schema_setup_event
+
+
 class AdminResource:
     """Data-management routes, mounted behind a path prefix by APIResource."""
 
     def __init__(
         self,
-        parent: APIResource,
         *,
-        conn_pool: psycopg_pool.ConnectionPool,
-        import_guard: LockType,
-        schema_setup_event: EventType,
+        app_context: AppContext,
+        admin_context: AdminContext | None = None,
     ) -> None:
-        """Attach to the parent resource and take ownership of the admin-only handles.
+        """Take ownership of the admin-only handles.
 
         Args:
-            parent: The resource this is mounted on, for the shared methods and handles.
-            conn_pool: This resource's own connection pool -- built by the caller (mirroring the
-                parent's own `_conn_pool`), so a test can inject a mock without a real pool ever
-                opening a connection.
-            import_guard: Cross-process lock serialising imports.
-            schema_setup_event: Set once the schema has been created.
+            app_context: State and resources shared with the resource this is mounted on --
+                connection pools, the query engine, the cross-worker cache/import signals.
+            admin_context: Import-serialisation primitives private to this resource. Built fresh if
+                not given, matching every other handle here.
         """
-        self._parent = parent
-        self._conn_pool = conn_pool
-        self._import_guard = import_guard
-        self._schema_setup_event = schema_setup_event
+        self.app_context = app_context
+        self.admin_context = admin_context or AdminContext()
         self._session = requests.Session()
         self._session.headers.update({"User-Agent": make_user_agent()})
         self._bulk_data_fetcher = ScryfallBulkDataFetcher()
@@ -214,21 +222,21 @@ class AdminResource:
     @route()
     def setup_schema(self, *_: object, **__: object) -> None:
         """Set up the database schema and apply migrations as needed."""
-        if self._schema_setup_event.is_set():
+        if self.admin_context.schema_setup_event.is_set():
             logger.info("Schema already setup (fastpath) in pid %d", os.getpid())
             return
 
         filesystem_migrations = db_utils.get_migrations()
 
-        with self._import_guard:
-            if self._schema_setup_event.is_set():
+        with self.admin_context.import_guard:
+            if self.admin_context.schema_setup_event.is_set():
                 logger.info("Schema already setup (slowpath) in pid %d", os.getpid())
                 return
             logger.info("Setting up schema in pid %d", os.getpid())
             # read migrations from the db dir...
             # if any already applied migrations differ from what we want
             # to apply then drop everything
-            with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+            with self.app_context.writer_pool.connection() as conn, conn.cursor() as cursor:
                 cursor.execute(
                     """CREATE TABLE IF NOT EXISTS migrations (
                         file_name text not null,
@@ -271,15 +279,15 @@ class AdminResource:
                     )
                     conn.commit()
 
-            self._schema_setup_event.set()
+            self.admin_context.schema_setup_event.set()
             logger.info("Schema setup complete in pid %d", os.getpid())
 
     def _import_recent(self) -> bool:
         """Return True if a bulk import completed in the last 5 minutes (or setup is complete when no shared timestamp)."""
-        if self._parent._last_import_time is None:
-            return self._parent._setup_complete()
+        if self.app_context.last_import_time is None:
+            return self.app_context.setup_complete()
         # Unlocked read: c_double is atomic on typical platforms; avoids lock contention on fast path
-        t = self._parent._last_import_time.get_obj().value
+        t = self.app_context.last_import_time.get_obj().value
         if not t:
             logger.info("No import recorded...")
             return False
@@ -302,8 +310,8 @@ class AdminResource:
         after_transfer = time.monotonic()
 
         if result["status"] == "success":
-            if self._parent._last_import_time is not None:
-                self._parent._last_import_time.value = time.time()
+            if self.app_context.last_import_time is not None:
+                self.app_context.last_import_time.value = time.time()
             total_time = after_transfer - before
             cards_sent = result.get("cards_sent", result["cards_loaded"])
             rate = cards_sent / total_time if total_time > 0 else 0
@@ -319,14 +327,14 @@ class AdminResource:
             # running the backfill ahead of the tag import scored every card as on-style on a
             # first boot, and nothing rescored until the next import. Oracle tags feed search
             # rather than scoring, so their position relative to the backfill does not matter.
-            _import_art_tags(self._conn_pool, self._bulk_data_fetcher)
+            _import_art_tags(self.app_context.writer_pool, self._bulk_data_fetcher)
             self.backfill_prefer_scores()
             self.backfill_cubecobra_scores()
-            _import_oracle_tags(self._conn_pool, self._bulk_data_fetcher)
-            self._parent._reload_engine(force=True)
+            _import_oracle_tags(self.app_context.writer_pool, self._bulk_data_fetcher)
+            self.app_context.reload_engine(force=True)
             self._clear_caches()
-            self._parent._last_import_time.value = time.time()
-            self._parent._setup_complete_cache = None
+            self.app_context.last_import_time.value = time.time()
+            self.app_context.invalidate_setup_complete()
             # Every step above logs its own duration; this closes the sequence with the wall
             # clock the operator actually waited, upsert through engine reload.
             logger.info("Import complete in %.2f seconds", time.monotonic() - before)
@@ -350,11 +358,11 @@ class AdminResource:
 
         logger.info("Hitting slowpath in pid %d", os.getpid())
 
-        import_lock = self._parent._last_import_time.get_lock()
+        import_lock = self.app_context.last_import_time.get_lock()
 
         acquired = import_lock.acquire(timeout=IMPORT_LOCK_TIMEOUT)
         if not acquired:
-            if self._parent._setup_complete():
+            if self.app_context.setup_complete():
                 logger.info(
                     "Timed out waiting %.0fs for import lock; setup complete, skipping in pid %d",
                     IMPORT_LOCK_TIMEOUT,
@@ -405,7 +413,7 @@ class AdminResource:
         logger.info("Starting prefer score backfill")
 
         backfill_sql = db_utils.read_sql("backfill_prefer_scores")
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self.app_context.writer_pool.connection() as conn, conn.cursor() as cursor:
             db_utils.set_statement_timeout(cursor, settings.prefer_score_backfill_timeout_ms)
             cursor.execute(backfill_sql)
             updated_count = cursor.rowcount
@@ -500,7 +508,7 @@ class AdminResource:
             ]
         )
 
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self.app_context.writer_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 """
                 WITH incoming AS (
@@ -552,7 +560,7 @@ class AdminResource:
         logger.info("Starting CubeCobra score backfill with weights: %s", weights)
 
         backfill_sql = db_utils.read_sql("backfill_cubecobra_scores")
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self.app_context.writer_pool.connection() as conn, conn.cursor() as cursor:
             db_utils.set_statement_timeout(cursor, 600_000)
             cursor.execute(backfill_sql, weights)
             updated_count = cursor.rowcount
@@ -592,7 +600,7 @@ class AdminResource:
         """
         logger.info("Starting CubeCobra ingest")
         # fetch the distinct, non-null oracle ids that are in the db
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self.app_context.writer_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 "SELECT DISTINCT oracle_id FROM magic.cards WHERE oracle_id IS NOT NULL",
             )
@@ -678,7 +686,7 @@ class AdminResource:
         # Update cards in database with the new is: tag
         updated_count = 0
         new_tag = orjson.dumps({is_tag: True}).decode("utf-8")
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self.app_context.writer_pool.connection() as conn, conn.cursor() as cursor:
             # Use SQL update with jsonb concatenation to add the is: tag
             for card_name_batch in itertools.batched(sorted(card_names), 500):
                 cursor.execute(
@@ -760,7 +768,7 @@ class AdminResource:
         updated_count = 0
         new_tag = orjson.dumps({is_tag: True}).decode("utf-8")
         scryfall_ids = {p["id"] for p in printings}
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self.app_context.writer_pool.connection() as conn, conn.cursor() as cursor:
             # Use SQL update with jsonb concatenation to add the is: tag
             for scryfall_id_batch in itertools.batched(sorted(scryfall_ids), 500):
                 cursor.execute(
@@ -822,12 +830,12 @@ class AdminResource:
     @route()
     def import_oracle_tags(self, **_: object) -> dict[str, Any]:
         """Import oracle tags from Scryfall bulk data into oracle_tags, oracle_tag_relationships, and card_oracle_tags."""
-        return _import_oracle_tags(self._conn_pool, self._bulk_data_fetcher)
+        return _import_oracle_tags(self.app_context.writer_pool, self._bulk_data_fetcher)
 
     @route()
     def import_art_tags(self, **_: object) -> dict[str, Any]:
         """Import art tags from Scryfall bulk data into art_tags, art_tag_relationships, and card_art_tags."""
-        return _import_art_tags(self._conn_pool, self._bulk_data_fetcher)
+        return _import_art_tags(self.app_context.writer_pool, self._bulk_data_fetcher)
 
     @route()
     def import_all_is_tags(self, **_: object) -> dict[str, Any]:
@@ -936,7 +944,7 @@ class AdminResource:
         logger.info("Importing card by name: '%s'", card_name)
 
         # Check if card already exists in database for backward compatibility
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self.app_context.writer_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 "SELECT card_name FROM magic.cards WHERE card_name = %(card_name)s",
                 {"card_name": card_name},
@@ -1001,7 +1009,7 @@ class AdminResource:
         load_result = self._upsert_cards(cards)
 
         if load_result["status"] == "success":
-            self._parent._reload_engine(force=True)
+            self.app_context.reload_engine(force=True)
 
         # Add search_query to the result for consistency
         load_result["search_query"] = search_query
@@ -1109,7 +1117,7 @@ class AdminResource:
         self.setup_schema()
 
         try:
-            with self._conn_pool.connection() as conn:
+            with self.app_context.writer_pool.connection() as conn:
                 with conn.cursor() as cursor:
                     db_utils.set_statement_timeout(cursor, 30_000)
 
@@ -1183,5 +1191,4 @@ class AdminResource:
             }
 
     def _clear_caches(self) -> None:
-        with self._parent._cache_generation.get_lock():
-            self._parent._cache_generation.value += 1
+        self.app_context.bump_cache_generation()

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import copy
 import inspect
 import logging
-import multiprocessing
 import os
 import pathlib
 import threading
@@ -19,22 +18,20 @@ import time
 from collections.abc import Sequence  # noqa: TC003
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, NoReturn
-from typing import cast as typecast
 
 import falcon
 import orjson
 import psycopg
-import psycopg_pool
 from cachebox import LRUCache, TTLCache
-from psycopg import Connection
 
-from api.admin_resource import ADMIN_MOUNT_PREFIX, AdminResource
+from api.admin_resource import ADMIN_MOUNT_PREFIX, AdminContext, AdminResource
+from api.app_context import AppContext
 from api.enums import CardOrdering, PreferOrder, ResponseShape, SortDirection, UniqueOn
 from api.middlewares.timing import record_span
 from api.noscript_helpers import generate_results_count_html, generate_results_html
 from api.parsing import generate_sql_query, parse_scryfall_query
 from api.settings import settings
-from api.utils import db_utils, error_monitoring, multiprocessing_utils
+from api.utils import db_utils, error_monitoring
 from api.utils.css_utils import build_critical_css
 from api.utils.generation_cache import GenerationCache
 from api.utils.page_rendering import (
@@ -48,32 +45,14 @@ from api.utils.param_binding import ParamCoercionError
 from api.utils.routing import build_route_table, build_routes_listing, route
 from api.utils.site_name import hostname_to_site_name
 from api.utils.timer import Timer
-from card_engine import ENGINE_COLUMNS as _ENGINE_COLUMNS_FROM_MODULE
-from card_engine import QueryEngine as _QueryEngine
 from card_engine import QueryError as _QueryError
 
 if TYPE_CHECKING:
-    from multiprocessing.sharedctypes import Synchronized
-    from multiprocessing.synchronize import Event as EventType
-    from multiprocessing.synchronize import RLock as LockType
-
     from api.parsing.nodes import Query
     from api.utils.routing import BoundRoute
 
 
 logger = logging.getLogger(__name__)
-
-
-def _rss_mb() -> str:
-    """Return current RSS in MB as a string, or 'unknown' if /proc is unavailable."""
-    try:
-        with pathlib.Path("/proc/self/status").open() as f:
-            for line in f:
-                if line.startswith("VmRSS:"):
-                    return f"{int(line.split()[1]) // 1024} MB"
-    except OSError:
-        pass
-    return "unknown"
 
 
 # Postgres prefixes every 2201B message with this, e.g. "invalid regular expression: brackets []
@@ -116,13 +95,6 @@ DISALLOWED_QUERY_ARGS: frozenset[str] = frozenset(["falcon_response", "request_h
 # to the log and the error monitor, which are not attacker-readable; the client gets this and nothing
 # more. Callers must not append exception detail to it.
 INTERNAL_ERROR_DESCRIPTION = "An internal error occurred."
-
-MIN_IMPORT_CARDS = 90_000
-# Rows per batch streamed into the engine during a reload. The reload's memory
-# floor is the Rust-side build (~305 MB), so the batch only needs to be small
-# relative to that: ~2k rows ≈ 18 MB of dicts. Smaller adds round trips for no
-# measurable gain (see docs/issues/00505-engine-incremental-loading.md).
-_ENGINE_RELOAD_BATCH_SIZE = 2_000
 
 # Public field name -> magic.cards column. The `fields=` vocabulary for /search. This is
 # deliberately a subset of FIELD_TABLE in card_engine/src/lib.rs, not a mirror of it — not
@@ -247,65 +219,45 @@ def _columnarize_cards(cards: list[dict[str, Any]]) -> dict[str, list[Any]]:
 class APIResource:
     """Class implementing request handling for our simple API."""
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         *,
-        import_guard: LockType = multiprocessing_utils.DEFAULT_LOCK,
-        last_import_time: Synchronized | None = None,
-        schema_setup_event: EventType = multiprocessing_utils.DEFAULT_EVENT,
-        cache_generation: Synchronized | None = None,
-        engine_reload_guard: LockType | None = None,
-        conn_pool: psycopg_pool.ConnectionPool | None = None,
-        admin_conn_pool: psycopg_pool.ConnectionPool | None = None,
+        app_context: AppContext | None = None,
+        admin_context: AdminContext | None = None,
     ) -> None:
         """Initialize an APIResource object, set up connection pool and action map.
 
         Sets up the database connection pool and action mapping for the API.
 
         Args:
-            import_guard: Cross-process lock serialising imports.
-            last_import_time: Shared timestamp of the last completed import.
-            schema_setup_event: Set once the schema has been created.
-            cache_generation: Shared counter bumped to invalidate the query-result cache.
-            engine_reload_guard: Cross-process lock serialising engine reloads.
-            conn_pool: This resource's own connection pool. Built via `db_utils.make_pool()` if not
+            app_context: State and resources shared with the mounted AdminResource (connection
+                pools, the query engine, the cross-worker cache/import signals). Built fresh if not
                 given, matching every other handle here -- a caller (a test, mainly) can inject one
                 without a real pool ever opening a connection.
-            admin_conn_pool: The connection pool handed to the mounted AdminResource. Built the same
-                way if not given; kept separate from `conn_pool` so a test can inject the two
-                independently.
+            admin_context: Forwarded to the mounted AdminResource untouched; APIResource has no use
+                for its contents (import-serialisation primitives) and doesn't default it -- that's
+                AdminResource's own job, same as `app_context`.
         """
         self._critical_css: str = build_critical_css(STATIC_DIR / "styles.css")
-        self._conn_pool: psycopg_pool.ConnectionPool = conn_pool or db_utils.make_pool()
+        self.app_context = app_context or AppContext()
         # Build the route table from methods marked with @route, scanning the class rather than this
         # instance so nothing assigned below can become a route. Each entry carries everything
         # dispatch needs — the wrapped handler, how many positional path segments it absorbs, and
         # what it declared — computed once here rather than per-request in _handle.
         self.routes = build_route_table(self)
 
-        self._cache_generation: Synchronized = cache_generation or multiprocessing.Value("i", 0)
         self._query_cache: GenerationCache = GenerationCache(
             factory=lambda: LRUCache(maxsize=1_000 if settings.enable_cache else 1),
-            generation=self._cache_generation,
+            generation=self.app_context.cache_generation,
         )
         self._search_gen_cache: LRUCache = LRUCache(maxsize=1)  # generation → TTLCache
-        self._last_import_time: Synchronized = last_import_time or multiprocessing.Value("d", 0.0, lock=True)
-        self._engine = _QueryEngine()
         self._engine_reload_lock = threading.Lock()
-        # Cross-worker guard: the full-table fetch in _reload_engine is memory-hungry,
-        # so only one worker process should run it at a time (see _reload_engine).
-        self._engine_reload_guard: LockType = engine_reload_guard or multiprocessing.Lock()
-        logger.info("Worker with pid %d has conn pool %s", os.getpid(), self._conn_pool)
+        logger.info("Worker with pid %d has conn pool %s", os.getpid(), self.app_context.reader_pool)
 
         # Mounted after the parent's own state exists, since the child reaches back for the handles
         # they share. advertise=False is set here rather than on each handler: forgetting it is then
         # a property of this one call, not a hole in one route.
-        self.admin = AdminResource(
-            self,
-            conn_pool=admin_conn_pool or db_utils.make_pool(),
-            import_guard=import_guard,
-            schema_setup_event=schema_setup_event,
-        )
+        self.admin = AdminResource(app_context=self.app_context, admin_context=admin_context)
         self.routes.update(build_route_table(self.admin, prefix=ADMIN_MOUNT_PREFIX, advertise=False))
         self._not_found_routes = build_routes_listing(self.routes)
 
@@ -478,7 +430,7 @@ class APIResource:
         root_timing_key = "root_timing_key"
         timer = Timer()
         result: dict[str, Any] = {}
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             # Validate and set statement timeout
             db_utils.set_statement_timeout(cursor, statement_timeout)
             if explain:
@@ -510,54 +462,9 @@ class APIResource:
         set_no_store_header(falcon_response)
         return os.getpid()
 
-    _SETUP_COMPLETE_TTL = 60 * 60  # 1 hour; also invalidated when _last_import_time changes
-    _setup_complete_cache: tuple[bool, float, float] | None = None  # (result, expires_at, import_time)
-
-    def _setup_complete(self) -> bool:
-        """Return True if the setup is complete."""
-        now = time.monotonic()
-        current_import_time = self._last_import_time.get_obj().value
-        if self._setup_complete_cache is not None:
-            result, expires_at, cached_import_time = self._setup_complete_cache
-            if now < expires_at and current_import_time == cached_import_time:
-                logger.debug(
-                    "_setup_complete cache hit: result=%s, expires in %.0fs, pid %d",
-                    result,
-                    expires_at - now,
-                    os.getpid(),
-                )
-                return result
-        try:
-            with self._conn_pool.connection() as conn:
-                conn = typecast("Connection", conn)
-                with conn.cursor() as cursor:
-                    cursor.execute("SELECT COUNT(1) AS num_cards FROM magic.cards")
-                    cards_found = cursor.fetchall()[0]["num_cards"]
-                    result = cards_found > MIN_IMPORT_CARDS
-                    if result:
-                        logger.info("Found %d cards in pid %d", cards_found, os.getpid())
-                    else:
-                        logger.warning(
-                            "Setup not complete: found %d cards, need more than %d (pid %d)",
-                            cards_found,
-                            MIN_IMPORT_CARDS,
-                            os.getpid(),
-                        )
-        except Exception as oops:
-            logger.error(
-                "Error checking if setup is complete (pid %d): %s: %s",
-                os.getpid(),
-                type(oops).__name__,
-                oops,
-                exc_info=True,
-            )
-            result = False
-        self._setup_complete_cache = (result, now + self._SETUP_COMPLETE_TTL, current_import_time)
-        return result
-
     def _require_setup_complete(self) -> None:
         """Require that setup is complete or raise a ServiceUnavailable error."""
-        if not self._setup_complete():
+        if not self.app_context.setup_complete():
             logger.warning("Rejecting request in pid %d: setup is not complete", os.getpid())
             raise falcon.HTTPServiceUnavailable(
                 title="Service Unavailable",
@@ -565,76 +472,17 @@ class APIResource:
             ) from None
 
     def _trigger_background_reload_if_needed(self) -> None:
-        if self._engine.size() == 0 and self._engine_reload_lock.acquire(blocking=False):
+        if self.app_context.engine.size() == 0 and self._engine_reload_lock.acquire(blocking=False):
 
             def _bg_reload() -> None:
                 try:
-                    self._reload_engine()
+                    self.app_context.reload_engine()
                 except Exception as e:
                     logger.error("Background engine reload failed: %s", e, exc_info=True)
                 finally:
                     self._engine_reload_lock.release()
 
             threading.Thread(target=_bg_reload, daemon=True).start()
-
-    def _reload_engine(self, *, force: bool = False) -> None:
-        """Stream all cards from the DB into the Rust engine's card store in batches.
-
-        A server-side cursor feeds the engine's staged reload API
-        (reload_begin / add_batch / reload_commit) one batch at a time, so the
-        Python-side transient is one batch of row dicts (~18 MB at 2k rows)
-        instead of the whole corpus (~840 MB) — measurements in
-        docs/issues/00505-engine-incremental-loading.md. The reload is guarded by a
-        cross-worker lock so only one worker pays the build cost at a time.
-        With force=False (cold-start warming), losers of the race return
-        immediately and pick up the winner's archive via the engine's
-        inode-based remap. With force=True (data just changed), callers wait
-        their turn but skip the rebuild if another worker refreshed the store
-        while they were waiting.
-
-        Args:
-            force: If False, skip entirely when another worker holds the lock or the
-                store is already populated. If True, wait for the lock and always
-                reload (the data just changed, so the archive must be rebuilt).
-        """
-        if not settings.enable_engine:
-            logger.debug("Engine reload skipped: feature-gated off (ENABLE_ENGINE)")
-            return
-        if self._engine is None:
-            return
-        logger.info("Engine reload requested (force=%s, pid=%d, rss=%s)", force, os.getpid(), _rss_mb())
-        if not self._engine_reload_guard.acquire(block=force):
-            logger.info("Engine reload already in progress in another worker, skipping (pid=%d)", os.getpid())
-            return
-        try:
-            if not force and self._engine.size() > 0:
-                # Another worker populated the store while we raced for the lock.
-                return
-            logger.info("Engine reload starting (force=%s, pid=%d, rss=%s)", force, os.getpid(), _rss_mb())
-            cols_sql = ", ".join(f"card.{col}" for col in _ENGINE_COLUMNS_FROM_MODULE)
-            try:
-                with self._conn_pool.connection() as conn:
-                    # Named cursor => server-side: psycopg buffers one batch, not the full result.
-                    with conn.cursor(name="engine_reload") as cursor:
-                        cursor.itersize = _ENGINE_RELOAD_BATCH_SIZE
-                        cursor.execute(f"SELECT {cols_sql} FROM magic.cards AS card")
-                        if not self._engine.reload_begin():
-                            # Another process published a fresh archive while we
-                            # waited for the engine's write lock; it was remapped.
-                            return
-                        try:
-                            while batch := cursor.fetchmany(_ENGINE_RELOAD_BATCH_SIZE):
-                                self._engine.add_batch(batch)
-                            self._engine.reload_commit()
-                        except BaseException:
-                            self._engine.reload_abort()
-                            raise
-            except psycopg_pool.PoolClosed:
-                logger.debug("Connection pool closed during engine reload, skipping (pid=%d)", os.getpid())
-                return
-            logger.info("Engine reloaded with %d cards (pid=%d, rss=%s)", self._engine.size(), os.getpid(), _rss_mb())
-        finally:
-            self._engine_reload_guard.release()
 
     def _resolve_result_fields(self, fields: Sequence[str] | None) -> list[str]:
         """Validate a `fields=` request against RESULT_FIELD_COLUMNS, deduping repeats.
@@ -764,7 +612,7 @@ class APIResource:
 
         if settings.enable_cache:
             cache_key = (direction, limit, offset, orderby, prefer, query, unique, tuple(resolved_fields))
-            gen = self._cache_generation.value
+            gen = self.app_context.cache_generation.value
             try:
                 search_cache = self._search_gen_cache[gen]
             except KeyError:
@@ -785,7 +633,7 @@ class APIResource:
 
         if not settings.enable_engine:
             pass  # feature-gated off: SQL serves everything, the store never loads
-        elif self._engine.size() == 0:
+        elif self.app_context.engine.size() == 0:
             logger.info("Engine store empty, using SQL path for query=%r", query)
             self._trigger_background_reload_if_needed()
         else:
@@ -803,7 +651,7 @@ class APIResource:
                     fields=resolved_fields,
                 )
             except BaseException as e:
-                # BaseException, not Exception: a Rust panic anywhere under `self._engine.query`
+                # BaseException, not Exception: a Rust panic anywhere under `self.app_context.engine.query`
                 # surfaces as pyo3's `PanicException`, which derives from BaseException and so went
                 # straight past this handler — the one whose entire job is to let an engine failure
                 # degrade to the SQL path instead of failing the request. Falcon's own error handling
@@ -879,7 +727,7 @@ class APIResource:
         query_explanation = parsed_query.to_human_explanation() if query else ""
         try:
             with timer("engine_query"):
-                total_cards, cards = self._engine.query(
+                total_cards, cards = self.app_context.engine.query(
                     filters=parsed_query,
                     unique=str(unique),
                     prefer=str(prefer),
@@ -1335,18 +1183,18 @@ class APIResource:
         **_: object,
     ) -> dict[str, dict[str, int]]:
         """Get type and keyword frequency catalogs from the engine."""
-        if self._engine.size() == 0:
+        if self.app_context.engine.size() == 0:
             raise falcon.HTTPServiceUnavailable(
                 title="Service Unavailable",
                 description="Engine is not loaded, please try again later.",
             ) from None
         set_cache_header(falcon_response, duration=timedelta(hours=1))
-        type_counts: dict[str, int] = self._engine.common_card_types()
+        type_counts: dict[str, int] = self.app_context.engine.common_card_types()
         # tribal is the old name for kindred
         kindred_count = type_counts.get("Kindred", 0)
         if kindred_count:
             type_counts["Tribal"] = kindred_count
-        keyword_counts: dict[str, int] = self._engine.common_card_keywords()
+        keyword_counts: dict[str, int] = self.app_context.engine.common_card_keywords()
         keyword_catalog = {keyword.lower(): count for keyword, count in keyword_counts.items()}
         # Sorted keys compress ~5% smaller (adjacent keys share prefixes, so the
         # compressor's back-references stay short) and make the payload deterministic.
@@ -1387,11 +1235,11 @@ class APIResource:
         """
         set_no_store_header(falcon_response)
         num_cards = min(max(num_cards, 1), 1000)
-        if self._engine.size() == 0:
+        if self.app_context.engine.size() == 0:
             self._trigger_background_reload_if_needed()
             cards = []
         else:
-            cards = list(self._engine.sample_preferred(num_cards))
+            cards = list(self.app_context.engine.sample_preferred(num_cards))
         total_cards = len(cards)
         if shape == ResponseShape.COLUMNAR:
             cards = _columnarize_cards(cards)

--- a/api/api_worker.py
+++ b/api/api_worker.py
@@ -99,7 +99,9 @@ class ApiWorker(multiprocessing.Process):
             falcon.App: The configured Falcon application instance.
         """
         # Importing here (post-fork) is safer for some servers/clients than importing before forking.
+        from api.admin_resource import AdminContext  # pylint: disable=import-outside-toplevel
         from api.api_resource import APIResource  # pylint: disable=import-outside-toplevel
+        from api.app_context import AppContext  # pylint: disable=import-outside-toplevel
         from api.middlewares import (
             CachingMiddleware,
             CompressionMiddleware,
@@ -131,13 +133,16 @@ class ApiWorker(multiprocessing.Process):
             ],
         )
         api.set_error_serializer(json_error_serializer)  # Use custom JSON error serializer
-        sink = APIResource(
+        # Built here, post-fork: reader/writer pools and the query engine can't cross a fork the
+        # way a multiprocessing.Value/Lock can, so each worker builds its own AppContext from the
+        # primitives the master created before forking.
+        app_context = AppContext(
             cache_generation=cache_generation,
             engine_reload_guard=engine_reload_guard,
-            import_guard=import_guard,
             last_import_time=last_import_time,
-            schema_setup_event=schema_setup_event,
-        )  # Create the main API resource
+        )
+        admin_context = AdminContext(import_guard=import_guard, schema_setup_event=schema_setup_event)
+        sink = APIResource(app_context=app_context, admin_context=admin_context)  # Create the main API resource
         api.add_sink(sink._handle, prefix="/")  # Route all requests to the sink handler
 
         json_handler = falcon.media.JSONHandler(

--- a/api/app_context.py
+++ b/api/app_context.py
@@ -1,0 +1,221 @@
+"""The state and resources shared between peer resources (APIResource, AdminResource, ...).
+
+None of this is owned by any one resource: `reader_pool` and `engine` are read by every
+search-shaped resource, `writer_pool` is used by every resource that imports or backfills data, and
+`cache_generation`/`last_import_time` are the cross-worker-process signal that ties writers to
+readers ("the corpus changed," "check whether setup finished"). A resource that needs one of these
+takes an `AppContext` rather than reaching into a sibling resource for it.
+
+`AppContext` itself is a per-process object: `reader_pool`/`writer_pool`/`engine` are built fresh
+inside whichever worker process constructs it (sockets and the Rust engine's in-memory store can't
+cross a fork the way a `multiprocessing.Value` can), while `cache_generation`/`last_import_time`/
+`engine_reload_guard` are expected to be created once in the master process, before forking, and
+handed to every worker's `AppContext` unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import multiprocessing
+import os
+import pathlib
+import time
+from typing import TYPE_CHECKING
+
+import psycopg_pool
+
+from api.settings import settings
+from api.utils import db_utils
+from card_engine import ENGINE_COLUMNS as _ENGINE_COLUMNS
+from card_engine import QueryEngine as _QueryEngine
+
+if TYPE_CHECKING:
+    from multiprocessing.sharedctypes import Synchronized
+    from multiprocessing.synchronize import Lock as LockType
+
+    from card_engine import QueryEngine
+
+logger = logging.getLogger(__name__)
+
+# A corpus below this size means the import never finished (or hasn't started), not that it's
+# legitimately small -- see `AppContext.setup_complete`.
+MIN_IMPORT_CARDS = 90_000
+
+# How long a `setup_complete` result is trusted before re-checking the database, once the shared
+# last_import_time hasn't changed in the meantime -- see `AppContext.setup_complete`.
+_SETUP_COMPLETE_TTL = 60 * 60  # 1 hour
+
+# Rows per batch streamed into the engine during a reload. The reload's memory floor is the
+# Rust-side build (~305 MB), so the batch only needs to be small relative to that: ~2k rows ≈ 18 MB
+# of dicts. Smaller adds round trips for no measurable gain (see
+# docs/issues/00505-engine-incremental-loading.md).
+_ENGINE_RELOAD_BATCH_SIZE = 2_000
+
+
+def _rss_mb() -> str:
+    """Return current RSS in MB as a string, or 'unknown' if /proc is unavailable."""
+    try:
+        with pathlib.Path("/proc/self/status").open() as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    return f"{int(line.split()[1]) // 1024} MB"
+    except OSError:
+        pass
+    return "unknown"
+
+
+class AppContext:
+    """Cross-cutting state and resources shared by every resource mounted on the app."""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        reader_pool: psycopg_pool.ConnectionPool | None = None,
+        writer_pool: psycopg_pool.ConnectionPool | None = None,
+        engine: QueryEngine | None = None,
+        engine_reload_guard: LockType | None = None,
+        cache_generation: Synchronized | None = None,
+        last_import_time: Synchronized | None = None,
+    ) -> None:
+        """Build the per-worker resources, or accept ones a caller already built.
+
+        Args:
+            reader_pool: Connection pool for search-shaped resources. Built via
+                `db_utils.make_pool()` if not given, matching every other handle here -- a caller
+                (a test, mainly) can inject one without a real pool ever opening a connection.
+            writer_pool: Connection pool for resources that import or backfill data. Built the same
+                way if not given; kept separate from `reader_pool` so a slow bulk write can't
+                starve a live search request for a connection.
+            engine: The in-process query engine both search-shaped resources read from.
+            engine_reload_guard: Cross-process lock serialising engine reloads, so only one worker
+                pays the reload cost at a time.
+            cache_generation: Shared counter bumped to invalidate every worker's query-result cache.
+            last_import_time: Shared timestamp of the last completed import.
+        """
+        self.reader_pool: psycopg_pool.ConnectionPool = reader_pool or db_utils.make_pool()
+        self.writer_pool: psycopg_pool.ConnectionPool = writer_pool or db_utils.make_pool()
+        self.engine: QueryEngine = engine if engine is not None else _QueryEngine()
+        self.engine_reload_guard: LockType = engine_reload_guard or multiprocessing.Lock()
+        self.cache_generation: Synchronized = cache_generation or multiprocessing.Value("i", 0)
+        self.last_import_time: Synchronized = last_import_time or multiprocessing.Value("d", 0.0, lock=True)
+        # Per-process only -- a local TTL cache keyed off the shared last_import_time, not itself a
+        # cross-worker signal (a fresh worker starts with no cached opinion and checks for real).
+        self._setup_complete_cache: tuple[bool, float, float] | None = None
+
+    def setup_complete(self) -> bool:
+        """Return True if the setup is complete."""
+        now = time.monotonic()
+        current_import_time = self.last_import_time.get_obj().value
+        if self._setup_complete_cache is not None:
+            result, expires_at, cached_import_time = self._setup_complete_cache
+            if now < expires_at and current_import_time == cached_import_time:
+                logger.debug(
+                    "setup_complete cache hit: result=%s, expires in %.0fs, pid %d",
+                    result,
+                    expires_at - now,
+                    os.getpid(),
+                )
+                return result
+        try:
+            with self.reader_pool.connection() as conn, conn.cursor() as cursor:
+                cursor.execute("SELECT COUNT(1) AS num_cards FROM magic.cards")
+                cards_found = cursor.fetchall()[0]["num_cards"]
+                result = cards_found > MIN_IMPORT_CARDS
+                if result:
+                    logger.info("Found %d cards in pid %d", cards_found, os.getpid())
+                else:
+                    logger.warning(
+                        "Setup not complete: found %d cards, need more than %d (pid %d)",
+                        cards_found,
+                        MIN_IMPORT_CARDS,
+                        os.getpid(),
+                    )
+        except Exception as oops:
+            logger.error(
+                "Error checking if setup is complete (pid %d): %s: %s",
+                os.getpid(),
+                type(oops).__name__,
+                oops,
+                exc_info=True,
+            )
+            result = False
+        self._setup_complete_cache = (result, now + _SETUP_COMPLETE_TTL, current_import_time)
+        return result
+
+    def invalidate_setup_complete(self) -> None:
+        """Force the next `setup_complete()` call to re-check the database.
+
+        Called after a write that could change the answer (an import completing), rather than
+        waiting for the TTL to expire.
+        """
+        self._setup_complete_cache = None
+
+    def bump_cache_generation(self) -> None:
+        """Invalidate every worker's query-result cache. Call after any write to magic.cards."""
+        with self.cache_generation.get_lock():
+            self.cache_generation.value += 1
+
+    def reload_engine(self, *, force: bool = False) -> None:
+        """Stream all cards from the DB into the Rust engine's card store in batches.
+
+        A server-side cursor feeds the engine's staged reload API
+        (reload_begin / add_batch / reload_commit) one batch at a time, so the
+        Python-side transient is one batch of row dicts (~18 MB at 2k rows)
+        instead of the whole corpus (~840 MB) — measurements in
+        docs/issues/00505-engine-incremental-loading.md. The reload is guarded by a
+        cross-worker lock so only one worker pays the build cost at a time.
+        With force=False (cold-start warming), losers of the race return
+        immediately and pick up the winner's archive via the engine's
+        inode-based remap. With force=True (data just changed), callers wait
+        their turn but skip the rebuild if another worker refreshed the store
+        while they were waiting.
+
+        Reads via `writer_pool`, not `reader_pool`: this is a single giant SELECT (the whole
+        corpus) triggered by a write completing, and the cross-process guard means only one worker
+        ever runs it at a time -- but that one in-flight reload can run for minutes, and for that
+        whole window a connection borrowed from the reader pool is a connection live search traffic
+        doesn't have.
+
+        Args:
+            force: If False, skip entirely when another worker holds the lock or the
+                store is already populated. If True, wait for the lock and always
+                reload (the data just changed, so the archive must be rebuilt).
+        """
+        if not settings.enable_engine:
+            logger.debug("Engine reload skipped: feature-gated off (ENABLE_ENGINE)")
+            return
+        if self.engine is None:
+            return
+        logger.info("Engine reload requested (force=%s, pid=%d, rss=%s)", force, os.getpid(), _rss_mb())
+        if not self.engine_reload_guard.acquire(block=force):
+            logger.info("Engine reload already in progress in another worker, skipping (pid=%d)", os.getpid())
+            return
+        try:
+            if not force and self.engine.size() > 0:
+                # Another worker populated the store while we raced for the lock.
+                return
+            logger.info("Engine reload starting (force=%s, pid=%d, rss=%s)", force, os.getpid(), _rss_mb())
+            cols_sql = ", ".join(f"card.{col}" for col in _ENGINE_COLUMNS)
+            try:
+                with self.writer_pool.connection() as conn:
+                    # Named cursor => server-side: psycopg buffers one batch, not the full result.
+                    with conn.cursor(name="engine_reload") as cursor:
+                        cursor.itersize = _ENGINE_RELOAD_BATCH_SIZE
+                        cursor.execute(f"SELECT {cols_sql} FROM magic.cards AS card")
+                        if not self.engine.reload_begin():
+                            # Another process published a fresh archive while we
+                            # waited for the engine's write lock; it was remapped.
+                            return
+                        try:
+                            while batch := cursor.fetchmany(_ENGINE_RELOAD_BATCH_SIZE):
+                                self.engine.add_batch(batch)
+                            self.engine.reload_commit()
+                        except BaseException:
+                            self.engine.reload_abort()
+                            raise
+            except psycopg_pool.PoolClosed:
+                logger.debug("Connection pool closed during engine reload, skipping (pid=%d)", os.getpid())
+                return
+            logger.info("Engine reloaded with %d cards (pid=%d, rss=%s)", self.engine.size(), os.getpid(), _rss_mb())
+        finally:
+            self.engine_reload_guard.release()

--- a/api/app_context.py
+++ b/api/app_context.py
@@ -172,9 +172,14 @@ class AppContext:
 
         Reads via `writer_pool`, not `reader_pool`: this is a single giant SELECT (the whole
         corpus) triggered by a write completing, and the cross-process guard means only one worker
-        ever runs it at a time -- but that one in-flight reload can run for minutes, and for that
-        whole window a connection borrowed from the reader pool is a connection live search traffic
-        doesn't have.
+        ever runs it at a time. Measured 2026-08-21 against a ~98k-card corpus: ~3 seconds
+        end-to-end, not the "minutes" an earlier version of this docstring assumed -- so this isn't
+        a high-stakes call. It's also lower-stakes than a naive pool split suggests either way: the
+        in-process engine serves the large majority of search traffic directly, with no pool
+        involved at all, so reader_pool contention during those ~3 seconds would only ever touch the
+        minority of requests that fall back to SQL. Kept on `writer_pool` anyway on the same
+        reasoning as the pool split itself (a write-triggered bulk operation belongs with other
+        writes, not with reads), just without claiming a bigger effect than the numbers support.
 
         Args:
             force: If False, skip entirely when another worker holds the lock or the

--- a/api/settings.py
+++ b/api/settings.py
@@ -85,7 +85,7 @@ class Settings:
         """Check if the Rust card filter engine serves searches.
 
         Enabled by default. When disabled, the engine is fully inert: _search
-        routes every query to SQL and _reload_engine never runs. Disable via
+        routes every query to SQL and AppContext.reload_engine never runs. Disable via
         ENABLE_ENGINE=false for environments where the full-table fetch cost is
         unacceptable (e.g. low-memory dev machines).
         """

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -8,7 +8,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from api.admin_resource import AdminContext
 from api.api_resource import APIResource
+from api.app_context import AppContext
 from api.settings import settings
 from api.tests.support import override_attr
 
@@ -30,7 +32,8 @@ def stub_api_resource_fixture() -> Generator[APIResource]:
     """A fresh APIResource per test, readiness stubbed, both connection pools closed afterward.
 
     Function-scoped on purpose: it replaces per-class `setup_method` construction, and tests using it
-    mutate the instance (`_engine`, feature gates), so sharing one across a module would couple them.
+    mutate the instance (`app_context.engine`, feature gates), so sharing one across a module would
+    couple them.
 
     Two things it deliberately does *not* do:
 
@@ -42,11 +45,11 @@ def stub_api_resource_fixture() -> Generator[APIResource]:
     - It does not set up a schema or touch the database. Tests needing that want the `api_resource`
       fixture below instead.
     """
-    api = APIResource(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
-    override_attr(api, "_setup_complete", lambda: True)
+    api = APIResource(app_context=AppContext(last_import_time=multiprocessing.Value("d", time.time(), lock=True)))
+    override_attr(api.app_context, "setup_complete", lambda: True)
     yield api
-    api._conn_pool.close()
-    api.admin._conn_pool.close()
+    api.app_context.reader_pool.close()
+    api.app_context.writer_pool.close()
 
 
 @pytest.fixture(scope="module")
@@ -58,12 +61,12 @@ def api_resource(postgres_container: None) -> Generator[APIResource]:
     rows they created themselves (unique card names / oracle_ids), never about global counts.
     """
     api = APIResource(
-        last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-        schema_setup_event=multiprocessing.Event(),
+        app_context=AppContext(last_import_time=multiprocessing.Value("d", time.time(), lock=True)),
+        admin_context=AdminContext(schema_setup_event=multiprocessing.Event()),
     )
-    override_attr(api, "_setup_complete", lambda: True)
+    override_attr(api.app_context, "setup_complete", lambda: True)
     override_attr(api.admin, "_import_recent", lambda: True)
     api.admin.setup_schema()
     yield api
-    api._conn_pool.close()
-    api.admin._conn_pool.close()
+    api.app_context.reader_pool.close()
+    api.app_context.writer_pool.close()

--- a/api/tests/support.py
+++ b/api/tests/support.py
@@ -2,24 +2,40 @@
 
 from __future__ import annotations
 
+import multiprocessing
+import time
 from unittest.mock import MagicMock
 
+from api.app_context import AppContext
 
-def mock_conn_pool_kwargs() -> tuple[MagicMock, dict[str, MagicMock]]:
-    """A mock pool plus the APIResource(...) kwargs that inject it as both `_conn_pool`s.
 
-    APIResource.__init__ takes `conn_pool` and `admin_conn_pool` precisely so a test can hand it a
-    mock at construction time; passed the return value here as `**kwargs`, no real
-    psycopg_pool.ConnectionPool is ever opened, so there is nothing to close afterward. One mock
-    covers both attributes, matching how a single `_conn_pool` mock covered every code path before
-    AdminResource had its own pool.
+def mock_app_context(**overrides: object) -> AppContext:
+    """An AppContext with mock pools/engine, for injecting into APIResource(app_context=...).
+
+    No real `psycopg_pool.ConnectionPool` is ever opened, so there is nothing to close afterward.
+    `reader_pool`/`writer_pool` default to one shared `MagicMock()`, matching how a single
+    `_conn_pool` mock covered every code path before AdminResource had its own pool. `last_import_time`
+    defaults to now rather than `AppContext`'s own "nothing imported yet" default: `APIResource.__init__`
+    calls `self.admin.import_data()`, and a stale `last_import_time` would make its fast path
+    (`_import_recent`) miss and kick off a real Scryfall import during construction. Pass an
+    explicit `reader_pool=`/`writer_pool=`/`last_import_time=` (or anything else `AppContext` takes)
+    to override just that field.
+
+    Args:
+        **overrides: Any `AppContext.__init__` keyword to set explicitly instead of defaulting.
 
     Returns:
-        The mock, and a `{"conn_pool": ..., "admin_conn_pool": ...}` dict to spread into the
-        APIResource(...) call.
+        A ready `AppContext`.
     """
     mock_pool = MagicMock()
-    return mock_pool, {"conn_pool": mock_pool, "admin_conn_pool": mock_pool}
+    kwargs: dict[str, object] = {
+        "reader_pool": mock_pool,
+        "writer_pool": mock_pool,
+        "engine": MagicMock(),
+        "last_import_time": multiprocessing.Value("d", time.time(), lock=True),
+    }
+    kwargs.update(overrides)
+    return AppContext(**kwargs)
 
 
 def override_attr(obj: object, name: str, value: object) -> None:

--- a/api/tests/test_admin_mount.py
+++ b/api/tests/test_admin_mount.py
@@ -16,6 +16,7 @@ import pytest
 
 from api.admin_resource import ADMIN_MOUNT_PREFIX, AdminResource
 from api.api_resource import APIResource
+from api.app_context import AppContext
 
 # The complete public surface, as a literal. A route appearing or disappearing here is a deliberate
 # act, and this is the guard that makes it one — the failure this whole change exists to prevent was
@@ -61,15 +62,17 @@ EXPECTED_ADMIN_ROUTES = {
 def resource_fixture() -> APIResource:
     """An APIResource with its child mounted, against distinct mocked pools.
 
-    conn_pool and admin_conn_pool are injected separately (rather than left to default) so the
-    parent's and the child's pools are distinct objects, matching that AdminResource now opens its
-    own pool instead of sharing the parent's.
+    reader_pool and writer_pool are injected separately (rather than left to default) so the two
+    are distinct objects, matching that AdminResource reads/writes via its own pool rather than
+    the one search-shaped resources use.
     """
-    return APIResource(
+    app_context = AppContext(
+        reader_pool=MagicMock(),
+        writer_pool=MagicMock(),
+        engine=MagicMock(),
         last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-        conn_pool=MagicMock(),
-        admin_conn_pool=MagicMock(),
     )
+    return APIResource(app_context=app_context)
 
 
 class TestRouteTable:
@@ -144,24 +147,29 @@ class TestDispatch:
 
 
 class TestSharedSurface:
-    """The child reaches the parent for exactly the surface they share."""
+    """Both resources reach into one shared AppContext rather than one holding a reference to the other."""
 
-    def test_child_holds_its_parent(self, resource: APIResource) -> None:
+    def test_admin_holds_no_reference_to_the_parent(self, resource: APIResource) -> None:
         assert isinstance(resource.admin, AdminResource)
-        assert resource.admin._parent is resource
+        assert not hasattr(resource.admin, "_parent")
+
+    def test_both_resources_share_one_app_context(self, resource: APIResource) -> None:
+        assert resource.admin.app_context is resource.app_context
 
     def test_admin_only_handles_live_on_the_child(self, resource: APIResource) -> None:
-        for handle in ("_session", "_bulk_data_fetcher", "_import_guard", "_schema_setup_event"):
+        for handle in ("_session", "_bulk_data_fetcher", "admin_context"):
             assert hasattr(resource.admin, handle), handle
             assert not hasattr(resource, handle), f"{handle} should have moved to the child"
 
-    def test_shared_handles_stay_on_the_parent(self, resource: APIResource) -> None:
-        for handle in ("_cache_generation", "_last_import_time"):
-            assert hasattr(resource, handle), handle
+    def test_admin_context_holds_the_import_serialisation_primitives(self, resource: APIResource) -> None:
+        assert hasattr(resource.admin.admin_context, "import_guard")
+        assert hasattr(resource.admin.admin_context, "schema_setup_event")
 
-    def test_admin_has_its_own_conn_pool(self, resource: APIResource) -> None:
-        # Not a shared handle: each side opens its own psycopg_pool.ConnectionPool, so nothing
-        # here reaches through the parent for a connection, its query cache, or EXPLAIN plumbing.
-        assert hasattr(resource, "_conn_pool")
-        assert hasattr(resource.admin, "_conn_pool")
-        assert resource.admin._conn_pool is not resource._conn_pool
+    def test_shared_signals_live_on_app_context(self, resource: APIResource) -> None:
+        for handle in ("cache_generation", "last_import_time"):
+            assert hasattr(resource.app_context, handle), handle
+
+    def test_admin_reads_and_writes_via_its_own_pool(self, resource: APIResource) -> None:
+        # Each side reads/writes via its own pool, so nothing here needs the reader's query cache
+        # or EXPLAIN plumbing.
+        assert resource.app_context.writer_pool is not resource.app_context.reader_pool

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -3,7 +3,6 @@
 import multiprocessing
 import os
 import pathlib
-import time
 import unittest
 import uuid
 from collections.abc import Generator
@@ -16,11 +15,12 @@ import falcon.testing
 import pytest
 
 import api.api_resource as api_resource_module
+from api.admin_resource import AdminContext
 from api.api_resource import INTERNAL_ERROR_DESCRIPTION, APIResource
 from api.enums import ResponseShape
 from api.middlewares.caching_middleware import CachingMiddleware
 from api.settings import settings
-from api.tests.support import mock_conn_pool_kwargs
+from api.tests.support import mock_app_context
 from api.utils.routing import BoundRoute, RouteSpec, route
 from api.utils.site_name import FALLBACK_SITE_NAME
 
@@ -140,11 +140,9 @@ class TestBaseAPIResourceTest:
         """Set up test fixtures."""
         self_reference = request.instance
 
-        self_reference.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
-        self_reference.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self_reference.app_context = mock_app_context()
+        self_reference.mock_conn_pool = self_reference.app_context.reader_pool
+        self_reference.api_resource = APIResource(app_context=self_reference.app_context)
 
 
 class TestAPIResourceInitializationNewStyle(TestBaseAPIResourceTest):
@@ -153,7 +151,7 @@ class TestAPIResourceInitializationNewStyle(TestBaseAPIResourceTest):
     def test_initialization_defaults(self) -> None:
         """Test APIResource initialization with default parameters."""
         api_resource = self.api_resource
-        assert api_resource._conn_pool == self.mock_conn_pool
+        assert api_resource.app_context.reader_pool == self.mock_conn_pool
 
         # Check that action map is populated
         assert "get_pid" in api_resource.routes
@@ -169,11 +167,11 @@ class TestAPIResourceInitializationNewStyle(TestBaseAPIResourceTest):
         """Test APIResource initialization with custom import guard."""
         custom_guard = multiprocessing.RLock()
         api_resource = APIResource(
-            import_guard=custom_guard,
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            app_context=mock_app_context(),
+            admin_context=AdminContext(import_guard=custom_guard),
         )
 
-        assert api_resource.admin._import_guard == custom_guard
+        assert api_resource.admin.admin_context.import_guard == custom_guard
 
     def test_every_public_method_is_still_registered(self) -> None:
         """Test the marker migration left no previously-routed method behind.
@@ -302,7 +300,7 @@ class TestRequestDispatch(TestBaseAPIResourceTest):
             def shadows_search(self, **_: object) -> None: ...
 
         with pytest.raises(RuntimeError, match="claimed by both"):
-            Colliding(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
+            Colliding(app_context=mock_app_context())
 
     @pytest.mark.parametrize(argnames=["path"], argvalues=[("/index",), ("/index.html",)])
     def test_index_path_redirects_instead_of_erroring(self, path: str) -> None:
@@ -363,11 +361,9 @@ class TestAPIResourceCoreMethods(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self.app_context = mock_app_context()
+        self.mock_conn_pool = self.app_context.reader_pool
+        self.api_resource = APIResource(app_context=self.app_context)
 
     def test_get_pid_returns_process_id(self) -> None:
         """Test that get_pid returns the current process ID."""
@@ -381,11 +377,9 @@ class TestAPIResourceRequestHandling(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self.app_context = mock_app_context()
+        self.mock_conn_pool = self.app_context.reader_pool
+        self.api_resource = APIResource(app_context=self.app_context)
 
     def test_raise_not_found_raises_http_not_found(self) -> None:
         """Test _raise_not_found raises HTTPNotFound with route information."""
@@ -594,7 +588,7 @@ class TestSearchResponseShape(TestBaseAPIResourceTest):
         mock_engine = MagicMock()
         mock_engine.size.return_value = 100
         mock_engine.sample_preferred.return_value = iter(self.search_results["cards"])
-        with patch.object(self.api_resource, "_engine", mock_engine):
+        with patch.object(self.api_resource.app_context, "engine", mock_engine):
             result = self.api_resource.random_search(
                 falcon_response=MagicMock(),
                 num_cards=2,
@@ -644,11 +638,9 @@ class TestAPIResourceStaticFileServing(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self.app_context = mock_app_context()
+        self.mock_conn_pool = self.app_context.reader_pool
+        self.api_resource = APIResource(app_context=self.app_context)
 
     def test_index_html_serves_static_file(self) -> None:
         """Test _root serves the index.html file."""
@@ -775,11 +767,9 @@ class TestAPIResourceErrorHandling(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self.app_context = mock_app_context()
+        self.mock_conn_pool = self.app_context.reader_pool
+        self.api_resource = APIResource(app_context=self.app_context)
 
     def test_import_card_by_name_validates_card_name_parameter(self) -> None:
         """Test import_card_by_name validates card_name parameter."""
@@ -808,11 +798,9 @@ class TestAPIResourceCaching(unittest.TestCase):
         # Enable caching for these tests
         settings.enable_cache = True
         # Now create the APIResource with caching enabled
-        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self.app_context = mock_app_context()
+        self.mock_conn_pool = self.app_context.reader_pool
+        self.api_resource = APIResource(app_context=self.app_context)
 
     def tearDown(self) -> None:
         """Restore original cache setting."""
@@ -825,8 +813,8 @@ class TestAPIResourceCaching(unittest.TestCase):
         mock_cursor = MagicMock()
         mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
         with (
-            # _upsert_cards runs on AdminResource's own pool, not the parent's.
-            patch.object(self.api_resource.admin, "_conn_pool") as mock_pool,
+            # _upsert_cards runs via the shared AppContext's writer_pool, not the reader_pool.
+            patch.object(self.api_resource.admin.app_context, "writer_pool") as mock_pool,
             patch(
                 "api.admin_resource._bulk_upsert",
                 return_value={"inserted": 1, "updated": 0, "unchanged": 0},
@@ -865,10 +853,10 @@ class TestAPIResourceCaching(unittest.TestCase):
                 prices={},
             )
 
-            gen_before = self.api_resource._cache_generation.value
+            gen_before = self.api_resource.app_context.cache_generation.value
             self.api_resource.admin._upsert_cards([valid_card])
             # Generation increment is the cross-worker invalidation signal
-            assert self.api_resource._cache_generation.value > gen_before
+            assert self.api_resource.app_context.cache_generation.value > gen_before
 
     def test_random_search_uses_engine_sample_preferred(self) -> None:
         """random_search delegates to engine.sample_preferred() when the engine is loaded."""
@@ -879,7 +867,7 @@ class TestAPIResourceCaching(unittest.TestCase):
         mock_engine.size.return_value = 2
         mock_engine.sample_preferred.return_value = fake_cards
 
-        with patch.object(self.api_resource, "_engine", mock_engine):
+        with patch.object(self.api_resource.app_context, "engine", mock_engine):
             result = self.api_resource.random_search(num_cards=2)
 
         mock_engine.sample_preferred.assert_called_once_with(2)
@@ -894,7 +882,7 @@ class TestAPIResourceCaching(unittest.TestCase):
         mock_engine.size.return_value = 0
 
         with (
-            patch.object(self.api_resource, "_engine", mock_engine),
+            patch.object(self.api_resource.app_context, "engine", mock_engine),
             patch.object(self.api_resource, "_trigger_background_reload_if_needed"),
         ):
             result = self.api_resource.random_search(num_cards=1)
@@ -913,7 +901,7 @@ class TestAPIResourceCaching(unittest.TestCase):
         mock_engine = MagicMock()
         mock_engine.size.return_value = 0
 
-        with patch.object(self.api_resource, "_engine", mock_engine):
+        with patch.object(self.api_resource.app_context, "engine", mock_engine):
             with pytest.raises(falcon.HTTPServiceUnavailable):
                 self.api_resource.get_catalog()
 
@@ -939,7 +927,7 @@ class TestAPIResourceCaching(unittest.TestCase):
             "Haste": 3,
         }
 
-        with patch.object(self.api_resource, "_engine", mock_engine):
+        with patch.object(self.api_resource.app_context, "engine", mock_engine):
             result = self.api_resource.get_catalog()
 
         assert result == {
@@ -978,7 +966,7 @@ class TestAPIResourceCaching(unittest.TestCase):
             "Deathtouch": 2,
         }
 
-        with patch.object(self.api_resource, "_engine", mock_engine):
+        with patch.object(self.api_resource.app_context, "engine", mock_engine):
             result = self.api_resource.get_catalog()
 
         assert list(result["types"]) == ["Aura", "Aurochs", "Kindred", "Tribal", "Wall"]
@@ -994,20 +982,16 @@ class TestAPIResourceCaching(unittest.TestCase):
         assert "test_key" not in self.api_resource._query_cache
 
         # Test that generation increment invalidates the search gen cache
-        gen_before = self.api_resource._cache_generation.value
+        gen_before = self.api_resource.app_context.cache_generation.value
         self.api_resource.admin._clear_caches()
-        assert self.api_resource._cache_generation.value == gen_before + 1
+        assert self.api_resource.app_context.cache_generation.value == gen_before + 1
 
 
 class TestRootSiteNameInjection(unittest.TestCase):
     """Tests that _root injects the derived site name into the HTML."""
 
     def setUp(self) -> None:
-        _, pool_kwargs = mock_conn_pool_kwargs()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self.api_resource = APIResource(app_context=mock_app_context())
 
     def test_valid_hostname_replaces_fallback_in_html(self) -> None:
         mock_response = MagicMock()
@@ -1025,11 +1009,7 @@ class TestCardSiteNameInjection(unittest.TestCase):
     """Tests that card() injects the derived site name into card page HTML."""
 
     def setUp(self) -> None:
-        _, pool_kwargs = mock_conn_pool_kwargs()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self.api_resource = APIResource(app_context=mock_app_context())
 
     def test_valid_hostname_replaces_fallback_in_card_html(self) -> None:
         mock_response = MagicMock()

--- a/api/tests/test_app_context.py
+++ b/api/tests/test_app_context.py
@@ -1,0 +1,139 @@
+"""Tests for AppContext's setup-complete cache, cache-generation bump, and engine reload."""
+
+from __future__ import annotations
+
+import multiprocessing
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api.app_context import MIN_IMPORT_CARDS, AppContext
+
+
+def _mock_pool_returning(num_cards: int) -> MagicMock:
+    """A mock connection pool whose COUNT(1) query returns num_cards."""
+    pool = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchall.return_value = [{"num_cards": num_cards}]
+    pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = cursor
+    return pool
+
+
+class TestSetupComplete(unittest.TestCase):
+    def _make_context(self, *, num_cards: int) -> AppContext:
+        return AppContext(
+            reader_pool=_mock_pool_returning(num_cards),
+            writer_pool=MagicMock(),
+            engine=MagicMock(),
+            last_import_time=multiprocessing.Value("d", 1.0, lock=True),
+        )
+
+    def test_returns_true_above_threshold(self) -> None:
+        ctx = self._make_context(num_cards=MIN_IMPORT_CARDS + 1)
+        assert ctx.setup_complete() is True
+
+    def test_returns_false_below_threshold(self) -> None:
+        ctx = self._make_context(num_cards=MIN_IMPORT_CARDS - 1)
+        assert ctx.setup_complete() is False
+
+    def test_caches_result_within_ttl(self) -> None:
+        ctx = self._make_context(num_cards=MIN_IMPORT_CARDS + 1)
+        ctx.setup_complete()
+        ctx.reader_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value.fetchall.return_value = [
+            {"num_cards": 0},
+        ]
+        # Second call within the TTL must not re-query -- it should still see the cached True.
+        assert ctx.setup_complete() is True
+
+    def test_changed_last_import_time_invalidates_cache(self) -> None:
+        ctx = self._make_context(num_cards=MIN_IMPORT_CARDS + 1)
+        assert ctx.setup_complete() is True
+        ctx.last_import_time.value = 2.0
+        ctx.reader_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value.fetchall.return_value = [
+            {"num_cards": 0},
+        ]
+        assert ctx.setup_complete() is False
+
+    def test_invalidate_setup_complete_forces_recheck(self) -> None:
+        ctx = self._make_context(num_cards=MIN_IMPORT_CARDS + 1)
+        assert ctx.setup_complete() is True
+        ctx.invalidate_setup_complete()
+        ctx.reader_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value.fetchall.return_value = [
+            {"num_cards": 0},
+        ]
+        assert ctx.setup_complete() is False
+
+    def test_returns_false_on_database_error(self) -> None:
+        pool = MagicMock()
+        pool.connection.side_effect = RuntimeError("connection refused")
+        ctx = AppContext(reader_pool=pool, writer_pool=MagicMock(), engine=MagicMock())
+        assert ctx.setup_complete() is False
+
+
+class TestBumpCacheGeneration(unittest.TestCase):
+    def test_increments_the_shared_counter(self) -> None:
+        ctx = AppContext(
+            reader_pool=MagicMock(),
+            writer_pool=MagicMock(),
+            engine=MagicMock(),
+            cache_generation=multiprocessing.Value("i", 0),
+        )
+        ctx.bump_cache_generation()
+        ctx.bump_cache_generation()
+        assert ctx.cache_generation.value == 2
+
+
+class TestReloadEngine(unittest.TestCase):
+    def _make_context(self) -> tuple[AppContext, MagicMock, MagicMock]:
+        reader_pool = MagicMock()
+        writer_pool = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchmany.side_effect = [[{"scryfall_id": "x"}], []]
+        writer_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = cursor
+        engine = MagicMock()
+        engine.size.return_value = 0
+        engine.reload_begin.return_value = True
+        ctx = AppContext(reader_pool=reader_pool, writer_pool=writer_pool, engine=engine)
+        return ctx, reader_pool, writer_pool
+
+    def test_skipped_when_engine_feature_disabled(self) -> None:
+        ctx, _, writer_pool = self._make_context()
+        with patch("api.app_context.settings") as mock_settings:
+            mock_settings.enable_engine = False
+            ctx.reload_engine(force=True)
+        writer_pool.connection.assert_not_called()
+
+    def test_reads_via_writer_pool_not_reader_pool(self) -> None:
+        ctx, reader_pool, writer_pool = self._make_context()
+        with patch("api.app_context.settings") as mock_settings:
+            mock_settings.enable_engine = True
+            ctx.reload_engine(force=True)
+        writer_pool.connection.assert_called_once()
+        reader_pool.connection.assert_not_called()
+        ctx.engine.reload_commit.assert_called_once()
+
+    def test_skips_rebuild_when_not_forced_and_already_populated(self) -> None:
+        ctx, _, writer_pool = self._make_context()
+        ctx.engine.size.return_value = 1
+        with patch("api.app_context.settings") as mock_settings:
+            mock_settings.enable_engine = True
+            ctx.reload_engine(force=False)
+        writer_pool.connection.assert_not_called()
+
+    def test_releases_guard_on_failure(self) -> None:
+        ctx, _, writer_pool = self._make_context()
+        writer_pool.connection.side_effect = RuntimeError("boom")
+        with patch("api.app_context.settings") as mock_settings:
+            mock_settings.enable_engine = True
+            with pytest.raises(RuntimeError):
+                ctx.reload_engine(force=True)
+        # A second call must not block forever on a guard the first call failed to release.
+        writer_pool.connection.side_effect = None
+        with patch("api.app_context.settings") as mock_settings:
+            mock_settings.enable_engine = True
+            ctx.reload_engine(force=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/tests/test_app_context_cross_process.py
+++ b/api/tests/test_app_context_cross_process.py
@@ -1,0 +1,106 @@
+"""Tests that AppContext's shared signals actually cross a real process boundary.
+
+`api/app_context.py`'s docstring claims `cache_generation`/`last_import_time`/`engine_reload_guard`
+are "expected to be created once in the master process ... and handed to every worker's AppContext
+unchanged." Every other AppContext test builds one instance and calls methods on it directly, which
+never exercises that claim -- a bug that broke cross-process visibility (e.g. passing a *copy* of a
+`multiprocessing.Value` instead of the object itself) would still pass every one of those tests.
+
+These tests spawn a real child process via `multiprocessing.get_context("fork")` -- fork, not the
+platform default (`spawn` on macOS), so behavior matches production, which forks workers under
+Linux/Docker either way. Each side builds its OWN `AppContext`, sharing only the primitive under
+test, with `reader_pool`/`writer_pool`/`engine` mocked out on both sides since those are explicitly
+*not* meant to survive a fork (see the AppContext docstring) and are irrelevant to what's being
+proven here.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from api.app_context import AppContext
+
+if TYPE_CHECKING:
+    from multiprocessing.sharedctypes import Synchronized
+    from multiprocessing.synchronize import Event as EventType
+    from multiprocessing.synchronize import Lock as LockType
+
+_JOIN_TIMEOUT = 5
+
+
+def _mock_app_context(**overrides: object) -> AppContext:
+    kwargs: dict[str, object] = {"reader_pool": MagicMock(), "writer_pool": MagicMock(), "engine": MagicMock()}
+    kwargs.update(overrides)
+    return AppContext(**kwargs)
+
+
+def _child_bumps_cache_generation(cache_generation: Synchronized) -> None:
+    _mock_app_context(cache_generation=cache_generation).bump_cache_generation()
+
+
+def _child_writes_last_import_time(last_import_time: Synchronized, value: float) -> None:
+    _mock_app_context(last_import_time=last_import_time).last_import_time.value = value
+
+
+def _child_holds_the_guard(guard: LockType, acquired: EventType, release: EventType) -> None:
+    ctx = _mock_app_context(engine_reload_guard=guard)
+    ctx.engine_reload_guard.acquire()
+    acquired.set()
+    release.wait(timeout=_JOIN_TIMEOUT)
+    ctx.engine_reload_guard.release()
+
+
+class TestSharedSignalsCrossProcesses:
+    """Two AppContexts in two OS processes, sharing only the primitive under test."""
+
+    def test_cache_generation_bump_is_visible_across_processes(self) -> None:
+        fork_ctx = multiprocessing.get_context("fork")
+        cache_generation = multiprocessing.Value("i", 0)
+        process = fork_ctx.Process(target=_child_bumps_cache_generation, args=(cache_generation,))
+        process.start()
+        process.join(timeout=_JOIN_TIMEOUT)
+
+        assert process.exitcode == 0
+        # A *different* AppContext instance, in this (parent) process, built from the same shared
+        # Value -- not the one the child mutated -- must see the child's write.
+        parent_ctx = _mock_app_context(cache_generation=cache_generation)
+        assert parent_ctx.cache_generation.value == 1
+
+    def test_last_import_time_write_is_visible_across_processes(self) -> None:
+        fork_ctx = multiprocessing.get_context("fork")
+        last_import_time = multiprocessing.Value("d", 0.0, lock=True)
+        process = fork_ctx.Process(target=_child_writes_last_import_time, args=(last_import_time, 12345.0))
+        process.start()
+        process.join(timeout=_JOIN_TIMEOUT)
+
+        assert process.exitcode == 0
+        parent_ctx = _mock_app_context(last_import_time=last_import_time)
+        assert parent_ctx.last_import_time.value == 12345.0
+
+    def test_engine_reload_guard_serialises_across_processes(self) -> None:
+        fork_ctx = multiprocessing.get_context("fork")
+        guard = multiprocessing.Lock()
+        acquired = fork_ctx.Event()
+        release = fork_ctx.Event()
+        process = fork_ctx.Process(target=_child_holds_the_guard, args=(guard, acquired, release))
+        process.start()
+        try:
+            assert acquired.wait(timeout=_JOIN_TIMEOUT), "child never signalled that it holds the guard"
+
+            parent_ctx = _mock_app_context(engine_reload_guard=guard)
+            # The child holds the lock from a different process: a non-blocking acquire here must fail.
+            assert parent_ctx.engine_reload_guard.acquire(block=False) is False
+
+            release.set()
+            process.join(timeout=_JOIN_TIMEOUT)
+            assert process.exitcode == 0
+
+            # Released now -- the parent (which never itself held it) can take it.
+            assert parent_ctx.engine_reload_guard.acquire(block=False) is True
+            parent_ctx.engine_reload_guard.release()
+        finally:
+            if process.is_alive():
+                process.terminate()
+                process.join()

--- a/api/tests/test_card_ordering.py
+++ b/api/tests/test_card_ordering.py
@@ -19,8 +19,8 @@ def _compiled_sql(stub_api_resource: APIResource, ordering: CardOrdering) -> str
     """Return the compiled SQL string via the SQL path directly."""
     parsed_query = parse_scryfall_query("cmc=1")
     with (
-        patch.object(stub_api_resource, "_conn_pool") as mock_pool,
-        patch.object(stub_api_resource, "_setup_complete", return_value=True),
+        patch.object(stub_api_resource.app_context, "reader_pool") as mock_pool,
+        patch.object(stub_api_resource.app_context, "setup_complete", return_value=True),
     ):
         mock_cursor = MagicMock()
         mock_cursor.fetchall.return_value = [{"total_cards_count": 0, "name": None}]

--- a/api/tests/test_cubecobra_and_prefer_scores.py
+++ b/api/tests/test_cubecobra_and_prefer_scores.py
@@ -38,7 +38,7 @@ class TestInsertCubecobraData:
 
         assert rows_updated >= 1
 
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 "SELECT cubecobra_elo, cubecobra_cube_count, cubecobra_pick_count FROM magic.cards WHERE oracle_id = %s LIMIT 1",
                 (oracle_id,),
@@ -161,7 +161,7 @@ class TestBackfillPreferScores:
         oracle_id = _insert_card(api_resource, make_raw_card(name=f"Prefer Score Check {uuid.uuid4()}"))
         api_resource.admin.backfill_prefer_scores()
 
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute("SELECT prefer_score FROM magic.cards WHERE oracle_id = %s LIMIT 1", (oracle_id,))
             row = cursor.fetchone()
 

--- a/api/tests/test_datatype_mismatch.py
+++ b/api/tests/test_datatype_mismatch.py
@@ -21,6 +21,7 @@ import pytest
 from psycopg.pq import DiagnosticField
 
 from api.api_resource import APIResource, regex_error_reason
+from api.app_context import AppContext
 from api.tests.helpers import search_kwargs
 
 
@@ -30,15 +31,15 @@ class TestDatatypeMismatchHandling:
     def setup_method(self) -> None:
         """Set up test fixtures."""
         self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            app_context=AppContext(last_import_time=multiprocessing.Value("d", time.time(), lock=True)),
         )
 
     def teardown_method(self) -> None:
         """Clean up test fixtures."""
         if hasattr(self, "api_resource") and self.api_resource:
             # Close both connection pools to prevent thread pool warnings
-            self.api_resource._conn_pool.close()
-            self.api_resource.admin._conn_pool.close()
+            self.api_resource.app_context.reader_pool.close()
+            self.api_resource.app_context.writer_pool.close()
 
     def test_search_sql_handles_datatype_mismatch(self) -> None:
         """Test that DatatypeMismatch in _search_sql raises HTTPBadRequest."""
@@ -103,14 +104,14 @@ class TestInvalidRegularExpressionHandling:
     def setup_method(self) -> None:
         """Set up test fixtures."""
         self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            app_context=AppContext(last_import_time=multiprocessing.Value("d", time.time(), lock=True)),
         )
 
     def teardown_method(self) -> None:
         """Clean up test fixtures."""
         if hasattr(self, "api_resource") and self.api_resource:
-            self.api_resource._conn_pool.close()
-            self.api_resource.admin._conn_pool.close()
+            self.api_resource.app_context.reader_pool.close()
+            self.api_resource.app_context.writer_pool.close()
 
     def test_search_sql_handles_invalid_regular_expression(self) -> None:
         """An unparseable regex is the user's error, so it must be a 400 and not a 500.
@@ -149,14 +150,14 @@ class TestDataErrorHandling:
     def setup_method(self) -> None:
         """Set up test fixtures."""
         self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            app_context=AppContext(last_import_time=multiprocessing.Value("d", time.time(), lock=True)),
         )
 
     def teardown_method(self) -> None:
         """Clean up test fixtures."""
         if hasattr(self, "api_resource") and self.api_resource:
-            self.api_resource._conn_pool.close()
-            self.api_resource.admin._conn_pool.close()
+            self.api_resource.app_context.reader_pool.close()
+            self.api_resource.app_context.writer_pool.close()
 
     def test_search_sql_handles_division_by_zero(self) -> None:
         """power/0>1 parses cleanly but divides by zero at runtime — a 400, not a 500."""

--- a/api/tests/test_import_card_by_name.py
+++ b/api/tests/test_import_card_by_name.py
@@ -2,8 +2,6 @@
 
 # ruff: noqa: PT011
 
-import multiprocessing
-import time
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -13,7 +11,7 @@ import requests
 
 from api.admin_resource import AdminResource
 from api.api_resource import APIResource
-from api.tests.support import mock_conn_pool_kwargs
+from api.tests.support import mock_app_context
 
 
 class TestImportCardByName(unittest.TestCase):
@@ -21,11 +19,9 @@ class TestImportCardByName(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self.app_context = mock_app_context()
+        self.mock_conn_pool = self.app_context.reader_pool
+        self.api_resource = APIResource(app_context=self.app_context)
         self.mock_cursor = MagicMock()
         self.mock_cursor.fetchone.return_value = None
         self.mock_conn_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = (

--- a/api/tests/test_import_cards_by_search.py
+++ b/api/tests/test_import_cards_by_search.py
@@ -2,8 +2,6 @@
 
 # ruff: noqa: PT011
 
-import multiprocessing
-import time
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -11,7 +9,7 @@ import pytest
 
 from api.admin_resource import AdminResource
 from api.api_resource import APIResource
-from api.tests.support import mock_conn_pool_kwargs
+from api.tests.support import mock_app_context
 
 
 class TestImportCardsBySearch(unittest.TestCase):
@@ -19,11 +17,9 @@ class TestImportCardsBySearch(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self.app_context = mock_app_context()
+        self.mock_conn_pool = self.app_context.reader_pool
+        self.api_resource = APIResource(app_context=self.app_context)
 
     def test_import_cards_by_search_validates_input(self) -> None:
         """Test that import_cards_by_search validates search_query parameter."""
@@ -77,7 +73,7 @@ class TestImportCardsBySearch(unittest.TestCase):
             "message": "Successfully loaded 2 cards",
         }
 
-        with patch.object(self.api_resource, "_reload_engine"):
+        with patch.object(self.api_resource.app_context, "reload_engine"):
             result = self.api_resource.admin.import_cards_by_search(search_query="cmc<=2")
 
         assert result["status"] == "success"
@@ -90,7 +86,7 @@ class TestImportCardsBySearch(unittest.TestCase):
         with (
             patch.object(self.api_resource.admin, "_scryfall_search") as mock_search,
             patch.object(self.api_resource.admin, "_upsert_cards") as mock_load,
-            patch.object(self.api_resource, "_reload_engine"),
+            patch.object(self.api_resource.app_context, "reload_engine"),
         ):
             # Mock Scryfall API to return Sun Titan cards by Todd Lockwood
             mock_search.return_value = [

--- a/api/tests/test_integration_testcontainers.py
+++ b/api/tests/test_integration_testcontainers.py
@@ -14,7 +14,9 @@ import psycopg
 import pytest
 from testcontainers.postgres import PostgresContainer
 
+from api.admin_resource import AdminContext
 from api.api_resource import APIResource
+from api.app_context import AppContext
 from api.enums import CardOrdering, ResponseShape, SortDirection
 from api.tests.helpers import search_kwargs
 from api.tests.support import override_attr
@@ -110,14 +112,14 @@ class TestContainerIntegration:
         # Create APIResource instance
         schema_setup_event = multiprocessing.Event()
         api = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            schema_setup_event=schema_setup_event,
+            app_context=AppContext(last_import_time=multiprocessing.Value("d", time.time(), lock=True)),
+            admin_context=AdminContext(schema_setup_event=schema_setup_event),
         )
 
         def always_true() -> bool:
             return True
 
-        override_attr(api, "_setup_complete", always_true)
+        override_attr(api.app_context, "setup_complete", always_true)
         override_attr(api.admin, "_import_recent", always_true)
 
         # Set up the schema using real migrations
@@ -127,20 +129,18 @@ class TestContainerIntegration:
         test_dir = pathlib.Path(__file__).parent
         data_file = test_dir / "fixtures" / "test_data.sql"
 
-        with api._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(data_file.read_text())
             conn.commit()
 
-        api._reload_engine(force=True)
+        api.app_context.reload_engine(force=True)
 
         # Yield the fully configured APIResource for tests to use
         yield api
 
         # Clean up connection pools
-        if hasattr(api, "_conn_pool"):
-            api._conn_pool.close()
-        if hasattr(api.admin, "_conn_pool"):
-            api.admin._conn_pool.close()
+        api.app_context.reader_pool.close()
+        api.app_context.writer_pool.close()
 
     def test_query_parsing_with_database(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test query parsing and execution against real database."""
@@ -368,7 +368,7 @@ class TestContainerIntegration:
         assert import_result["status"] == "success"
         assert import_result["cards_loaded"] >= 35
 
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute("SELECT COUNT(*) as count FROM magic.cards WHERE card_name = %s", (card_name,))
             count_result = cursor.fetchone()
             card_count = count_result["count"] if count_result else 0
@@ -405,7 +405,7 @@ class TestContainerIntegration:
             assert import_result["cards_loaded"] == 3, f"Expected 3 cards loaded, got {import_result['cards_loaded']}"
 
         # Verify the card exists in database and has set information
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 "SELECT card_name, card_set_code FROM magic.cards WHERE card_name = %s",
                 (card_name,),
@@ -520,7 +520,7 @@ class TestContainerIntegration:
             "Black Lotus": 50.0,
             "Serra Angel": 90.0,
         }
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             for name, score in scores.items():
                 cursor.execute(
                     "UPDATE magic.cards SET cubecobra_score = %s WHERE card_name = %s",
@@ -532,11 +532,11 @@ class TestContainerIntegration:
         # store would shadow this test DB's data: swap in a private store for
         # this test (the api_resource fixture is class-scoped, so restore it).
         shm_path = pathlib.Path(tempfile.gettempdir()) / f"sylvan_librarian_it_{uuid.uuid4().hex}"
-        saved_engine = api_resource._engine
-        api_resource._engine = QueryEngine(shm_path=str(shm_path))
+        saved_engine = api_resource.app_context.engine
+        api_resource.app_context.engine = QueryEngine(shm_path=str(shm_path))
         try:
             # Reload the engine so it picks up the direct DB update
-            api_resource._reload_engine(force=True)
+            api_resource.app_context.reload_engine(force=True)
 
             result = api_resource._search_engine(
                 **search_kwargs("cmc>=0", limit=100, orderby=CardOrdering.CUBECOBRA, direction=SortDirection.ASC)
@@ -550,6 +550,6 @@ class TestContainerIntegration:
             names = [card["name"] for card in result["cards"] if card["name"] in scores]
             assert names == ["Serra Angel", "Black Lotus", "Lightning Bolt"]
         finally:
-            api_resource._engine = saved_engine
+            api_resource.app_context.engine = saved_engine
             shm_path.unlink(missing_ok=True)
             shm_path.with_suffix(".lock").unlink(missing_ok=True)

--- a/api/tests/test_page_rendering.py
+++ b/api/tests/test_page_rendering.py
@@ -2,15 +2,13 @@
 
 from __future__ import annotations
 
-import multiprocessing
-import time
 import unittest
 from unittest.mock import MagicMock, patch
 
 import falcon
 
 from api.api_resource import APIResource
-from api.tests.support import mock_conn_pool_kwargs
+from api.tests.support import mock_app_context
 from api.utils import page_rendering
 
 
@@ -46,11 +44,9 @@ class TestHtmlMinification(unittest.TestCase):
     """
 
     def setUp(self) -> None:
-        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self.app_context = mock_app_context()
+        self.mock_conn_pool = self.app_context.reader_pool
+        self.api_resource = APIResource(app_context=self.app_context)
 
     def test_minifies_whitespace_by_default(self) -> None:
         # minify_html also drops the redundant closing </p> (valid HTML5 tag-omission), hence

--- a/api/tests/test_parsing_errors.py
+++ b/api/tests/test_parsing_errors.py
@@ -59,10 +59,10 @@ class TestSearchRouting:
     @pytest.fixture(autouse=True)
     def _api(self, stub_api_resource: APIResource) -> None:
         self.api_resource = stub_api_resource
-        self.api_resource._engine = MagicMock()
+        self.api_resource.app_context.engine = MagicMock()
 
     def test_routes_to_sql_when_engine_empty(self) -> None:
-        self.api_resource._engine.size.return_value = 0
+        self.api_resource.app_context.engine.size.return_value = 0
         sentinel = {"cards": [], "total_cards": 0, "query": "name:opt"}
         with (
             patch.object(self.api_resource, "_search_sql", return_value=sentinel) as mock_sql,
@@ -74,7 +74,7 @@ class TestSearchRouting:
         assert result is sentinel
 
     def test_routes_to_engine_when_engine_has_data(self) -> None:
-        self.api_resource._engine.size.return_value = 87
+        self.api_resource.app_context.engine.size.return_value = 87
         sentinel = {"cards": [], "total_cards": 0, "query": "name:opt"}
         with (
             patch.object(self.api_resource, "_search_engine", return_value=sentinel) as mock_engine,
@@ -86,7 +86,7 @@ class TestSearchRouting:
         assert result is sentinel
 
     def test_falls_back_to_sql_when_engine_raises(self) -> None:
-        self.api_resource._engine.size.return_value = 87
+        self.api_resource.app_context.engine.size.return_value = 87
         sentinel = {"cards": [], "total_cards": 0, "query": "name:opt"}
         with (
             patch.object(self.api_resource, "_search_engine", side_effect=RuntimeError("engine failed")),
@@ -108,7 +108,7 @@ class TestSearchRouting:
         class _Panic(BaseException):
             pass
 
-        self.api_resource._engine.size.return_value = 87
+        self.api_resource.app_context.engine.size.return_value = 87
         sentinel = {"cards": [], "total_cards": 0, "query": "name:opt"}
         with (
             patch.object(self.api_resource, "_search_engine", side_effect=_Panic("engine panicked")),
@@ -129,7 +129,7 @@ class TestSearchRouting:
         """
         from card_engine import QueryError  # noqa: PLC0415
 
-        self.api_resource._engine.size.return_value = 87
+        self.api_resource.app_context.engine.size.return_value = 87
         sentinel = {"cards": [], "total_cards": 0, "query": "o:/^[/"}
         with (
             patch.object(
@@ -159,7 +159,7 @@ class TestSearchRouting:
         construction: QueryError is card_engine's own exception type, so an HTTPBadRequest raised for
         some other reason must still surface as an alertable failure.
         """
-        self.api_resource._engine.size.return_value = 87
+        self.api_resource.app_context.engine.size.return_value = 87
         sentinel = {"cards": [], "total_cards": 0, "query": "name:opt"}
         with (
             patch.object(
@@ -180,7 +180,7 @@ class TestSearchRouting:
 
     def test_a_real_engine_failure_still_warns_with_a_traceback(self, caplog: pytest.LogCaptureFixture) -> None:
         """Quieting the declined-query case must not quiet an engine that actually broke."""
-        self.api_resource._engine.size.return_value = 87
+        self.api_resource.app_context.engine.size.return_value = 87
         sentinel = {"cards": [], "total_cards": 0, "query": "name:opt"}
         with (
             patch.object(self.api_resource, "_search_engine", side_effect=RuntimeError("engine failed")),
@@ -196,7 +196,7 @@ class TestSearchRouting:
     @pytest.mark.parametrize(argnames=["exc"], argvalues=[(KeyboardInterrupt,), (SystemExit,)])
     def test_interpreter_shutdown_signals_still_propagate(self, exc: type[BaseException]) -> None:
         """Widening the catch to BaseException must not swallow Ctrl-C or interpreter exit."""
-        self.api_resource._engine.size.return_value = 87
+        self.api_resource.app_context.engine.size.return_value = 87
         with (
             patch.object(self.api_resource, "_search_engine", side_effect=exc()),
             patch.object(self.api_resource, "_search_sql") as mock_sql,
@@ -211,7 +211,7 @@ class TestSearchRouting:
         assert exc_info.value.title == "Invalid Limit"
 
     def test_raises_service_unavailable_when_setup_incomplete(self) -> None:
-        override_attr(self.api_resource, "_setup_complete", lambda: False)
+        override_attr(self.api_resource.app_context, "setup_complete", lambda: False)
         with pytest.raises(falcon.HTTPServiceUnavailable) as exc_info:
             self.api_resource._search(query="name:opt")
         assert exc_info.value.title == "Service Unavailable"
@@ -269,19 +269,19 @@ class TestSearchEngineDirect:
     @pytest.fixture(autouse=True)
     def _api(self, stub_api_resource: APIResource) -> None:
         self.api_resource = stub_api_resource
-        self.api_resource._engine = MagicMock()
+        self.api_resource.app_context.engine = MagicMock()
 
     def test_total_cards_and_cards_forwarded(self) -> None:
         mock_cards = [{"name": "Lightning Bolt"}, {"name": "Counterspell"}]
-        self.api_resource._engine.query.return_value = (2, mock_cards)
+        self.api_resource.app_context.engine.query.return_value = (2, mock_cards)
         result = self.api_resource._search_engine(**search_kwargs("type:instant"))
         assert result["total_cards"] == 2
         assert result["cards"] == mock_cards
 
     def test_engine_called_with_limit(self) -> None:
-        self.api_resource._engine.query.return_value = (0, [])
+        self.api_resource.app_context.engine.query.return_value = (0, [])
         self.api_resource._search_engine(**search_kwargs("name:opt", limit=5))
-        call_kwargs = self.api_resource._engine.query.call_args.kwargs
+        call_kwargs = self.api_resource.app_context.engine.query.call_args.kwargs
         assert call_kwargs["limit"] == 5
 
     def test_query_error_propagates_unwrapped(self) -> None:
@@ -293,7 +293,7 @@ class TestSearchEngineDirect:
         """
         from card_engine import QueryError  # noqa: PLC0415
 
-        self.api_resource._engine.query.side_effect = QueryError("cannot build")
+        self.api_resource.app_context.engine.query.side_effect = QueryError("cannot build")
         with pytest.raises(QueryError):
             self.api_resource._search_engine(**search_kwargs("o:/^[/"))
 
@@ -332,17 +332,17 @@ class TestResultFieldRouting:
     @pytest.fixture(autouse=True)
     def _api(self, stub_api_resource: APIResource) -> None:
         self.api_resource = stub_api_resource
-        self.api_resource._engine = MagicMock()
+        self.api_resource.app_context.engine = MagicMock()
 
     def test_fields_passed_to_sql_path(self) -> None:
-        self.api_resource._engine.size.return_value = 0
+        self.api_resource.app_context.engine.size.return_value = 0
         sentinel = {"cards": [], "total_cards": 0, "query": ""}
         with patch.object(self.api_resource, "_search_sql", return_value=sentinel) as mock_sql:
             self.api_resource._search(query="", fields=["name", "illustration_id"])
         assert mock_sql.call_args.kwargs["fields"] == ["name", "illustration_id"]
 
     def test_fields_passed_to_engine_path(self) -> None:
-        self.api_resource._engine.size.return_value = 87
+        self.api_resource.app_context.engine.size.return_value = 87
         sentinel = {"cards": [], "total_cards": 0, "query": ""}
         with patch.object(self.api_resource, "_search_engine", return_value=sentinel) as mock_engine:
             self.api_resource._search(query="", fields=["name", "price_usd"])
@@ -355,7 +355,7 @@ class TestEngineFeatureGate:
     @pytest.fixture(autouse=True)
     def _api(self, stub_api_resource: APIResource) -> Generator[None]:
         self.api_resource = stub_api_resource
-        self.api_resource._engine = MagicMock()
+        self.api_resource.app_context.engine = MagicMock()
         saved_enable_engine = settings.enable_engine
         yield
         settings.enable_engine = saved_enable_engine
@@ -368,7 +368,7 @@ class TestEngineFeatureGate:
 
     def test_disabled_routes_to_sql_even_with_populated_store(self) -> None:
         settings.enable_engine = False
-        self.api_resource._engine.size.return_value = 87
+        self.api_resource.app_context.engine.size.return_value = 87
         with (
             patch.object(self.api_resource, "_run_query", return_value=self._mock_result()),
             patch.object(self.api_resource, "_search_engine") as mock_engine,
@@ -383,19 +383,19 @@ class TestEngineFeatureGate:
         settings.enable_engine = False
         with patch.object(self.api_resource, "_run_query", return_value=self._mock_result()):
             self.api_resource._search(query="name:opt", limit=10)
-        self.api_resource._engine.size.assert_not_called()
-        self.api_resource._engine.query.assert_not_called()
+        self.api_resource.app_context.engine.size.assert_not_called()
+        self.api_resource.app_context.engine.query.assert_not_called()
 
     def test_disabled_reload_is_a_noop(self) -> None:
         settings.enable_engine = False
-        with patch.object(self.api_resource, "_conn_pool") as mock_pool:
-            self.api_resource._reload_engine()
+        with patch.object(self.api_resource.app_context, "writer_pool") as mock_pool:
+            self.api_resource.app_context.reload_engine()
         mock_pool.connection.assert_not_called()
-        self.api_resource._engine.reload.assert_not_called()
+        self.api_resource.app_context.engine.reload.assert_not_called()
 
     def test_enabled_routes_to_engine(self) -> None:
         settings.enable_engine = True
-        self.api_resource._engine.size.return_value = 87
+        self.api_resource.app_context.engine.size.return_value = 87
         sentinel = {"cards": [], "total_cards": 0, "query": "name:opt"}
         with patch.object(self.api_resource, "_search_engine", return_value=sentinel) as mock_engine:
             result = self.api_resource._search(query="name:opt", limit=10)
@@ -405,15 +405,15 @@ class TestEngineFeatureGate:
     def test_enabled_reload_streams_batches(self) -> None:
         settings.enable_engine = True
         # Empty store, or the populated-store fast path skips the reload.
-        self.api_resource._engine.size.return_value = 0
-        self.api_resource._engine.reload_begin.return_value = True
+        self.api_resource.app_context.engine.size.return_value = 0
+        self.api_resource.app_context.engine.reload_begin.return_value = True
         batch1, batch2 = [{"card_name": "A"}], [{"card_name": "B"}]
-        with patch.object(self.api_resource, "_conn_pool") as mock_pool:
+        with patch.object(self.api_resource.app_context, "writer_pool") as mock_pool:
             mock_cursor = MagicMock()
             mock_cursor.fetchmany.side_effect = [batch1, batch2, []]
             mock_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
-            self.api_resource._reload_engine()
-        engine = self.api_resource._engine
+            self.api_resource.app_context.reload_engine()
+        engine = self.api_resource.app_context.engine
         engine.reload_begin.assert_called_once()
         assert [c.args[0] for c in engine.add_batch.call_args_list] == [batch1, batch2]
         engine.reload_commit.assert_called_once()
@@ -421,28 +421,28 @@ class TestEngineFeatureGate:
 
     def test_enabled_reload_skips_when_another_worker_published(self) -> None:
         settings.enable_engine = True
-        self.api_resource._engine.size.return_value = 0
-        self.api_resource._engine.reload_begin.return_value = False
-        with patch.object(self.api_resource, "_conn_pool") as mock_pool:
+        self.api_resource.app_context.engine.size.return_value = 0
+        self.api_resource.app_context.engine.reload_begin.return_value = False
+        with patch.object(self.api_resource.app_context, "writer_pool") as mock_pool:
             mock_cursor = MagicMock()
             mock_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
-            self.api_resource._reload_engine()
-        self.api_resource._engine.add_batch.assert_not_called()
-        self.api_resource._engine.reload_commit.assert_not_called()
+            self.api_resource.app_context.reload_engine()
+        self.api_resource.app_context.engine.add_batch.assert_not_called()
+        self.api_resource.app_context.engine.reload_commit.assert_not_called()
 
     def test_enabled_reload_aborts_on_failure(self) -> None:
         settings.enable_engine = True
-        self.api_resource._engine.size.return_value = 0
-        self.api_resource._engine.reload_begin.return_value = True
-        self.api_resource._engine.add_batch.side_effect = RuntimeError("boom")
-        with patch.object(self.api_resource, "_conn_pool") as mock_pool:
+        self.api_resource.app_context.engine.size.return_value = 0
+        self.api_resource.app_context.engine.reload_begin.return_value = True
+        self.api_resource.app_context.engine.add_batch.side_effect = RuntimeError("boom")
+        with patch.object(self.api_resource.app_context, "writer_pool") as mock_pool:
             mock_cursor = MagicMock()
             mock_cursor.fetchmany.side_effect = [[{"card_name": "A"}], []]
             mock_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
             with pytest.raises(RuntimeError, match="boom"):
-                self.api_resource._reload_engine()
-        self.api_resource._engine.reload_abort.assert_called_once()
-        self.api_resource._engine.reload_commit.assert_not_called()
+                self.api_resource.app_context.reload_engine()
+        self.api_resource.app_context.engine.reload_abort.assert_called_once()
+        self.api_resource.app_context.engine.reload_commit.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/api/tests/test_prefer_order.py
+++ b/api/tests/test_prefer_order.py
@@ -6,6 +6,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from api.api_resource import APIResource
+from api.app_context import AppContext
 from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
 from api.parsing import parse_scryfall_query
 from api.utils.timer import Timer
@@ -22,20 +23,20 @@ class TestPreferOrder(unittest.TestCase):
         here calls an import path afterwards, so no suppression override is needed.
         """
         self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            app_context=AppContext(last_import_time=multiprocessing.Value("d", time.time(), lock=True)),
         )
 
     def tearDown(self) -> None:
         """Close the connection pools this test case opened."""
-        self.api_resource._conn_pool.close()
-        self.api_resource.admin._conn_pool.close()
+        self.api_resource.app_context.reader_pool.close()
+        self.api_resource.app_context.writer_pool.close()
 
     def _search_sql(self, query: str, prefer: PreferOrder) -> dict:
         """Run _search_sql directly, bypassing engine dispatch."""
         parsed_query = parse_scryfall_query(query)
         with (
-            patch.object(self.api_resource, "_conn_pool") as mock_pool,
-            patch.object(self.api_resource, "_setup_complete", return_value=True),
+            patch.object(self.api_resource.app_context, "reader_pool") as mock_pool,
+            patch.object(self.api_resource.app_context, "setup_complete", return_value=True),
         ):
             mock_cursor = MagicMock()
             mock_cursor.fetchall.return_value = [{"total_cards_count": 0, "name": None}]

--- a/api/tests/test_type_conversion.py
+++ b/api/tests/test_type_conversion.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from api.api_resource import APIResource
+from api.app_context import AppContext
 from api.utils.type_conversions import make_type_converting_wrapper
 
 
@@ -112,11 +113,11 @@ class TestTypeConversion:
     def test_action_map_uses_type_converting_wrappers(self) -> None:
         """Test that APIResource action map uses type converting wrappers."""
         with (
-            patch("api.api_resource.db_utils.make_pool"),
+            patch("api.app_context.db_utils.make_pool"),
             patch("api.admin_resource.requests.Session"),
         ):
             api_resource = APIResource(
-                last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+                app_context=AppContext(last_import_time=multiprocessing.Value("d", time.time(), lock=True)),
             )
 
             # Check that import_oracle_tags is wrapped

--- a/api/tests/test_upsert_cards.py
+++ b/api/tests/test_upsert_cards.py
@@ -16,7 +16,7 @@ from api.card_processing import preprocess_card
 from api.db.bulk_upsert import bulk_upsert
 from api.scryfall_bulk_data_fetcher import BulkDataKey
 from api.tests.helpers import make_raw_card
-from api.tests.support import mock_conn_pool_kwargs
+from api.tests.support import mock_app_context
 
 if TYPE_CHECKING:
     import pytest
@@ -68,7 +68,7 @@ class TestUpsertCardsStatus:
 
 
 def _is_tags_for(api_resource: APIResource, scryfall_id: str) -> dict:
-    with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+    with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
         cursor.execute(
             "SELECT card_is_tags FROM magic.cards WHERE scryfall_id = %(sid)s",
             {"sid": scryfall_id},
@@ -112,7 +112,7 @@ class TestBooleanIsTags:
         card = make_raw_card(name="Historic Bystander Test")
         card["reserved"] = True
         api_resource.admin._upsert_cards([card])
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 """UPDATE magic.cards SET card_is_tags = card_is_tags || '{"historic": true}'::jsonb
                    WHERE scryfall_id = %(sid)s""",
@@ -238,9 +238,9 @@ class TestRunImportUnderLockStreaming:
     def _make_api(self) -> APIResource:
         # Patch out setup_schema and import_data during construction: __init__ calls both, and an
         # unpatched import_data with last_import_time=0.0 performs a real full Scryfall import.
-        _, pool_kwargs = mock_conn_pool_kwargs()
+        app_context = mock_app_context(last_import_time=multiprocessing.Value("d", 0.0, lock=True))
         with patch.object(AdminResource, "setup_schema"), patch.object(AdminResource, "import_data"):
-            return APIResource(last_import_time=multiprocessing.Value("d", 0.0, lock=True), **pool_kwargs)
+            return APIResource(app_context=app_context)
 
     def test_calls_stream_data_for_key(self) -> None:
         api = self._make_api()
@@ -289,7 +289,7 @@ class TestBulkUpsertDedup:
         card_id = str(uuid.uuid4())
         (row_a,) = preprocess_card(make_raw_card(card_id=card_id, rarity="common"))
         (row_b,) = preprocess_card(make_raw_card(card_id=card_id, rarity="rare"))
-        with api_resource._conn_pool.connection() as conn:
+        with api_resource.app_context.reader_pool.connection() as conn:
             result = bulk_upsert(
                 conn,
                 "cards",
@@ -299,7 +299,7 @@ class TestBulkUpsertDedup:
             )
             conn.commit()
         assert result["inserted"] == 1
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute("SELECT card_rarity_text FROM magic.cards WHERE scryfall_id = %s", (card_id,))
             row = cursor.fetchone()
         assert row["card_rarity_text"] == "rare"
@@ -332,7 +332,7 @@ class TestUpsertBehavior:
         assert result["cards_inserted"] == 0
         assert result["cards_updated"] == 1
 
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute("SELECT card_rarity_text FROM magic.cards WHERE scryfall_id = %s", (card_id,))
             row = cursor.fetchone()
         assert row["card_rarity_text"] == "rare"
@@ -342,7 +342,7 @@ class TestUpsertBehavior:
         card_id = str(uuid.uuid4())
         api_resource.admin._upsert_cards([make_raw_card(card_id=card_id)])
 
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 "UPDATE magic.cards SET prefer_score = 42.0, card_is_tags = '{\"is:instant\": true}'::jsonb WHERE scryfall_id = %s",
                 (card_id,),
@@ -351,7 +351,7 @@ class TestUpsertBehavior:
 
         api_resource.admin._upsert_cards([make_raw_card(card_id=card_id, rarity="rare")])
 
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute("SELECT prefer_score, card_is_tags FROM magic.cards WHERE scryfall_id = %s", (card_id,))
             row = cursor.fetchone()
         assert row["prefer_score"] == 42.0

--- a/scripts/bench_random.py
+++ b/scripts/bench_random.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 sys.path.insert(0, "/app")
 
 from api.api_resource import APIResource
+from api.app_context import AppContext
 from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
 from api.parsing import parse_scryfall_query
 from api.tests.support import override_attr
@@ -41,11 +42,11 @@ REPEATS = 3  # independent timed windows per cell (report min to reduce noise)
 # ─── Setup ────────────────────────────────────────────────────────────────────
 
 print("Connecting to DB and loading engine store…", flush=True)
-api = APIResource(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
+api = APIResource(app_context=AppContext(last_import_time=multiprocessing.Value("d", time.time(), lock=True)))
 override_attr(api, "_import_recent", lambda: True)
-override_attr(api, "_setup_complete", lambda: True)
-api._reload_engine(force=True)
-total_printings = api._engine.size()
+override_attr(api.app_context, "setup_complete", lambda: True)
+api.app_context.reload_engine(force=True)
+total_printings = api.app_context.engine.size()
 print(f"Engine loaded: {total_printings:,} printings", flush=True)
 
 # Build the prebuilt list that the old implementation kept in memory.
@@ -53,7 +54,7 @@ print(f"Engine loaded: {total_printings:,} printings", flush=True)
 print("Building prebuilt card list (old approach)…", flush=True)
 tracemalloc.start()
 snapshot_before = tracemalloc.take_snapshot()
-_, prebuilt = api._engine.query(
+_, prebuilt = api.app_context.engine.query(
     filters=parse_scryfall_query(""),
     unique=str(UniqueOn.CARD),
     prefer=str(PreferOrder.DEFAULT),
@@ -89,9 +90,9 @@ def _time_fn(fn: Callable[[], object], warmup: int, window: float) -> float:
 def bench(n: int) -> tuple[float, float, float, float]:
     """Return (py_sample_us, preferred_us, reservoir_us, indexed_us) as min over REPEATS windows."""
     py_timings = [_time_fn(lambda: random.sample(prebuilt, n), WARMUP, WINDOW) for _ in range(REPEATS)]
-    pref_timings = [_time_fn(lambda: api._engine.sample_preferred(n), WARMUP, WINDOW) for _ in range(REPEATS)]
-    res_timings = [_time_fn(lambda: api._engine.sample_reservoir(n), WARMUP, WINDOW) for _ in range(REPEATS)]
-    idx_timings = [_time_fn(lambda: api._engine.sample_indexed(n), WARMUP, WINDOW) for _ in range(REPEATS)]
+    pref_timings = [_time_fn(lambda: api.app_context.engine.sample_preferred(n), WARMUP, WINDOW) for _ in range(REPEATS)]
+    res_timings = [_time_fn(lambda: api.app_context.engine.sample_reservoir(n), WARMUP, WINDOW) for _ in range(REPEATS)]
+    idx_timings = [_time_fn(lambda: api.app_context.engine.sample_indexed(n), WARMUP, WINDOW) for _ in range(REPEATS)]
     return min(py_timings), min(pref_timings), min(res_timings), min(idx_timings)
 
 


### PR DESCRIPTION
## Summary

Follow-up to #961: introduces `AppContext`, the object holding the state genuinely shared between peer resources rather than owned by one — connection pools, the query engine, and the cross-worker cache/import signals. `AdminResource` no longer holds a `_parent` reference to `APIResource` at all.

- **`api/app_context.py`** (new): `AppContext` holds `reader_pool`, `writer_pool`, `engine`, `engine_reload_guard`, `cache_generation`, `last_import_time`, plus the `setup_complete`/`reload_engine`/`bump_cache_generation`/`invalidate_setup_complete` logic that operates on them (moved from `APIResource`).
- **`APIResource.__init__`** now takes `app_context`/`admin_context` instead of five granular params (`conn_pool`, `admin_conn_pool`, `cache_generation`, `engine_reload_guard`, `import_guard`, `schema_setup_event`, `last_import_time`).
- **`AdminResource.__init__`** drops `parent`/`conn_pool`/`import_guard`/`schema_setup_event`, takes `app_context`/`admin_context` instead. Every `self._parent.X` access is gone.
- **`AdminContext`** (new, defined in `admin_resource.py`): `import_guard`/`schema_setup_event`, kept separate from `AppContext` since they're cross-worker-shared only *within* AdminResource's own copies — nothing on the search side touches them. `APIResource.__init__` forwards it opaquely without needing to know its shape.
- **`api_worker.py`**: `get_api()` now builds both context objects post-fork from the same five primitives it already received; its own signature and `entrypoint.py` are unchanged.
- Every test constructing `APIResource(...)`/`AdminResource(...)` directly, plus `scripts/bench_random.py`, updated for the new constructor shape. `api/tests/support.py`'s `mock_conn_pool_kwargs()` is replaced with `mock_app_context()`.

One correctness bug surfaced during the migration and is fixed here: three tests in `test_parsing_errors.py` that patch a pool and call `reload_engine()` were patching `reader_pool`, which `reload_engine` no longer reads from (it deliberately reads via `writer_pool` — see the docstring on `AppContext.reload_engine`) — fixed to patch `writer_pool`.

Two follow-up commits address review discussion:
- `reload_engine`'s docstring cited an unmeasured "can run for minutes" claim justifying the `writer_pool` choice. Measured against a real ~98k-card corpus: ~3 seconds end-to-end, matching `docs/issues/done/00505-engine-incremental-loading.md`'s "seconds-long" characterization. Docstring corrected to cite the number and note the in-process engine serves the large majority of search traffic without touching `reader_pool` at all — so the choice stands, but was never as consequential as originally implied.
- Added `api/tests/test_app_context_cross_process.py`: every other `AppContext` test builds one instance and calls its methods directly, which never exercises the actual cross-worker claim — that `cache_generation`/`last_import_time`/`engine_reload_guard` stay genuinely shared across a fork. These spawn a real child process (`multiprocessing.get_context("fork")`, explicit so behavior matches production regardless of host OS) and prove a write in one process is visible from an independent `AppContext` built from the same primitive in another.

## Test plan

- [x] Full suite (unit + docker integration): 3032 passed, 7 deselected (pre-existing stale-engine failures unrelated to this change), 19 xfailed
- [x] `ruff check` / `ruff format --check` on every touched file
- [x] Manual sanity check of `ApiWorker.get_api()`'s actual production wiring path (not exercised by any existing test) — builds the Falcon app successfully with mocked pools
- [x] Real measured timing of `reload_engine(force=True)` against a populated dev DB (~98k cards): ~3 seconds