### PR TITLE
Combined: Admin Resource Split + AppContext (#794 + #961 + #962)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Browser → GET /search?q=<query>
 
 - **`api/parsing/`** — Core query parser (~2,500 lines). `parsing_f.py` drives the pyparsing grammar; `nodes.py` defines AST node types; `card_query_nodes.py` has card-specific nodes; `db_info.py` maps query fields to DB columns.
 - **`api/api_resource.py`** — Dispatch (Falcon sink), search logic, SQL generation from AST, and the public routes.
-- **`api/admin_resource.py`** — Data-management handlers (import, backfill, tagging), mounted by `APIResource` under a path prefix rather than sharing the public namespace. Holds a reference to its parent for the handful of methods and handles they share.
+- **`api/admin_resource.py`** — Data-management handlers (import, backfill, tagging), mounted by `APIResource` under a path prefix rather than sharing the public namespace. Holds no reference to its parent; state the two resources share (connection pools, the query engine, cross-worker cache/import signals) lives on the `AppContext` both take a reference to at construction (`api/app_context.py`).
 - **`api/utils/routing.py`** — The `@route` marker, route-table construction, and the 404 listing. A handler is reachable only if marked; the listing skips anything registered `advertise=False`, which is what makes the mount a boundary rather than a URL prefix.
 - **`api/utils/param_binding.py`** — Resolves each handler's annotations once at registration and binds request parameters against a fixed plan.
 - **`api/utils/page_rendering.py`**, **`api/utils/css_utils.py`**, **`api/utils/site_name.py`**, **`api/utils/caching.py`** — Page assembly, critical-CSS extraction, Host-header display names, and the settings-aware cache decorator.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,11 @@ Browser → GET /search?q=<query>
 ### Key Directories
 
 - **`api/parsing/`** — Core query parser (~2,500 lines). `parsing_f.py` drives the pyparsing grammar; `nodes.py` defines AST node types; `card_query_nodes.py` has card-specific nodes; `db_info.py` maps query fields to DB columns.
-- **`api/api_resource.py`** — All HTTP routing (Falcon sink), search logic, SQL generation from AST, and bulk import endpoints.
+- **`api/api_resource.py`** — Dispatch (Falcon sink), search logic, SQL generation from AST, and the public routes.
+- **`api/admin_resource.py`** — Data-management handlers (import, backfill, tagging), mounted by `APIResource` under a path prefix rather than sharing the public namespace. Holds a reference to its parent for the handful of methods and handles they share.
+- **`api/utils/routing.py`** — The `@route` marker, route-table construction, and the 404 listing. A handler is reachable only if marked; the listing skips anything registered `advertise=False`, which is what makes the mount a boundary rather than a URL prefix.
+- **`api/utils/param_binding.py`** — Resolves each handler's annotations once at registration and binds request parameters against a fixed plan.
+- **`api/utils/page_rendering.py`**, **`api/utils/css_utils.py`**, **`api/utils/site_name.py`**, **`api/utils/caching.py`** — Page assembly, critical-CSS extraction, Host-header display names, and the settings-aware cache decorator.
 - **`api/entrypoint.py`** + **`api/api_worker.py`** — Multi-process Bjoern WSGI server startup.
 - **`api/db/`** — PostgreSQL schema SQL (`2025-09-29-great-reset.sql`). The `magic.cards` table has 22 specialized indices (trigram GIN for text, GIN for JSONB arrays, B-tree for numerics).
 - **`api/tests/`** — Integration tests using `testcontainers` (spins up a real PostgreSQL instance).

--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -16,9 +16,11 @@ reference to at construction (see `api/app_context.py`). Neither resource owns t
 peers that reach into a neutral shared object instead of into each other.
 
 `import_guard`/`schema_setup_event` are not part of `AppContext`: they're cross-worker-shared, but
-only *within* `AdminResource`'s own copies across processes (serialising concurrent import
-attempts) — nothing on the search side ever touches either one. They get their own small bundle,
-`AdminContext`, defined here since nothing outside this module needs it.
+only *within* `AdminResource`'s own copies across processes. `import_guard` serialises concurrent
+*schema setup* only — the import flow itself serialises on `AppContext.last_import_time`'s own lock
+instead (see `import_data`) — and nothing on the search side ever touches either primitive. They get
+their own small bundle, `AdminContext`, defined here. `APIResource` and `api_worker` import the type
+to construct and forward it, but nothing outside this module reads or writes its fields.
 """
 
 from __future__ import annotations
@@ -178,7 +180,11 @@ CARD_IS_TAGS = LAND_IS_TAGS + [  # noqa: RUF005
 
 
 class AdminContext:
-    """Cross-worker primitives private to AdminResource: not shared with any other resource."""
+    """Cross-worker primitives private to AdminResource's own use.
+
+    The type itself is imported by `APIResource` and `api_worker` to construct and forward an
+    instance, but nothing outside `AdminResource` reads or writes the primitives it holds.
+    """
 
     def __init__(
         self,
@@ -189,7 +195,9 @@ class AdminContext:
         """Build the primitives, or accept ones a caller already built.
 
         Args:
-            import_guard: Cross-process lock serialising imports.
+            import_guard: Cross-process lock serialising concurrent schema setup (see
+                `setup_schema`) -- not the import flow itself, which serialises on
+                `AppContext.last_import_time`'s own lock instead (see `import_data`).
             schema_setup_event: Set once the schema has been created.
         """
         self.import_guard = import_guard
@@ -210,8 +218,8 @@ class AdminResource:
         Args:
             app_context: State and resources shared with the resource this is mounted on --
                 connection pools, the query engine, the cross-worker cache/import signals.
-            admin_context: Import-serialisation primitives private to this resource. Built fresh if
-                not given, matching every other handle here.
+            admin_context: Schema-setup-serialisation primitives private to this resource. Built
+                fresh if not given, matching every other handle here.
         """
         self.app_context = app_context
         self.admin_context = admin_context or AdminContext()
@@ -283,9 +291,7 @@ class AdminResource:
             logger.info("Schema setup complete in pid %d", os.getpid())
 
     def _import_recent(self) -> bool:
-        """Return True if a bulk import completed in the last 5 minutes (or setup is complete when no shared timestamp)."""
-        if self.app_context.last_import_time is None:
-            return self.app_context.setup_complete()
+        """Return True if a bulk import completed in the last 5 minutes."""
         # Unlocked read: c_double is atomic on typical platforms; avoids lock contention on fast path
         t = self.app_context.last_import_time.get_obj().value
         if not t:
@@ -310,8 +316,7 @@ class AdminResource:
         after_transfer = time.monotonic()
 
         if result["status"] == "success":
-            if self.app_context.last_import_time is not None:
-                self.app_context.last_import_time.value = time.time()
+            self.app_context.last_import_time.value = time.time()
             total_time = after_transfer - before
             cards_sent = result.get("cards_sent", result["cards_loaded"])
             rate = cards_sent / total_time if total_time > 0 else 0
@@ -945,6 +950,7 @@ class AdminResource:
 
         # Check if card already exists in database for backward compatibility
         with self.app_context.writer_pool.connection() as conn, conn.cursor() as cursor:
+            db_utils.set_statement_timeout(cursor, 10_000)
             cursor.execute(
                 "SELECT card_name FROM magic.cards WHERE card_name = %(card_name)s",
                 {"card_name": card_name},

--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -9,11 +9,20 @@ public method became a route, and the only lever was a leading underscore, which
 method's Python visibility. Mounting a separate resource replaces that lever with a boundary, and
 keeps the honest names.
 
-The child holds a reference to its parent for the small surface they genuinely share — five methods
-(`_reload_engine`, `_run_query`, `_serve_static_file`, `_set_statement_timeout`, `_setup_complete`)
-and four handles (`_conn_pool`, `_cache_generation`, `_last_import_time`, `_setup_complete_cache`).
-That is deliberately not a decoupling: the boundary here is about routing, and pretending otherwise
-would mean an `AppContext` refactor that the routing fix does not need.
+The child holds a reference to its parent for the small surface they genuinely share — two methods
+(`_reload_engine`, `_setup_complete`) and three handles (`_cache_generation`, `_last_import_time`,
+`_setup_complete_cache`). All three of those handles are `multiprocessing` primitives: the actual
+mechanism by which one worker process tells every other worker "the corpus changed" or "check
+whether setup finished," not incidental references. That is deliberately not a decoupling: the
+boundary here is about routing, and pretending otherwise would mean an `AppContext` refactor that
+the routing fix does not need.
+
+The child keeps its own `_conn_pool` rather than sharing the parent's: nothing here needs the
+parent's query-result cache or EXPLAIN plumbing, only a connection, so a second pool removes that
+coupling for the price of a second `psycopg_pool.ConnectionPool` (and its own connections) per
+worker process. `APIResource.__init__` builds both pools and hands this one over at construction,
+rather than this module building its own — so a test can inject a mock in place of either without
+a real connection ever opening.
 """
 
 from __future__ import annotations
@@ -46,6 +55,7 @@ from api.tag_import import import_oracle_tags as _import_oracle_tags
 from api.utils import db_utils
 from api.utils.caching import cached
 from api.utils.http_utils import make_user_agent
+from api.utils.page_rendering import serve_static_file
 from api.utils.routing import route
 
 if TYPE_CHECKING:
@@ -53,6 +63,7 @@ if TYPE_CHECKING:
     from multiprocessing.synchronize import Event as EventType
     from multiprocessing.synchronize import RLock as LockType
 
+    import psycopg_pool
     from psycopg import Connection
 
     from api.api_resource import APIResource
@@ -174,15 +185,26 @@ CARD_IS_TAGS = LAND_IS_TAGS + [  # noqa: RUF005
 class AdminResource:
     """Data-management routes, mounted behind a path prefix by APIResource."""
 
-    def __init__(self, parent: APIResource, *, import_guard: LockType, schema_setup_event: EventType) -> None:
+    def __init__(
+        self,
+        parent: APIResource,
+        *,
+        conn_pool: psycopg_pool.ConnectionPool,
+        import_guard: LockType,
+        schema_setup_event: EventType,
+    ) -> None:
         """Attach to the parent resource and take ownership of the admin-only handles.
 
         Args:
             parent: The resource this is mounted on, for the shared methods and handles.
+            conn_pool: This resource's own connection pool -- built by the caller (mirroring the
+                parent's own `_conn_pool`), so a test can inject a mock without a real pool ever
+                opening a connection.
             import_guard: Cross-process lock serialising imports.
             schema_setup_event: Set once the schema has been created.
         """
         self._parent = parent
+        self._conn_pool = conn_pool
         self._import_guard = import_guard
         self._schema_setup_event = schema_setup_event
         self._session = requests.Session()
@@ -206,7 +228,7 @@ class AdminResource:
             # read migrations from the db dir...
             # if any already applied migrations differ from what we want
             # to apply then drop everything
-            with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+            with self._conn_pool.connection() as conn, conn.cursor() as cursor:
                 cursor.execute(
                     """CREATE TABLE IF NOT EXISTS migrations (
                         file_name text not null,
@@ -297,10 +319,10 @@ class AdminResource:
             # running the backfill ahead of the tag import scored every card as on-style on a
             # first boot, and nothing rescored until the next import. Oracle tags feed search
             # rather than scoring, so their position relative to the backfill does not matter.
-            _import_art_tags(self._parent._conn_pool, self._bulk_data_fetcher)
+            _import_art_tags(self._conn_pool, self._bulk_data_fetcher)
             self.backfill_prefer_scores()
             self.backfill_cubecobra_scores()
-            _import_oracle_tags(self._parent._conn_pool, self._bulk_data_fetcher)
+            _import_oracle_tags(self._conn_pool, self._bulk_data_fetcher)
             self._parent._reload_engine(force=True)
             self._clear_caches()
             self._parent._last_import_time.value = time.time()
@@ -355,7 +377,7 @@ class AdminResource:
             falcon_response (falcon.Response): The Falcon response to write to.
 
         """
-        self._parent._serve_static_file(filename="prefer_score_tuner.html", falcon_response=falcon_response)
+        serve_static_file(filename="prefer_score_tuner.html", falcon_response=falcon_response)
         falcon_response.content_type = "text/html"
 
     @route()
@@ -383,8 +405,8 @@ class AdminResource:
         logger.info("Starting prefer score backfill")
 
         backfill_sql = db_utils.read_sql("backfill_prefer_scores")
-        with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
-            self._parent._set_statement_timeout(cursor, settings.prefer_score_backfill_timeout_ms)
+        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+            db_utils.set_statement_timeout(cursor, settings.prefer_score_backfill_timeout_ms)
             cursor.execute(backfill_sql)
             updated_count = cursor.rowcount
 
@@ -478,7 +500,7 @@ class AdminResource:
             ]
         )
 
-        with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 """
                 WITH incoming AS (
@@ -530,8 +552,8 @@ class AdminResource:
         logger.info("Starting CubeCobra score backfill with weights: %s", weights)
 
         backfill_sql = db_utils.read_sql("backfill_cubecobra_scores")
-        with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
-            self._parent._set_statement_timeout(cursor, 600_000)
+        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+            db_utils.set_statement_timeout(cursor, 600_000)
             cursor.execute(backfill_sql, weights)
             updated_count = cursor.rowcount
 
@@ -570,7 +592,7 @@ class AdminResource:
         """
         logger.info("Starting CubeCobra ingest")
         # fetch the distinct, non-null oracle ids that are in the db
-        with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 "SELECT DISTINCT oracle_id FROM magic.cards WHERE oracle_id IS NOT NULL",
             )
@@ -656,7 +678,7 @@ class AdminResource:
         # Update cards in database with the new is: tag
         updated_count = 0
         new_tag = orjson.dumps({is_tag: True}).decode("utf-8")
-        with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
             # Use SQL update with jsonb concatenation to add the is: tag
             for card_name_batch in itertools.batched(sorted(card_names), 500):
                 cursor.execute(
@@ -738,7 +760,7 @@ class AdminResource:
         updated_count = 0
         new_tag = orjson.dumps({is_tag: True}).decode("utf-8")
         scryfall_ids = {p["id"] for p in printings}
-        with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
             # Use SQL update with jsonb concatenation to add the is: tag
             for scryfall_id_batch in itertools.batched(sorted(scryfall_ids), 500):
                 cursor.execute(
@@ -800,12 +822,12 @@ class AdminResource:
     @route()
     def import_oracle_tags(self, **_: object) -> dict[str, Any]:
         """Import oracle tags from Scryfall bulk data into oracle_tags, oracle_tag_relationships, and card_oracle_tags."""
-        return _import_oracle_tags(self._parent._conn_pool, self._bulk_data_fetcher)
+        return _import_oracle_tags(self._conn_pool, self._bulk_data_fetcher)
 
     @route()
     def import_art_tags(self, **_: object) -> dict[str, Any]:
         """Import art tags from Scryfall bulk data into art_tags, art_tag_relationships, and card_art_tags."""
-        return _import_art_tags(self._parent._conn_pool, self._bulk_data_fetcher)
+        return _import_art_tags(self._conn_pool, self._bulk_data_fetcher)
 
     @route()
     def import_all_is_tags(self, **_: object) -> dict[str, Any]:
@@ -914,13 +936,14 @@ class AdminResource:
         logger.info("Importing card by name: '%s'", card_name)
 
         # Check if card already exists in database for backward compatibility
-        existing_check = self._parent._run_query(
-            query="SELECT card_name FROM magic.cards WHERE card_name = %(card_name)s",
-            params={"card_name": card_name},
-            explain=False,
-        )
+        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+            cursor.execute(
+                "SELECT card_name FROM magic.cards WHERE card_name = %(card_name)s",
+                {"card_name": card_name},
+            )
+            card_already_exists = cursor.fetchone() is not None
 
-        if existing_check["result"]:
+        if card_already_exists:
             return {
                 "card_name": card_name,
                 "status": "already_exists",
@@ -1086,9 +1109,9 @@ class AdminResource:
         self.setup_schema()
 
         try:
-            with self._parent._conn_pool.connection() as conn:
+            with self._conn_pool.connection() as conn:
                 with conn.cursor() as cursor:
-                    self._parent._set_statement_timeout(cursor, 30_000)
+                    db_utils.set_statement_timeout(cursor, 30_000)
 
                 class _CardStream:
                     """Preprocesses raw cards lazily, tracking stage counts."""

--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -9,20 +9,16 @@ public method became a route, and the only lever was a leading underscore, which
 method's Python visibility. Mounting a separate resource replaces that lever with a boundary, and
 keeps the honest names.
 
-The child holds a reference to its parent for the small surface they genuinely share — two methods
-(`_reload_engine`, `_setup_complete`) and three handles (`_cache_generation`, `_last_import_time`,
-`_setup_complete_cache`). All three of those handles are `multiprocessing` primitives: the actual
-mechanism by which one worker process tells every other worker "the corpus changed" or "check
-whether setup finished," not incidental references. That is deliberately not a decoupling: the
-boundary here is about routing, and pretending otherwise would mean an `AppContext` refactor that
-the routing fix does not need.
+`AdminResource` no longer holds a reference to `APIResource` at all. What it used to reach a parent
+for — `reload_engine`, `setup_complete`, `cache_generation`, `last_import_time`,
+`invalidate_setup_complete`, the connection pool — all live on the `AppContext` both resources take a
+reference to at construction (see `api/app_context.py`). Neither resource owns that state; both are
+peers that reach into a neutral shared object instead of into each other.
 
-The child keeps its own `_conn_pool` rather than sharing the parent's: nothing here needs the
-parent's query-result cache or EXPLAIN plumbing, only a connection, so a second pool removes that
-coupling for the price of a second `psycopg_pool.ConnectionPool` (and its own connections) per
-worker process. `APIResource.__init__` builds both pools and hands this one over at construction,
-rather than this module building its own — so a test can inject a mock in place of either without
-a real connection ever opening.
+`import_guard`/`schema_setup_event` are not part of `AppContext`: they're cross-worker-shared, but
+only *within* `AdminResource`'s own copies across processes (serialising concurrent import
+attempts) — nothing on the search side ever touches either one. They get their own small bundle,
+`AdminContext`, defined here since nothing outside this module needs it.
 """
 
 from __future__ import annotations
@@ -52,7 +48,7 @@ from api.scryfall_bulk_data_fetcher import BulkDataKey, ScryfallBulkDataFetcher
 from api.settings import settings
 from api.tag_import import import_art_tags as _import_art_tags
 from api.tag_import import import_oracle_tags as _import_oracle_tags
-from api.utils import db_utils
+from api.utils import db_utils, multiprocessing_utils
 from api.utils.caching import cached
 from api.utils.http_utils import make_user_agent
 from api.utils.page_rendering import serve_static_file
@@ -63,10 +59,9 @@ if TYPE_CHECKING:
     from multiprocessing.synchronize import Event as EventType
     from multiprocessing.synchronize import RLock as LockType
 
-    import psycopg_pool
     from psycopg import Connection
 
-    from api.api_resource import APIResource
+    from api.app_context import AppContext
 
 # Path prefix the child mounts under. Underscore-prefixed to match the convention API namespaces use
 # for internal routes (Elasticsearch _search, CouchDB _all_docs), and to stay clear of /admin, which
@@ -182,31 +177,44 @@ CARD_IS_TAGS = LAND_IS_TAGS + [  # noqa: RUF005
 ]
 
 
+class AdminContext:
+    """Cross-worker primitives private to AdminResource: not shared with any other resource."""
+
+    def __init__(
+        self,
+        *,
+        import_guard: LockType = multiprocessing_utils.DEFAULT_LOCK,
+        schema_setup_event: EventType = multiprocessing_utils.DEFAULT_EVENT,
+    ) -> None:
+        """Build the primitives, or accept ones a caller already built.
+
+        Args:
+            import_guard: Cross-process lock serialising imports.
+            schema_setup_event: Set once the schema has been created.
+        """
+        self.import_guard = import_guard
+        self.schema_setup_event = schema_setup_event
+
+
 class AdminResource:
     """Data-management routes, mounted behind a path prefix by APIResource."""
 
     def __init__(
         self,
-        parent: APIResource,
         *,
-        conn_pool: psycopg_pool.ConnectionPool,
-        import_guard: LockType,
-        schema_setup_event: EventType,
+        app_context: AppContext,
+        admin_context: AdminContext | None = None,
     ) -> None:
-        """Attach to the parent resource and take ownership of the admin-only handles.
+        """Take ownership of the admin-only handles.
 
         Args:
-            parent: The resource this is mounted on, for the shared methods and handles.
-            conn_pool: This resource's own connection pool -- built by the caller (mirroring the
-                parent's own `_conn_pool`), so a test can inject a mock without a real pool ever
-                opening a connection.
-            import_guard: Cross-process lock serialising imports.
-            schema_setup_event: Set once the schema has been created.
+            app_context: State and resources shared with the resource this is mounted on --
+                connection pools, the query engine, the cross-worker cache/import signals.
+            admin_context: Import-serialisation primitives private to this resource. Built fresh if
+                not given, matching every other handle here.
         """
-        self._parent = parent
-        self._conn_pool = conn_pool
-        self._import_guard = import_guard
-        self._schema_setup_event = schema_setup_event
+        self.app_context = app_context
+        self.admin_context = admin_context or AdminContext()
         self._session = requests.Session()
         self._session.headers.update({"User-Agent": make_user_agent()})
         self._bulk_data_fetcher = ScryfallBulkDataFetcher()
@@ -214,21 +222,21 @@ class AdminResource:
     @route()
     def setup_schema(self, *_: object, **__: object) -> None:
         """Set up the database schema and apply migrations as needed."""
-        if self._schema_setup_event.is_set():
+        if self.admin_context.schema_setup_event.is_set():
             logger.info("Schema already setup (fastpath) in pid %d", os.getpid())
             return
 
         filesystem_migrations = db_utils.get_migrations()
 
-        with self._import_guard:
-            if self._schema_setup_event.is_set():
+        with self.admin_context.import_guard:
+            if self.admin_context.schema_setup_event.is_set():
                 logger.info("Schema already setup (slowpath) in pid %d", os.getpid())
                 return
             logger.info("Setting up schema in pid %d", os.getpid())
             # read migrations from the db dir...
             # if any already applied migrations differ from what we want
             # to apply then drop everything
-            with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+            with self.app_context.writer_pool.connection() as conn, conn.cursor() as cursor:
                 cursor.execute(
                     """CREATE TABLE IF NOT EXISTS migrations (
                         file_name text not null,
@@ -271,15 +279,15 @@ class AdminResource:
                     )
                     conn.commit()
 
-            self._schema_setup_event.set()
+            self.admin_context.schema_setup_event.set()
             logger.info("Schema setup complete in pid %d", os.getpid())
 
     def _import_recent(self) -> bool:
         """Return True if a bulk import completed in the last 5 minutes (or setup is complete when no shared timestamp)."""
-        if self._parent._last_import_time is None:
-            return self._parent._setup_complete()
+        if self.app_context.last_import_time is None:
+            return self.app_context.setup_complete()
         # Unlocked read: c_double is atomic on typical platforms; avoids lock contention on fast path
-        t = self._parent._last_import_time.get_obj().value
+        t = self.app_context.last_import_time.get_obj().value
         if not t:
             logger.info("No import recorded...")
             return False
@@ -302,8 +310,8 @@ class AdminResource:
         after_transfer = time.monotonic()
 
         if result["status"] == "success":
-            if self._parent._last_import_time is not None:
-                self._parent._last_import_time.value = time.time()
+            if self.app_context.last_import_time is not None:
+                self.app_context.last_import_time.value = time.time()
             total_time = after_transfer - before
             cards_sent = result.get("cards_sent", result["cards_loaded"])
             rate = cards_sent / total_time if total_time > 0 else 0
@@ -319,14 +327,14 @@ class AdminResource:
             # running the backfill ahead of the tag import scored every card as on-style on a
             # first boot, and nothing rescored until the next import. Oracle tags feed search
             # rather than scoring, so their position relative to the backfill does not matter.
-            _import_art_tags(self._conn_pool, self._bulk_data_fetcher)
+            _import_art_tags(self.app_context.writer_pool, self._bulk_data_fetcher)
             self.backfill_prefer_scores()
             self.backfill_cubecobra_scores()
-            _import_oracle_tags(self._conn_pool, self._bulk_data_fetcher)
-            self._parent._reload_engine(force=True)
+            _import_oracle_tags(self.app_context.writer_pool, self._bulk_data_fetcher)
+            self.app_context.reload_engine(force=True)
             self._clear_caches()
-            self._parent._last_import_time.value = time.time()
-            self._parent._setup_complete_cache = None
+            self.app_context.last_import_time.value = time.time()
+            self.app_context.invalidate_setup_complete()
             # Every step above logs its own duration; this closes the sequence with the wall
             # clock the operator actually waited, upsert through engine reload.
             logger.info("Import complete in %.2f seconds", time.monotonic() - before)
@@ -350,11 +358,11 @@ class AdminResource:
 
         logger.info("Hitting slowpath in pid %d", os.getpid())
 
-        import_lock = self._parent._last_import_time.get_lock()
+        import_lock = self.app_context.last_import_time.get_lock()
 
         acquired = import_lock.acquire(timeout=IMPORT_LOCK_TIMEOUT)
         if not acquired:
-            if self._parent._setup_complete():
+            if self.app_context.setup_complete():
                 logger.info(
                     "Timed out waiting %.0fs for import lock; setup complete, skipping in pid %d",
                     IMPORT_LOCK_TIMEOUT,
@@ -405,7 +413,7 @@ class AdminResource:
         logger.info("Starting prefer score backfill")
 
         backfill_sql = db_utils.read_sql("backfill_prefer_scores")
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self.app_context.writer_pool.connection() as conn, conn.cursor() as cursor:
             db_utils.set_statement_timeout(cursor, settings.prefer_score_backfill_timeout_ms)
             cursor.execute(backfill_sql)
             updated_count = cursor.rowcount
@@ -500,7 +508,7 @@ class AdminResource:
             ]
         )
 
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self.app_context.writer_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 """
                 WITH incoming AS (
@@ -552,7 +560,7 @@ class AdminResource:
         logger.info("Starting CubeCobra score backfill with weights: %s", weights)
 
         backfill_sql = db_utils.read_sql("backfill_cubecobra_scores")
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self.app_context.writer_pool.connection() as conn, conn.cursor() as cursor:
             db_utils.set_statement_timeout(cursor, 600_000)
             cursor.execute(backfill_sql, weights)
             updated_count = cursor.rowcount
@@ -592,7 +600,7 @@ class AdminResource:
         """
         logger.info("Starting CubeCobra ingest")
         # fetch the distinct, non-null oracle ids that are in the db
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self.app_context.writer_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 "SELECT DISTINCT oracle_id FROM magic.cards WHERE oracle_id IS NOT NULL",
             )
@@ -678,7 +686,7 @@ class AdminResource:
         # Update cards in database with the new is: tag
         updated_count = 0
         new_tag = orjson.dumps({is_tag: True}).decode("utf-8")
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self.app_context.writer_pool.connection() as conn, conn.cursor() as cursor:
             # Use SQL update with jsonb concatenation to add the is: tag
             for card_name_batch in itertools.batched(sorted(card_names), 500):
                 cursor.execute(
@@ -760,7 +768,7 @@ class AdminResource:
         updated_count = 0
         new_tag = orjson.dumps({is_tag: True}).decode("utf-8")
         scryfall_ids = {p["id"] for p in printings}
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self.app_context.writer_pool.connection() as conn, conn.cursor() as cursor:
             # Use SQL update with jsonb concatenation to add the is: tag
             for scryfall_id_batch in itertools.batched(sorted(scryfall_ids), 500):
                 cursor.execute(
@@ -822,12 +830,12 @@ class AdminResource:
     @route()
     def import_oracle_tags(self, **_: object) -> dict[str, Any]:
         """Import oracle tags from Scryfall bulk data into oracle_tags, oracle_tag_relationships, and card_oracle_tags."""
-        return _import_oracle_tags(self._conn_pool, self._bulk_data_fetcher)
+        return _import_oracle_tags(self.app_context.writer_pool, self._bulk_data_fetcher)
 
     @route()
     def import_art_tags(self, **_: object) -> dict[str, Any]:
         """Import art tags from Scryfall bulk data into art_tags, art_tag_relationships, and card_art_tags."""
-        return _import_art_tags(self._conn_pool, self._bulk_data_fetcher)
+        return _import_art_tags(self.app_context.writer_pool, self._bulk_data_fetcher)
 
     @route()
     def import_all_is_tags(self, **_: object) -> dict[str, Any]:
@@ -936,7 +944,7 @@ class AdminResource:
         logger.info("Importing card by name: '%s'", card_name)
 
         # Check if card already exists in database for backward compatibility
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self.app_context.writer_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 "SELECT card_name FROM magic.cards WHERE card_name = %(card_name)s",
                 {"card_name": card_name},
@@ -1001,7 +1009,7 @@ class AdminResource:
         load_result = self._upsert_cards(cards)
 
         if load_result["status"] == "success":
-            self._parent._reload_engine(force=True)
+            self.app_context.reload_engine(force=True)
 
         # Add search_query to the result for consistency
         load_result["search_query"] = search_query
@@ -1109,7 +1117,7 @@ class AdminResource:
         self.setup_schema()
 
         try:
-            with self._conn_pool.connection() as conn:
+            with self.app_context.writer_pool.connection() as conn:
                 with conn.cursor() as cursor:
                     db_utils.set_statement_timeout(cursor, 30_000)
 
@@ -1183,5 +1191,4 @@ class AdminResource:
             }
 
     def _clear_caches(self) -> None:
-        with self._parent._cache_generation.get_lock():
-            self._parent._cache_generation.value += 1
+        self.app_context.bump_cache_generation()

--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -1,0 +1,1164 @@
+"""Data-management handlers, mounted as a child resource rather than sharing the public namespace.
+
+These import, backfill and re-tag the card corpus. They are not part of the API a visitor uses, and
+nothing calls them over HTTP — `APIResource.__init__` calls two of them in-process at startup, and the
+rest are operator actions.
+
+They live here because registration used to have no way to say "not part of the public API": every
+public method became a route, and the only lever was a leading underscore, which also lies about a
+method's Python visibility. Mounting a separate resource replaces that lever with a boundary, and
+keeps the honest names.
+
+The child holds a reference to its parent for the small surface they genuinely share — five methods
+(`_reload_engine`, `_run_query`, `_serve_static_file`, `_set_statement_timeout`, `_setup_complete`)
+and four handles (`_conn_pool`, `_cache_generation`, `_last_import_time`, `_setup_complete_cache`).
+That is deliberately not a decoupling: the boundary here is about routing, and pretending otherwise
+would mean an `AppContext` refactor that the routing fix does not need.
+"""
+
+from __future__ import annotations
+
+import datetime
+import itertools
+import logging
+import os
+import re
+import time
+import uuid
+from typing import TYPE_CHECKING, Any
+
+# Imported at runtime, not under TYPE_CHECKING, because route handlers annotate falcon_response with
+# it and build_route_table resolves those annotations to real types at mount. Under TYPE_CHECKING the
+# name is absent at runtime and resolution raises UnresolvableAnnotationError — by design, rather than
+# silently losing coercion. Same reason api_resource keeps Sequence at runtime.
+import falcon  # noqa: TC002
+import orjson
+import psycopg
+import requests
+from cachebox import TTLCache
+
+from api.card_processing import preprocess_card
+from api.db.bulk_upsert import bulk_upsert as _bulk_upsert
+from api.scryfall_bulk_data_fetcher import BulkDataKey, ScryfallBulkDataFetcher
+from api.settings import settings
+from api.tag_import import import_art_tags as _import_art_tags
+from api.tag_import import import_oracle_tags as _import_oracle_tags
+from api.utils import db_utils
+from api.utils.caching import cached
+from api.utils.http_utils import make_user_agent
+from api.utils.routing import route
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+    from multiprocessing.synchronize import Event as EventType
+    from multiprocessing.synchronize import RLock as LockType
+
+    from psycopg import Connection
+
+    from api.api_resource import APIResource
+
+# Path prefix the child mounts under. Underscore-prefixed to match the convention API namespaces use
+# for internal routes (Elasticsearch _search, CouchDB _all_docs), and to stay clear of /admin, which
+# is among the most-scanned paths on the internet. The prefix is not a control — an unmounted path and
+# an unknown one return the same 404 — it just keeps the probe noise down.
+ADMIN_MOUNT_PREFIX = "_admin"
+
+logger = logging.getLogger(__name__)
+
+
+# pylint: disable=c-extension-no-member
+NOT_FOUND = 404
+
+MIN_IMPORT_INTERVAL = 300
+
+IMPORT_LOCK_TIMEOUT = 2
+
+
+# Cards per bulk_upsert call during an import. The whole batch becomes ONE bind parameter: a JSON
+# array that Postgres must receive, cast to jsonb, expand with jsonb_array_elements, and join against
+# magic.cards. So this value sets the server-side peak for the statement, and the corpus grows over
+# time — a size that fit once does not stay fitting. Lowered from 6000 to 3000 after backends were
+# lost mid-statement during import; the extra round trips are not measurable against the import's
+# total, and it halves the logged parameter too (see log_parameter_max_length in the pg config).
+_UPSERT_PAGE_SIZE = 3_000
+
+# is: values Scryfall ships as BOOLEANS on every bulk card object, synced
+# in one set-based statement from raw_card_blob after each import (see
+# _sync_boolean_is_tags) -- no per-tag API sweep, unlike CUSTOM_IS_TAGS
+# below, and no accumulation in the import loop. card_is_tags key -> raw
+# blob key; adding a field here is the whole change. foil/promo/reprint are
+# deliberately NOT here yet (higher cardinality, memory check first).
+BOOLEAN_IS_TAGS: dict[str, str] = {
+    "reserved": "reserved",
+    "gamechanger": "game_changer",
+}
+
+_SYNC_BOOLEAN_IS_TAGS_SQL = """
+WITH tag_map(tag, blob_key) AS (
+    SELECT key, value FROM jsonb_each_text(%(tag_map)s::jsonb)
+),
+proposed AS (
+    SELECT
+        cards.scryfall_id,
+        (cards.card_is_tags - (SELECT array_agg(tag_map.tag) FROM tag_map))
+            || COALESCE(
+                   (
+                       SELECT jsonb_object_agg(tag_map.tag, true)
+                       FROM tag_map
+                       WHERE cards.raw_card_blob -> tag_map.blob_key = 'true'::jsonb
+                   ),
+                   '{}'::jsonb
+               ) AS proposed_is_tags
+    FROM magic.cards
+)
+UPDATE magic.cards
+SET card_is_tags = proposed.proposed_is_tags
+FROM proposed
+WHERE
+    cards.scryfall_id = proposed.scryfall_id AND
+    cards.card_is_tags IS DISTINCT FROM proposed.proposed_is_tags
+"""
+
+CUSTOM_IS_TAGS = [
+    "historic",  # artifact, legendary, saga
+    "pathway",  # land and name contains pathway
+    "permanent",  # ...
+    "reprint",
+    "spell",  # ...
+    "unique",  # has exactly one printing
+    "old",  # 93/97 frame
+    "new",  # newer frames
+    "foil",  # foil version of a card
+    "nonfoil",  # non-foil version of a card
+    "datestamped",  # can get from the json promo_types array
+    "universesbeyond",  # can get from the json promo_types array
+    # I don't know how to do this, I just don't want to make the normal requests
+    "booster",
+    "default",
+]
+
+LAND_IS_TAGS = [
+    "bikeland",
+    "bondland",
+    "bounceland",
+    "canopyland",
+    "checkland",
+    "creatureland",
+    "fastland",
+    "fetchland",
+    "filterland",
+    "gainland",
+    "manland",
+    "painland",
+    "scryland",
+    "shadowland",
+    "shockland",
+    "slowland",
+    "storageland",
+    "surveilland",
+    "tangoland",
+    "tricycleland",
+    "triland",
+]
+
+CARD_IS_TAGS = LAND_IS_TAGS + [  # noqa: RUF005
+    "bear",  # easy to make custom, but also small
+    "commander",
+    "outlaw",  # based on creature type
+    "party",  # based on creature type
+    "reserved",
+    "vanilla",
+]
+
+
+class AdminResource:
+    """Data-management routes, mounted behind a path prefix by APIResource."""
+
+    def __init__(self, parent: APIResource, *, import_guard: LockType, schema_setup_event: EventType) -> None:
+        """Attach to the parent resource and take ownership of the admin-only handles.
+
+        Args:
+            parent: The resource this is mounted on, for the shared methods and handles.
+            import_guard: Cross-process lock serialising imports.
+            schema_setup_event: Set once the schema has been created.
+        """
+        self._parent = parent
+        self._import_guard = import_guard
+        self._schema_setup_event = schema_setup_event
+        self._session = requests.Session()
+        self._session.headers.update({"User-Agent": make_user_agent()})
+        self._bulk_data_fetcher = ScryfallBulkDataFetcher()
+
+    @route()
+    def setup_schema(self, *_: object, **__: object) -> None:
+        """Set up the database schema and apply migrations as needed."""
+        if self._schema_setup_event.is_set():
+            logger.info("Schema already setup (fastpath) in pid %d", os.getpid())
+            return
+
+        filesystem_migrations = db_utils.get_migrations()
+
+        with self._import_guard:
+            if self._schema_setup_event.is_set():
+                logger.info("Schema already setup (slowpath) in pid %d", os.getpid())
+                return
+            logger.info("Setting up schema in pid %d", os.getpid())
+            # read migrations from the db dir...
+            # if any already applied migrations differ from what we want
+            # to apply then drop everything
+            with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+                cursor.execute(
+                    """CREATE TABLE IF NOT EXISTS migrations (
+                        file_name text not null,
+                        file_sha256 text not null,
+                        date_applied timestamp default now(),
+                        file_contents text not null
+                    )""",
+                )
+                cursor.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_migrations_filename ON migrations (file_name)")
+                cursor.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_migrations_file_sha256 ON migrations USING HASH (file_sha256)",
+                )
+
+                cursor.execute("SELECT file_name, file_sha256 FROM migrations ORDER BY date_applied")
+                applied_migrations = [dict(r) for r in cursor]
+
+                already_applied = set()
+                for applied_migration, fs_migration in zip(applied_migrations, filesystem_migrations, strict=False):
+                    if applied_migration.items() <= fs_migration.items():
+                        already_applied.add(applied_migration["file_sha256"])
+                    else:
+                        already_applied.clear()
+                        cursor.execute("DELETE FROM migrations")
+                        cursor.execute("DROP SCHEMA IF EXISTS magic CASCADE")
+                        conn.commit()
+
+                for imigration in filesystem_migrations:
+                    file_sha256 = imigration["file_sha256"]
+                    if file_sha256 in already_applied:
+                        logger.info("%s was already applied...", imigration["file_name"])
+                        continue
+                    logger.info("Applying %s ...", imigration["file_name"])
+                    cursor.execute(imigration["file_contents"])
+                    cursor.execute(
+                        """
+                            INSERT INTO migrations
+                                (  file_name  ,   file_sha256  ,   file_contents  ) VALUES
+                                (%(file_name)s, %(file_sha256)s, %(file_contents)s)""",
+                        imigration,
+                    )
+                    conn.commit()
+
+            self._schema_setup_event.set()
+            logger.info("Schema setup complete in pid %d", os.getpid())
+
+    def _import_recent(self) -> bool:
+        """Return True if a bulk import completed in the last 5 minutes (or setup is complete when no shared timestamp)."""
+        if self._parent._last_import_time is None:
+            return self._parent._setup_complete()
+        # Unlocked read: c_double is atomic on typical platforms; avoids lock contention on fast path
+        t = self._parent._last_import_time.get_obj().value
+        if not t:
+            logger.info("No import recorded...")
+            return False
+        time_since_import = time.time() - t
+        retval = time_since_import < MIN_IMPORT_INTERVAL
+        logger.info("Last import was %d seconds ago, %s", time_since_import, retval)
+        return retval
+
+    def _run_import_under_lock(self) -> None:
+        """Run the import flow; caller must hold the import lock."""
+        if self._import_recent():
+            logger.info("Import recent slowpath...")
+            return
+        self.setup_schema()
+
+        before = time.monotonic()
+
+        result = self._upsert_cards(self._bulk_data_fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        after_transfer = time.monotonic()
+
+        if result["status"] == "success":
+            if self._parent._last_import_time is not None:
+                self._parent._last_import_time.value = time.time()
+            total_time = after_transfer - before
+            cards_sent = result.get("cards_sent", result["cards_loaded"])
+            rate = cards_sent / total_time if total_time > 0 else 0
+            logger.info(
+                "Loaded %d cards (%d new, %d updated) in %.2f seconds, rate: %.2f cards/s...",
+                result["cards_loaded"],
+                result.get("cards_inserted", 0),
+                result.get("cards_updated", 0),
+                total_time,
+                rate,
+            )
+            # Art tags first: the prefer score's art_style component reads card_art_tags, so
+            # running the backfill ahead of the tag import scored every card as on-style on a
+            # first boot, and nothing rescored until the next import. Oracle tags feed search
+            # rather than scoring, so their position relative to the backfill does not matter.
+            _import_art_tags(self._parent._conn_pool, self._bulk_data_fetcher)
+            self.backfill_prefer_scores()
+            self.backfill_cubecobra_scores()
+            _import_oracle_tags(self._parent._conn_pool, self._bulk_data_fetcher)
+            self._parent._reload_engine(force=True)
+            self._clear_caches()
+            self._parent._last_import_time.value = time.time()
+            self._parent._setup_complete_cache = None
+            # Every step above logs its own duration; this closes the sequence with the wall
+            # clock the operator actually waited, upsert through engine reload.
+            logger.info("Import complete in %.2f seconds", time.monotonic() - before)
+            return
+        logger.error("Failed to import data: %s", result["message"])
+        return
+
+    @cached(
+        cache=TTLCache(maxsize=1, global_ttl=MIN_IMPORT_INTERVAL),
+    )
+    @route()
+    def import_data(self, **_: object) -> None:
+        """Import data from Scryfall and insert into the database."""
+        before = time.monotonic()
+        if self._import_recent():
+            after = time.monotonic()
+            total_time = after - before
+            logger.info("Import recent fastpath took %.2f seconds in pid %d", total_time, os.getpid())
+            # check without taking the lock so the majority of the time we never take the lock
+            return None
+
+        logger.info("Hitting slowpath in pid %d", os.getpid())
+
+        import_lock = self._parent._last_import_time.get_lock()
+
+        acquired = import_lock.acquire(timeout=IMPORT_LOCK_TIMEOUT)
+        if not acquired:
+            if self._parent._setup_complete():
+                logger.info(
+                    "Timed out waiting %.0fs for import lock; setup complete, skipping in pid %d",
+                    IMPORT_LOCK_TIMEOUT,
+                    os.getpid(),
+                )
+                return None
+            # acquire with no timeout...
+            import_lock.acquire()
+        try:
+            return self._run_import_under_lock()
+        finally:
+            import_lock.release()
+
+    @route()
+    def prefer_score_tuner(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
+        """Return the prefer score tuner page.
+
+        Args:
+        ----
+            falcon_response (falcon.Response): The Falcon response to write to.
+
+        """
+        self._parent._serve_static_file(filename="prefer_score_tuner.html", falcon_response=falcon_response)
+        falcon_response.content_type = "text/html"
+
+    @route()
+    def backfill_prefer_scores(self, **_: object) -> dict[str, Any]:
+        """Backfill prefer_score and prefer_score_components for all cards.
+
+        This endpoint recalculates the prefer score for all existing cards based on:
+        - Border color (black: 14, white: 0)
+        - Frame version (2015: 42, 2003: 30)
+        - Artwork popularity (logarithmic scaling: 23 * ln(count) / ln(40))
+        - Rarity (common: 16, uncommon: 16, rare: 11, mythic: 0)
+        - Extended art (12 points if present)
+        - Highres scan (8 points if image_status='highres_scan')
+        - Has paper (6 points if 'paper' in games array)
+        - Language (English: 40 points)
+        - Legendary frame (5 points if 'legendary' in frame_effects)
+        - Non-showcase (10 points if 'showcase' not in frame_effects)
+        - Finish (nonfoil: 10, foil: 5, etched: 0)
+        - Artwork set (full-color: 20, black/white: 0)
+
+        Returns:
+            Dict with status and count of cards updated
+        """
+        start = time.monotonic()
+        logger.info("Starting prefer score backfill")
+
+        backfill_sql = db_utils.read_sql("backfill_prefer_scores")
+        with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+            self._parent._set_statement_timeout(cursor, settings.prefer_score_backfill_timeout_ms)
+            cursor.execute(backfill_sql)
+            updated_count = cursor.rowcount
+
+            # Get count of updated cards
+            cursor.execute("SELECT COUNT(*) as count FROM magic.cards WHERE prefer_score IS NOT NULL")
+            result = cursor.fetchone()
+            total_cards = result["count"] if result else 0
+
+            conn.commit()
+
+        # cards_updated counts only rows whose score actually moved -- the backfill's UPDATE
+        # skips rows already carrying the right value, so a steady-state re-run reports 0 of N
+        # rather than N of N. Both numbers are worth having: the first says how much churned,
+        # the second that the corpus is fully scored.
+        stats = {
+            "duration_seconds": round(time.monotonic() - start, 2),
+            "cards_updated": updated_count,
+            "cards_scored": total_cards,
+        }
+        logger.info("Prefer score backfill complete: %s", stats)
+
+        return {
+            "status": "success",
+            "message": f"Successfully backfilled prefer scores for {updated_count} of {total_cards} cards",
+            **stats,
+        }
+
+    def _fetch_cubecobra_data(self, db_oracle_ids: set[uuid.UUID]) -> dict[uuid.UUID, dict[str, Any]]:
+        """Paginate the CubeCobra top-cards API and return data keyed by oracle_id.
+
+        Returns:
+            Mapping of oracle_id -> {elo, cube_count, pick_count, popularity}.
+        """
+        cubecobra_url = "https://cubecobra.com/tool/api/topcards/"
+        page = 1
+
+        while True:
+            time.sleep(0.5)
+            logger.info("Fetching CubeCobra page %d", page)
+            response = self._session.get(
+                cubecobra_url,
+                params={"p": page, "f": "", "s": "Elo", "d": "descending"},
+                timeout=30,
+            )
+            response.raise_for_status()
+            cards = response.json().get("data") or []
+
+            if not cards:
+                logger.info("Empty page %d - done paginating CubeCobra", page)
+                break
+
+            results: dict[uuid.UUID, dict[str, Any]] = {}
+            for card in cards:
+                oracle_id_str = card.get("oracle_id")
+                if not oracle_id_str:
+                    continue
+                try:
+                    oracle_id = uuid.UUID(oracle_id_str)
+                except ValueError:
+                    logger.warning("CubeCobra returned malformed oracle_id %r on page %d", oracle_id_str, page)
+                    continue
+                if oracle_id in db_oracle_ids:
+                    results[oracle_id] = {
+                        "elo": card.get("elo"),
+                        "cube_count": card.get("cubeCount"),
+                        "pick_count": card.get("pickCount"),
+                    }
+
+            logger.info("CubeCobra page %d: %d cards (total: %d)", page, len(cards), len(results))
+            page += 1
+            yield results
+
+    def _insert_cubecobra_data(self, cubecobra_data: dict[uuid.UUID, dict[str, Any]]) -> int:
+        """Write CubeCobra data into magic.cards, matching on oracle_id.
+
+        Args:
+            cubecobra_data: Mapping of oracle_id -> data dict from _fetch_cubecobra_data().
+
+        Returns:
+            Total number of card rows updated.
+        """
+        records = db_utils.maybe_json(
+            [
+                {
+                    "elo": data["elo"],
+                    "cube_count": data["cube_count"],
+                    "pick_count": data["pick_count"],
+                    "oracle_id": oracle_id,
+                }
+                for oracle_id, data in cubecobra_data.items()
+            ]
+        )
+
+        with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+            cursor.execute(
+                """
+                WITH incoming AS (
+                    SELECT * FROM jsonb_to_recordset(%(records)s) AS t(
+                        elo real, cube_count integer, pick_count integer, oracle_id uuid
+                    )
+                )
+                UPDATE magic.cards
+                SET
+                    cubecobra_elo        = incoming.elo,
+                    cubecobra_cube_count = incoming.cube_count,
+                    cubecobra_pick_count = incoming.pick_count
+                FROM incoming
+                WHERE magic.cards.oracle_id = incoming.oracle_id
+                """,
+                {"records": records},
+            )
+            total_updated = cursor.rowcount
+            conn.commit()
+
+        return total_updated
+
+    @route()
+    def backfill_cubecobra_scores(self, **_: object) -> dict[str, Any]:
+        """Backfill cubecobra_score for all cards.
+
+        Computes a weighted average of per-dimension PERCENT_RANK values (each in the 0-1
+        range, where 0 is best and 1 is worst) and scales the result to a 0-100 score
+        (0 = best, 100 = worst).
+
+        The per-dimension weights are treated as relative and are internally normalized so
+        that their sum is 100. Callers may supply any non-negative weights; they do not need
+        to sum to 1.0.
+
+        One score per distinct card_name is computed and then propagated to all printings.
+
+        Returns:
+            Dict with status and count of cards updated.
+        """
+        weights = {
+            "w_cube_count": 1,
+            "w_edhrec": 1,
+            "w_elo": 1,
+            "w_pick_count": 1,
+        }
+        start = time.monotonic()
+        scale_factor = sum(weights.values()) / 100.0
+        weights = {k: v / scale_factor for k, v in weights.items()}
+        logger.info("Starting CubeCobra score backfill with weights: %s", weights)
+
+        backfill_sql = db_utils.read_sql("backfill_cubecobra_scores")
+        with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+            self._parent._set_statement_timeout(cursor, 600_000)
+            cursor.execute(backfill_sql, weights)
+            updated_count = cursor.rowcount
+
+            # The percent ranks are computed over cubecobra_elo and friends, which the normal
+            # import never populates -- they arrive via ingest_cubecobra. Reporting how many
+            # cards actually carry that data distinguishes "ranked the whole corpus" from
+            # "ranked a corpus of all-NULLs", which otherwise look identical in the log.
+            cursor.execute("SELECT COUNT(*) as count FROM magic.cards WHERE cubecobra_elo IS NOT NULL")
+            result = cursor.fetchone()
+            cards_with_data = result["count"] if result else 0
+
+            conn.commit()
+
+        stats = {
+            "duration_seconds": round(time.monotonic() - start, 2),
+            "cards_updated": updated_count,
+            "cards_with_cubecobra_data": cards_with_data,
+        }
+        logger.info("CubeCobra score backfill complete: %s", stats)
+        return {
+            "status": "success",
+            "weights": weights,
+            **stats,
+        }
+
+    @route()
+    def ingest_cubecobra(self, **_: object) -> dict[str, Any]:
+        """Fetch card data from CubeCobra and store it in magic.cards.
+
+        Paginates the CubeCobra top-cards API, then updates all matching rows
+        in magic.cards (matched on oracle_id). Cards not present in CubeCobra
+        are left with NULL values for the cubecobra_* columns.
+
+        Returns:
+            Dict with status and count of rows updated.
+        """
+        logger.info("Starting CubeCobra ingest")
+        # fetch the distinct, non-null oracle ids that are in the db
+        with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+            cursor.execute(
+                "SELECT DISTINCT oracle_id FROM magic.cards WHERE oracle_id IS NOT NULL",
+            )
+            db_oracle_ids = {r["oracle_id"] for r in cursor.fetchall()}
+
+        for cubecobra_page in self._fetch_cubecobra_data(db_oracle_ids):
+            logger.info("Fetched %d oracle_ids from CubeCobra", len(cubecobra_page))
+            cards_updated = self._insert_cubecobra_data(cubecobra_page)
+        logger.info("CubeCobra ingest complete: %d card rows updated", cards_updated)
+
+        backfill_result = self.backfill_cubecobra_scores()
+        self._clear_caches()
+
+        return {
+            "status": "success",
+            "cards_updated": cards_updated,
+            "scores_backfilled": backfill_result["cards_updated"],
+        }
+
+    def _add_is_tag_to_cards_or_printings(self, *, is_tag: str) -> dict[str, Any]:
+        """Add a specific is: tag to all cards or printings matching that tag using Scryfall search.
+
+        Args:
+        ----
+            is_tag (str): The is: tag to fetch and apply to cards (e.g., 'creature', 'spell').
+
+        Returns:
+        -------
+            Dict[str, Any]: Result summary with updated card count and tag info.
+
+        """
+        # TODO: is tags are not based on card name, but rather specific printing
+        # meaning this needs to not use unique on cards, but instead do unique printing
+        # which means it's gonna be hella slow
+
+        if not is_tag:
+            msg = "is_tag parameter is required"
+            raise ValueError(msg)
+
+        if is_tag in CUSTOM_IS_TAGS:
+            return self._add_is_tag_to_custom(is_tag=is_tag)
+        if is_tag in CARD_IS_TAGS:
+            return self._add_is_tag_to_cards(is_tag=is_tag)
+        return self._add_is_tag_to_printings(is_tag=is_tag)
+
+    def _add_is_tag_to_custom(self, *, is_tag: str) -> dict[str, Any]:
+        """Add a specific is: tag to all custom cards matching that tag using Scryfall search."""
+        # these are special cases where you can phrase the tag as a query over other properties
+        logger.info("Adding is:%s to custom cards", is_tag)
+        return {
+            "cards_updated": 0,
+            "is_tag": is_tag,
+            "message": f"Custom is: tag {is_tag} is not supported",
+            "total_cards_found": 0,
+        }
+
+    def _add_is_tag_to_cards(self, *, is_tag: str) -> dict[str, Any]:
+        """Add a specific is: tag to all cards matching that tag using Scryfall search.
+
+        Args:
+        ----
+            is_tag (str): The is: tag to fetch and apply to cards (e.g., 'creature', 'spell').
+
+        Returns:
+        -------
+            Dict[str, Any]: Result summary with updated card count and tag info.
+
+        """
+        # Fetch cards with this is: tag from Scryfall API (handles pagination)
+        cards = self._scryfall_search(query=f"is:{is_tag}", unique="cards")
+        card_names = {c["name"] for c in cards}
+
+        if not cards:
+            logger.warning("No cards found with is:%s in Scryfall API", is_tag)
+            return {
+                "is_tag": is_tag,
+                "cards_updated": 0,
+                "total_cards_found": 0,
+                "message": f"No cards found with is:{is_tag} in Scryfall API",
+            }
+
+        logger.info("Updating %d cards with is:%s", len(card_names), is_tag)
+        # Update cards in database with the new is: tag
+        updated_count = 0
+        new_tag = orjson.dumps({is_tag: True}).decode("utf-8")
+        with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+            # Use SQL update with jsonb concatenation to add the is: tag
+            for card_name_batch in itertools.batched(sorted(card_names), 500):
+                cursor.execute(
+                    """
+                    UPDATE
+                        magic.cards
+                    SET
+                        card_is_tags = card_is_tags || %(new_tag)s::jsonb
+                    WHERE
+                        card_name = ANY(%(card_names)s) AND
+                        not(card_is_tags @> %(new_tag)s::jsonb)
+                    """,
+                    {
+                        "card_names": list(card_name_batch),
+                        "new_tag": new_tag,
+                    },
+                )
+                updated_count += cursor.rowcount
+                conn.commit()
+
+        return {
+            "is_tag": is_tag,
+            "cards_updated": updated_count,
+            "total_cards_found": len(card_names),
+            "message": f"Successfully updated {updated_count} cards with is:{is_tag}",
+        }
+
+    def _sync_boolean_is_tags(self, conn: Connection) -> int:
+        """Sync the boolean-backed is: tags (BOOLEAN_IS_TAGS) from raw_card_blob, one-shot.
+
+        Rebuilds each card's managed keys as (existing minus managed) plus the keys whose
+        blob boolean is true, touching only rows whose result actually differs -- so list
+        churn (a card entering or leaving the game-changer roster) converges on every
+        import, and unrelated card_is_tags entries are never disturbed.
+
+        Args:
+        ----
+            conn (Connection): open connection; committed here.
+
+        Returns:
+        -------
+            int: rows whose card_is_tags changed.
+
+        """
+        with conn.cursor() as cursor:
+            cursor.execute(_SYNC_BOOLEAN_IS_TAGS_SQL, {"tag_map": orjson.dumps(BOOLEAN_IS_TAGS).decode("utf-8")})
+            updated_count = cursor.rowcount
+        conn.commit()
+        if updated_count:
+            logger.info("Synced boolean is: tags on %d printings", updated_count)
+        return updated_count
+
+    def _add_is_tag_to_printings(self, *, is_tag: str) -> dict[str, Any]:
+        """Add a specific is: tag to all printings matching that tag using Scryfall search.
+
+        Args:
+        ----
+            is_tag (str): The is: tag to fetch and apply to printings (e.g., 'creature', 'spell').
+
+        Returns:
+        -------
+            Dict[str, Any]: Result summary with updated card count and tag info.
+
+        """
+        # Fetch cards with this is: tag from Scryfall API (handles pagination)
+        printings = self._scryfall_search(query=f"is:{is_tag}", unique="printings")
+
+        if not printings:
+            logger.warning("No printings found with is:%s in Scryfall API", is_tag)
+            return {
+                "is_tag": is_tag,
+                "cards_updated": 0,
+                "total_cards_found": 0,
+                "message": f"No cards found with is:{is_tag} in Scryfall API",
+            }
+
+        logger.info("Updating %d printings with is:%s", len(printings), is_tag)
+        # Update cards in database with the new is: tag
+        updated_count = 0
+        new_tag = orjson.dumps({is_tag: True}).decode("utf-8")
+        scryfall_ids = {p["id"] for p in printings}
+        with self._parent._conn_pool.connection() as conn, conn.cursor() as cursor:
+            # Use SQL update with jsonb concatenation to add the is: tag
+            for scryfall_id_batch in itertools.batched(sorted(scryfall_ids), 500):
+                cursor.execute(
+                    """
+                    UPDATE
+                        magic.cards
+                    SET
+                        card_is_tags = card_is_tags || %(new_tag)s::jsonb
+                    WHERE
+                        scryfall_id = ANY(%(scryfall_ids)s) AND
+                        not(card_is_tags @> %(new_tag)s::jsonb)
+                    """,
+                    {
+                        "scryfall_ids": list(scryfall_id_batch),
+                        "new_tag": new_tag,
+                    },
+                )
+                updated_count += cursor.rowcount
+                conn.commit()
+
+        return {
+            "is_tag": is_tag,
+            "cards_updated": updated_count,
+            "total_cards_found": len(scryfall_ids),
+            "message": f"Successfully updated {updated_count} printings with is:{is_tag}",
+        }
+
+    @route()
+    def discover_is_tags_from_syntax(self, **_: object) -> list[str]:
+        """Discover all available is: tags from Scryfall syntax documentation.
+
+        Returns:
+        -------
+            List[str]: List of all available is: tag names.
+
+        Raises:
+        ------
+            ValueError: If API request fails or returns invalid data.
+
+        """
+        try:
+            response = self._session.get("https://scryfall.com/docs/syntax", timeout=30)
+            response.raise_for_status()
+        except requests.RequestException as e:
+            msg = f"Failed to fetch is: tags from Scryfall syntax: {e}"
+            raise ValueError(msg) from e
+
+        # Extract is: tag names from the documentation
+        # Look for patterns like "is:permanent", "is:spell", etc.
+        is_tag_pattern = r"is:([a-zA-Z_-]+)"
+        matches = re.findall(is_tag_pattern, response.text)
+
+        # Remove duplicates and sort
+        unique_is_tags = sorted({match.lower() for match in matches})
+
+        logger.info("Discovered %d unique is: tags from Scryfall syntax", len(unique_is_tags))
+        return unique_is_tags
+
+    @route()
+    def import_oracle_tags(self, **_: object) -> dict[str, Any]:
+        """Import oracle tags from Scryfall bulk data into oracle_tags, oracle_tag_relationships, and card_oracle_tags."""
+        return _import_oracle_tags(self._parent._conn_pool, self._bulk_data_fetcher)
+
+    @route()
+    def import_art_tags(self, **_: object) -> dict[str, Any]:
+        """Import art tags from Scryfall bulk data into art_tags, art_tag_relationships, and card_art_tags."""
+        return _import_art_tags(self._parent._conn_pool, self._bulk_data_fetcher)
+
+    @route()
+    def import_all_is_tags(self, **_: object) -> dict[str, Any]:
+        """Discover and import all is: tags from Scryfall syntax documentation.
+
+        Returns:
+        -------
+            Dict[str, Any]: Summary of the bulk is: tag import operation.
+
+        """
+        result: dict[str, Any] = {
+            "success": True,
+        }
+        logger.info("Starting bulk is: tag discovery and import")
+
+        try:
+            all_is_tags = self.discover_is_tags_from_syntax()
+        except ValueError as e:
+            result.update(
+                {
+                    "success": False,
+                    "error": str(e),
+                    "message": "Failed to discover is: tags from Scryfall syntax",
+                },
+            )
+            return result
+
+        if not all_is_tags:
+            return {
+                "success": False,
+                "message": "No is: tags discovered from Scryfall syntax",
+            }
+
+        # Import card associations for each is: tag
+        start_time = time.monotonic()
+        imported_tags = []
+        failed_tags = []
+        total_cards_updated = 0
+
+        for idx, is_tag in enumerate(all_is_tags):
+            try:
+                if idx > 0:
+                    elapsed_time = time.monotonic() - start_time
+                    fraction_complete = idx / len(all_is_tags)
+                    estimated_time_remaining = (elapsed_time / fraction_complete) - elapsed_time
+                    estimated_duration = datetime.timedelta(seconds=round(estimated_time_remaining, 1))
+                    logger.info(
+                        "Importing is: tag %d of %d: %20s (ETA: %s)",
+                        idx + 1,
+                        len(all_is_tags),
+                        is_tag,
+                        estimated_duration,
+                    )
+
+                tag_result = self._add_is_tag_to_cards_or_printings(is_tag=is_tag)
+                imported_tags.append(
+                    {
+                        "is_tag": is_tag,
+                        "cards_updated": tag_result["cards_updated"],
+                        "total_cards_found": tag_result["total_cards_found"],
+                    },
+                )
+                total_cards_updated += tag_result["cards_updated"]
+
+            except ValueError as e:
+                logger.warning("Failed to import is: tag '%s': %s", is_tag, e)
+                failed_tags.append({"is_tag": is_tag, "error": str(e)})
+
+        result.update(
+            {
+                "duration": time.monotonic() - start_time,
+                "discovered_is_tags": len(all_is_tags),
+                "imported_is_tags": len(imported_tags),
+                "failed_is_tags": len(failed_tags),
+                "total_cards_updated": total_cards_updated,
+                "imported_tags": imported_tags,
+                "failed_tags": failed_tags,
+                "message": f"Successfully imported {len(imported_tags)} is: tags, {len(failed_tags)} failed",
+            },
+        )
+
+        return result
+
+    @route()
+    def import_card_by_name(
+        self,
+        *,
+        card_name: str,
+        **_: object,
+    ) -> dict[str, Any]:
+        """Import a single card by name from Scryfall API.
+
+        Args:
+        ----
+            card_name (str): The exact name of the card to import.
+
+        Returns:
+        -------
+            Dict[str, Any]: Result summary with import status and card info.
+
+        """
+        if not card_name:
+            msg = "card_name parameter is required"
+            raise ValueError(msg)
+
+        logger.info("Importing card by name: '%s'", card_name)
+
+        # Check if card already exists in database for backward compatibility
+        existing_check = self._parent._run_query(
+            query="SELECT card_name FROM magic.cards WHERE card_name = %(card_name)s",
+            params={"card_name": card_name},
+            explain=False,
+        )
+
+        if existing_check["result"]:
+            return {
+                "card_name": card_name,
+                "status": "already_exists",
+                "message": f"Card '{card_name}' already exists in database",
+            }
+
+        # Use import_cards_by_search with exact name query
+        return self.import_cards_by_search(search_query=f'!"{card_name}"')
+
+    @route()
+    def import_cards_by_search(
+        self,
+        *,
+        search_query: str,
+        **_: object,
+    ) -> dict[str, Any]:
+        """Import cards from Scryfall API using any search query.
+
+        Args:
+        ----
+            search_query (str): The Scryfall search query to execute.
+
+        Returns:
+        -------
+            Dict[str, Any]: Result summary with import status and card info.
+
+        """
+        if not search_query:
+            msg = "search_query parameter is required"
+            raise ValueError(msg)
+
+        logger.info("Importing cards by search: '%s'", search_query)
+
+        # Fetch card data from Scryfall API using the provided search query
+        try:
+            cards = self._scryfall_search(query=search_query)
+            if not cards:
+                return {
+                    "search_query": search_query,
+                    "status": "not_found",
+                    "message": f"No cards found for search query '{search_query}' in Scryfall API",
+                    "cards_loaded": 0,
+                }
+
+        except (requests.RequestException, ValueError, KeyError) as e:
+            logger.error("Error fetching cards for search '%s' from Scryfall: %s", search_query, e)
+            return {
+                "search_query": search_query,
+                "status": "error",
+                "message": f"Error fetching cards from Scryfall: {e}",
+                "cards_loaded": 0,
+            }
+
+        # Insert the cards into the database using the consolidated method
+        load_result = self._upsert_cards(cards)
+
+        if load_result["status"] == "success":
+            self._parent._reload_engine(force=True)
+
+        # Add search_query to the result for consistency
+        load_result["search_query"] = search_query
+
+        return load_result
+
+    def _scryfall_search(self, *, query: str, unique: str = "prints") -> list[dict[str, Any]]:
+        """Search Scryfall API for cards matching the given query.
+
+        This method handles pagination to get the complete list of cards and
+        automatically applies filters for paper format and format legality.
+
+        Args:
+        ----
+            query (str): The search query string for Scryfall.
+            unique (str): The unique parameter to pass to the Scryfall API.
+
+        Returns:
+        -------
+            List[Dict[str, Any]]: List of card data from Scryfall API.
+
+        Raises:
+        ------
+            ValueError: If API request fails or returns invalid data.
+
+        """
+        # Add standard filters for paper format and format legality
+        # Wrap original query in parentheses to ensure proper filter application
+        filters = [
+            "(f:m or f:l or f:c or f:v)",
+            "game:paper",
+            f"unique:{unique}",
+        ]
+        full_query = f"({query}) {' '.join(filters)}"
+
+        base_url = "https://api.scryfall.com/cards/search"
+        params = {"q": full_query, "format": "json"}
+        all_cards = []
+
+        total_cards = "?"
+        try:
+            while True:
+                time.sleep(1 / 10)  # Rate limiting - 10 requests per second max
+                logger.info(
+                    "Making request to Scryfall API: %s %s (have %d of %s total cards)",
+                    base_url,
+                    params,
+                    len(all_cards),
+                    total_cards,
+                )
+                response = self._session.get(base_url, params=params, timeout=30)
+                response.raise_for_status()
+                data = orjson.loads(response.content)
+
+                total_cards = data.get("total_cards", 1) or 1
+
+                if "data" not in data:
+                    break
+
+                # Extract card data from current page
+                page_cards = [card for card in data["data"] if card]
+                all_cards.extend(page_cards)
+
+                # Check if there are more pages
+                if not data.get("has_more", False):
+                    break
+
+                # Get next page URL
+                next_page = data.get("next_page")
+                if not next_page:
+                    break
+
+                # Update base_url and clear params for next page
+                base_url = next_page
+                params = {}
+
+        except requests.RequestException as oops:
+            # Check if it's a 404 error - return empty list
+            if (hasattr(oops, "response") and oops.response and oops.response.status_code == NOT_FOUND) or "404" in str(oops):
+                return all_cards
+            msg = f"Failed to fetch data from Scryfall API: {oops}"
+            raise ValueError(msg) from oops
+
+        return all_cards
+
+    def _upsert_cards(
+        self,
+        cards: Iterable[dict[str, Any]],
+        page_size: int = _UPSERT_PAGE_SIZE,
+    ) -> dict[str, Any]:
+        """Preprocess and upsert an iterable of raw card dicts into magic.cards.
+
+        Preprocessing is applied lazily as cards flow through, so the full dataset
+        is never held in memory. Each batch is upserted via bulk_upsert: new rows
+        are inserted, changed rows are updated, and unchanged rows are skipped.
+
+        Returns a dict with:
+            - cards_inserted: new cards added
+            - cards_updated: existing cards with changed data
+            - cards_loaded: cards_inserted + cards_updated
+            - cards_sent: rows attempted (after preprocessing)
+            - status: "success", "no_cards_before_preprocessing", "no_cards_after_preprocessing", "database_error"
+            - message: descriptive message
+        """
+        self.setup_schema()
+
+        try:
+            with self._parent._conn_pool.connection() as conn:
+                with conn.cursor() as cursor:
+                    self._parent._set_statement_timeout(cursor, 30_000)
+
+                class _CardStream:
+                    """Preprocesses raw cards lazily, tracking stage counts."""
+
+                    def __init__(self) -> None:
+                        self.raw = 0
+                        self.preprocessed = 0
+
+                    def __iter__(self) -> Iterator[dict[str, Any]]:
+                        for card in cards:
+                            self.raw += 1
+                            for processed in preprocess_card(card):
+                                self.preprocessed += 1
+                                yield processed
+
+                stream = _CardStream()
+                cards_inserted = cards_updated = cards_sent = 0
+
+                for page in itertools.batched(stream, page_size):
+                    batch = _bulk_upsert(
+                        conn,
+                        "cards",
+                        list(page),
+                        schema="magic",
+                        conflict_target=["scryfall_id"],
+                        skip_columns=["card_oracle_tags", "card_art_tags", "card_is_tags"],
+                    )
+                    cards_sent += len(page)
+                    cards_inserted += batch["inserted"]
+                    cards_updated += batch["updated"]
+                    logger.info(
+                        "%d inserted, %d updated, %d sent so far",
+                        cards_inserted,
+                        cards_updated,
+                        cards_sent,
+                    )
+
+                conn.commit()
+
+                if cards_sent:
+                    self._sync_boolean_is_tags(conn)
+
+                if cards_sent == 0:
+                    if stream.raw == 0:
+                        status, message = "no_cards_before_preprocessing", "No cards provided for loading"
+                    else:
+                        status, message = "no_cards_after_preprocessing", "No cards remaining after preprocessing"
+                    logger.info("No cards imported: %s (raw=%d preprocessed=%d)", message, stream.raw, stream.preprocessed)
+                    return {"status": status, "cards_loaded": 0, "cards_sent": 0, "message": message}
+
+                cards_loaded = cards_inserted + cards_updated
+                self._clear_caches()
+                return {
+                    "status": "success",
+                    "cards_inserted": cards_inserted,
+                    "cards_updated": cards_updated,
+                    "cards_loaded": cards_loaded,
+                    "cards_sent": cards_sent,
+                    "message": f"Successfully loaded {cards_loaded} cards ({cards_inserted} new, {cards_updated} updated)",
+                }
+
+        except (psycopg.Error, ValueError, KeyError) as e:
+            logger.exception("Error loading cards")
+            return {
+                "status": "database_error",
+                "cards_loaded": 0,
+                "cards_sent": 0,
+                "message": f"Error loading cards: {type(e).__name__}: {e}",
+            }
+
+    def _clear_caches(self) -> None:
+        with self._parent._cache_generation.get_lock():
+            self._parent._cache_generation.value += 1

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -26,7 +26,7 @@ import orjson
 import psycopg
 import psycopg_pool
 from cachebox import LRUCache, TTLCache
-from psycopg import Connection, Cursor
+from psycopg import Connection
 
 from api.admin_resource import ADMIN_MOUNT_PREFIX, AdminResource
 from api.enums import CardOrdering, PreferOrder, ResponseShape, SortDirection, UniqueOn
@@ -37,7 +37,13 @@ from api.settings import settings
 from api.utils import db_utils, error_monitoring, multiprocessing_utils
 from api.utils.css_utils import build_critical_css
 from api.utils.generation_cache import GenerationCache
-from api.utils.page_rendering import SITE_NAME_PLACEHOLDER, STATIC_DIR, build_base_html, build_card_html
+from api.utils.page_rendering import (
+    SITE_NAME_PLACEHOLDER,
+    STATIC_DIR,
+    build_base_html,
+    build_card_html,
+    serve_static_file,
+)
 from api.utils.param_binding import ParamCoercionError
 from api.utils.routing import build_route_table, build_routes_listing, route
 from api.utils.site_name import hostname_to_site_name
@@ -241,7 +247,7 @@ def _columnarize_cards(cards: list[dict[str, Any]]) -> dict[str, list[Any]]:
 class APIResource:
     """Class implementing request handling for our simple API."""
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         *,
         import_guard: LockType = multiprocessing_utils.DEFAULT_LOCK,
@@ -249,13 +255,28 @@ class APIResource:
         schema_setup_event: EventType = multiprocessing_utils.DEFAULT_EVENT,
         cache_generation: Synchronized | None = None,
         engine_reload_guard: LockType | None = None,
+        conn_pool: psycopg_pool.ConnectionPool | None = None,
+        admin_conn_pool: psycopg_pool.ConnectionPool | None = None,
     ) -> None:
         """Initialize an APIResource object, set up connection pool and action map.
 
         Sets up the database connection pool and action mapping for the API.
+
+        Args:
+            import_guard: Cross-process lock serialising imports.
+            last_import_time: Shared timestamp of the last completed import.
+            schema_setup_event: Set once the schema has been created.
+            cache_generation: Shared counter bumped to invalidate the query-result cache.
+            engine_reload_guard: Cross-process lock serialising engine reloads.
+            conn_pool: This resource's own connection pool. Built via `db_utils.make_pool()` if not
+                given, matching every other handle here -- a caller (a test, mainly) can inject one
+                without a real pool ever opening a connection.
+            admin_conn_pool: The connection pool handed to the mounted AdminResource. Built the same
+                way if not given; kept separate from `conn_pool` so a test can inject the two
+                independently.
         """
         self._critical_css: str = build_critical_css(STATIC_DIR / "styles.css")
-        self._conn_pool: psycopg_pool.ConnectionPool = db_utils.make_pool()
+        self._conn_pool: psycopg_pool.ConnectionPool = conn_pool or db_utils.make_pool()
         # Build the route table from methods marked with @route, scanning the class rather than this
         # instance so nothing assigned below can become a route. Each entry carries everything
         # dispatch needs — the wrapped handler, how many positional path segments it absorbs, and
@@ -279,30 +300,17 @@ class APIResource:
         # Mounted after the parent's own state exists, since the child reaches back for the handles
         # they share. advertise=False is set here rather than on each handler: forgetting it is then
         # a property of this one call, not a hole in one route.
-        self.admin = AdminResource(self, import_guard=import_guard, schema_setup_event=schema_setup_event)
+        self.admin = AdminResource(
+            self,
+            conn_pool=admin_conn_pool or db_utils.make_pool(),
+            import_guard=import_guard,
+            schema_setup_event=schema_setup_event,
+        )
         self.routes.update(build_route_table(self.admin, prefix=ADMIN_MOUNT_PREFIX, advertise=False))
         self._not_found_routes = build_routes_listing(self.routes)
 
         self.admin.setup_schema()
         self.admin.import_data()  # ensures that database is setup
-
-    def _set_statement_timeout(self, cursor: Cursor, statement_timeout: int) -> None:
-        """Validate and set the statement timeout for a database cursor.
-
-        PostgreSQL SET commands don't support parameterized values, so we must
-        validate the value before using it in string interpolation.
-
-        Args:
-            cursor: Database cursor to execute the SET command on
-            statement_timeout: The statement timeout value in milliseconds
-
-        Raises:
-            ValueError: If statement_timeout is not a non-negative integer
-        """
-        if not isinstance(statement_timeout, int) or statement_timeout < 0:
-            msg = f"statement_timeout must be a non-negative integer, got: {statement_timeout}"
-            raise ValueError(msg)
-        cursor.execute(f"set statement_timeout = {statement_timeout}")
 
     def _resolve_action(self, path: str) -> tuple[BoundRoute | None, list[str]]:
         """Map a request path to the route that answers it.
@@ -472,7 +480,7 @@ class APIResource:
         result: dict[str, Any] = {}
         with self._conn_pool.connection() as conn, conn.cursor() as cursor:
             # Validate and set statement timeout
-            self._set_statement_timeout(cursor, statement_timeout)
+            db_utils.set_statement_timeout(cursor, statement_timeout)
             if explain:
                 explain_query = f"EXPLAIN (FORMAT JSON) {query}"
                 cursor.execute(explain_query, params)
@@ -1236,7 +1244,7 @@ class APIResource:
         """
         if falcon_response is None:
             return
-        self._serve_static_file(filename="styles.css", falcon_response=falcon_response)
+        serve_static_file(filename="styles.css", falcon_response=falcon_response)
         falcon_response.content_type = "text/css"
         set_cache_header(falcon_response, duration=timedelta(days=30))
 
@@ -1250,7 +1258,7 @@ class APIResource:
         """
         if falcon_response is None:
             return
-        self._serve_static_file(filename="app.js", falcon_response=falcon_response)
+        serve_static_file(filename="app.js", falcon_response=falcon_response)
         falcon_response.content_type = "application/javascript"
         # Cache JavaScript for 1 hour - it changes infrequently
         set_cache_header(falcon_response, duration=timedelta(hours=1))
@@ -1265,7 +1273,7 @@ class APIResource:
         """
         if falcon_response is None:
             return
-        self._serve_static_file(filename="app.min.js", falcon_response=falcon_response)
+        serve_static_file(filename="app.min.js", falcon_response=falcon_response)
         falcon_response.content_type = "application/javascript"
         set_cache_header(falcon_response, duration=timedelta(days=30))
 
@@ -1274,7 +1282,7 @@ class APIResource:
         """Return the robots.txt file."""
         if falcon_response is None:
             return
-        self._serve_static_file(filename="robots.txt", falcon_response=falcon_response)
+        serve_static_file(filename="robots.txt", falcon_response=falcon_response)
         falcon_response.content_type = "text/plain"
 
     @route(paths=("static/card.js",))
@@ -1287,7 +1295,7 @@ class APIResource:
         """
         if falcon_response is None:
             return
-        self._serve_static_file(filename="card.js", falcon_response=falcon_response)
+        serve_static_file(filename="card.js", falcon_response=falcon_response)
         falcon_response.content_type = "application/javascript"
         set_cache_header(falcon_response, duration=timedelta(hours=1))
 
@@ -1318,29 +1326,6 @@ class APIResource:
         falcon_response.text = html.replace(SITE_NAME_PLACEHOLDER, site_name)
         falcon_response.content_type = "text/html"
         set_cache_header(falcon_response, duration=timedelta(hours=1))
-
-    def _serve_static_file(self, *, filename: str, falcon_response: falcon.Response) -> None:
-        """Serve a static file to the Falcon response.
-
-        Args:
-        ----
-            filename (str): The file to serve.
-            falcon_response (falcon.Response): The Falcon response to write to.
-
-        """
-        full_filename = STATIC_DIR / filename
-        try:
-            with pathlib.Path(full_filename).open() as f:
-                falcon_response.text = f.read()
-        except FileNotFoundError:
-            falcon_response.status = falcon.HTTP_404
-            falcon_response.text = f"File not found: {filename}"
-        except PermissionError:
-            falcon_response.status = falcon.HTTP_403
-            falcon_response.text = f"Permission denied: {filename}"
-        except OSError as e:
-            falcon_response.status = falcon.HTTP_500
-            falcon_response.text = f"Error reading file {filename}: {e}"
 
     @route()
     def get_catalog(

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import copy
 import inspect
 import logging
-import multiprocessing
 import os
 import pathlib
 import threading
@@ -19,22 +18,20 @@ import time
 from collections.abc import Sequence  # noqa: TC003
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, NoReturn
-from typing import cast as typecast
 
 import falcon
 import orjson
 import psycopg
-import psycopg_pool
 from cachebox import LRUCache, TTLCache
-from psycopg import Connection
 
-from api.admin_resource import ADMIN_MOUNT_PREFIX, AdminResource
+from api.admin_resource import ADMIN_MOUNT_PREFIX, AdminContext, AdminResource
+from api.app_context import AppContext
 from api.enums import CardOrdering, PreferOrder, ResponseShape, SortDirection, UniqueOn
 from api.middlewares.timing import record_span
 from api.noscript_helpers import generate_results_count_html, generate_results_html
 from api.parsing import generate_sql_query, parse_scryfall_query
 from api.settings import settings
-from api.utils import db_utils, error_monitoring, multiprocessing_utils
+from api.utils import db_utils, error_monitoring
 from api.utils.css_utils import build_critical_css
 from api.utils.generation_cache import GenerationCache
 from api.utils.page_rendering import (
@@ -48,32 +45,14 @@ from api.utils.param_binding import ParamCoercionError
 from api.utils.routing import build_route_table, build_routes_listing, route
 from api.utils.site_name import hostname_to_site_name
 from api.utils.timer import Timer
-from card_engine import ENGINE_COLUMNS as _ENGINE_COLUMNS_FROM_MODULE
-from card_engine import QueryEngine as _QueryEngine
 from card_engine import QueryError as _QueryError
 
 if TYPE_CHECKING:
-    from multiprocessing.sharedctypes import Synchronized
-    from multiprocessing.synchronize import Event as EventType
-    from multiprocessing.synchronize import RLock as LockType
-
     from api.parsing.nodes import Query
     from api.utils.routing import BoundRoute
 
 
 logger = logging.getLogger(__name__)
-
-
-def _rss_mb() -> str:
-    """Return current RSS in MB as a string, or 'unknown' if /proc is unavailable."""
-    try:
-        with pathlib.Path("/proc/self/status").open() as f:
-            for line in f:
-                if line.startswith("VmRSS:"):
-                    return f"{int(line.split()[1]) // 1024} MB"
-    except OSError:
-        pass
-    return "unknown"
 
 
 # Postgres prefixes every 2201B message with this, e.g. "invalid regular expression: brackets []
@@ -116,13 +95,6 @@ DISALLOWED_QUERY_ARGS: frozenset[str] = frozenset(["falcon_response", "request_h
 # to the log and the error monitor, which are not attacker-readable; the client gets this and nothing
 # more. Callers must not append exception detail to it.
 INTERNAL_ERROR_DESCRIPTION = "An internal error occurred."
-
-MIN_IMPORT_CARDS = 90_000
-# Rows per batch streamed into the engine during a reload. The reload's memory
-# floor is the Rust-side build (~305 MB), so the batch only needs to be small
-# relative to that: ~2k rows ≈ 18 MB of dicts. Smaller adds round trips for no
-# measurable gain (see docs/issues/00505-engine-incremental-loading.md).
-_ENGINE_RELOAD_BATCH_SIZE = 2_000
 
 # Public field name -> magic.cards column. The `fields=` vocabulary for /search. This is
 # deliberately a subset of FIELD_TABLE in card_engine/src/lib.rs, not a mirror of it — not
@@ -247,65 +219,45 @@ def _columnarize_cards(cards: list[dict[str, Any]]) -> dict[str, list[Any]]:
 class APIResource:
     """Class implementing request handling for our simple API."""
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         *,
-        import_guard: LockType = multiprocessing_utils.DEFAULT_LOCK,
-        last_import_time: Synchronized | None = None,
-        schema_setup_event: EventType = multiprocessing_utils.DEFAULT_EVENT,
-        cache_generation: Synchronized | None = None,
-        engine_reload_guard: LockType | None = None,
-        conn_pool: psycopg_pool.ConnectionPool | None = None,
-        admin_conn_pool: psycopg_pool.ConnectionPool | None = None,
+        app_context: AppContext | None = None,
+        admin_context: AdminContext | None = None,
     ) -> None:
         """Initialize an APIResource object, set up connection pool and action map.
 
         Sets up the database connection pool and action mapping for the API.
 
         Args:
-            import_guard: Cross-process lock serialising imports.
-            last_import_time: Shared timestamp of the last completed import.
-            schema_setup_event: Set once the schema has been created.
-            cache_generation: Shared counter bumped to invalidate the query-result cache.
-            engine_reload_guard: Cross-process lock serialising engine reloads.
-            conn_pool: This resource's own connection pool. Built via `db_utils.make_pool()` if not
+            app_context: State and resources shared with the mounted AdminResource (connection
+                pools, the query engine, the cross-worker cache/import signals). Built fresh if not
                 given, matching every other handle here -- a caller (a test, mainly) can inject one
                 without a real pool ever opening a connection.
-            admin_conn_pool: The connection pool handed to the mounted AdminResource. Built the same
-                way if not given; kept separate from `conn_pool` so a test can inject the two
-                independently.
+            admin_context: Forwarded to the mounted AdminResource untouched; APIResource has no use
+                for its contents (import-serialisation primitives) and doesn't default it -- that's
+                AdminResource's own job, same as `app_context`.
         """
         self._critical_css: str = build_critical_css(STATIC_DIR / "styles.css")
-        self._conn_pool: psycopg_pool.ConnectionPool = conn_pool or db_utils.make_pool()
+        self.app_context = app_context or AppContext()
         # Build the route table from methods marked with @route, scanning the class rather than this
         # instance so nothing assigned below can become a route. Each entry carries everything
         # dispatch needs — the wrapped handler, how many positional path segments it absorbs, and
         # what it declared — computed once here rather than per-request in _handle.
         self.routes = build_route_table(self)
 
-        self._cache_generation: Synchronized = cache_generation or multiprocessing.Value("i", 0)
         self._query_cache: GenerationCache = GenerationCache(
             factory=lambda: LRUCache(maxsize=1_000 if settings.enable_cache else 1),
-            generation=self._cache_generation,
+            generation=self.app_context.cache_generation,
         )
         self._search_gen_cache: LRUCache = LRUCache(maxsize=1)  # generation → TTLCache
-        self._last_import_time: Synchronized = last_import_time or multiprocessing.Value("d", 0.0, lock=True)
-        self._engine = _QueryEngine()
         self._engine_reload_lock = threading.Lock()
-        # Cross-worker guard: the full-table fetch in _reload_engine is memory-hungry,
-        # so only one worker process should run it at a time (see _reload_engine).
-        self._engine_reload_guard: LockType = engine_reload_guard or multiprocessing.Lock()
-        logger.info("Worker with pid %d has conn pool %s", os.getpid(), self._conn_pool)
+        logger.info("Worker with pid %d has conn pool %s", os.getpid(), self.app_context.reader_pool)
 
         # Mounted after the parent's own state exists, since the child reaches back for the handles
         # they share. advertise=False is set here rather than on each handler: forgetting it is then
         # a property of this one call, not a hole in one route.
-        self.admin = AdminResource(
-            self,
-            conn_pool=admin_conn_pool or db_utils.make_pool(),
-            import_guard=import_guard,
-            schema_setup_event=schema_setup_event,
-        )
+        self.admin = AdminResource(app_context=self.app_context, admin_context=admin_context)
         self.routes.update(build_route_table(self.admin, prefix=ADMIN_MOUNT_PREFIX, advertise=False))
         self._not_found_routes = build_routes_listing(self.routes)
 
@@ -478,7 +430,7 @@ class APIResource:
         root_timing_key = "root_timing_key"
         timer = Timer()
         result: dict[str, Any] = {}
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with self.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             # Validate and set statement timeout
             db_utils.set_statement_timeout(cursor, statement_timeout)
             if explain:
@@ -510,54 +462,9 @@ class APIResource:
         set_no_store_header(falcon_response)
         return os.getpid()
 
-    _SETUP_COMPLETE_TTL = 60 * 60  # 1 hour; also invalidated when _last_import_time changes
-    _setup_complete_cache: tuple[bool, float, float] | None = None  # (result, expires_at, import_time)
-
-    def _setup_complete(self) -> bool:
-        """Return True if the setup is complete."""
-        now = time.monotonic()
-        current_import_time = self._last_import_time.get_obj().value
-        if self._setup_complete_cache is not None:
-            result, expires_at, cached_import_time = self._setup_complete_cache
-            if now < expires_at and current_import_time == cached_import_time:
-                logger.debug(
-                    "_setup_complete cache hit: result=%s, expires in %.0fs, pid %d",
-                    result,
-                    expires_at - now,
-                    os.getpid(),
-                )
-                return result
-        try:
-            with self._conn_pool.connection() as conn:
-                conn = typecast("Connection", conn)
-                with conn.cursor() as cursor:
-                    cursor.execute("SELECT COUNT(1) AS num_cards FROM magic.cards")
-                    cards_found = cursor.fetchall()[0]["num_cards"]
-                    result = cards_found > MIN_IMPORT_CARDS
-                    if result:
-                        logger.info("Found %d cards in pid %d", cards_found, os.getpid())
-                    else:
-                        logger.warning(
-                            "Setup not complete: found %d cards, need more than %d (pid %d)",
-                            cards_found,
-                            MIN_IMPORT_CARDS,
-                            os.getpid(),
-                        )
-        except Exception as oops:
-            logger.error(
-                "Error checking if setup is complete (pid %d): %s: %s",
-                os.getpid(),
-                type(oops).__name__,
-                oops,
-                exc_info=True,
-            )
-            result = False
-        self._setup_complete_cache = (result, now + self._SETUP_COMPLETE_TTL, current_import_time)
-        return result
-
     def _require_setup_complete(self) -> None:
         """Require that setup is complete or raise a ServiceUnavailable error."""
-        if not self._setup_complete():
+        if not self.app_context.setup_complete():
             logger.warning("Rejecting request in pid %d: setup is not complete", os.getpid())
             raise falcon.HTTPServiceUnavailable(
                 title="Service Unavailable",
@@ -565,76 +472,17 @@ class APIResource:
             ) from None
 
     def _trigger_background_reload_if_needed(self) -> None:
-        if self._engine.size() == 0 and self._engine_reload_lock.acquire(blocking=False):
+        if self.app_context.engine.size() == 0 and self._engine_reload_lock.acquire(blocking=False):
 
             def _bg_reload() -> None:
                 try:
-                    self._reload_engine()
+                    self.app_context.reload_engine()
                 except Exception as e:
                     logger.error("Background engine reload failed: %s", e, exc_info=True)
                 finally:
                     self._engine_reload_lock.release()
 
             threading.Thread(target=_bg_reload, daemon=True).start()
-
-    def _reload_engine(self, *, force: bool = False) -> None:
-        """Stream all cards from the DB into the Rust engine's card store in batches.
-
-        A server-side cursor feeds the engine's staged reload API
-        (reload_begin / add_batch / reload_commit) one batch at a time, so the
-        Python-side transient is one batch of row dicts (~18 MB at 2k rows)
-        instead of the whole corpus (~840 MB) — measurements in
-        docs/issues/00505-engine-incremental-loading.md. The reload is guarded by a
-        cross-worker lock so only one worker pays the build cost at a time.
-        With force=False (cold-start warming), losers of the race return
-        immediately and pick up the winner's archive via the engine's
-        inode-based remap. With force=True (data just changed), callers wait
-        their turn but skip the rebuild if another worker refreshed the store
-        while they were waiting.
-
-        Args:
-            force: If False, skip entirely when another worker holds the lock or the
-                store is already populated. If True, wait for the lock and always
-                reload (the data just changed, so the archive must be rebuilt).
-        """
-        if not settings.enable_engine:
-            logger.debug("Engine reload skipped: feature-gated off (ENABLE_ENGINE)")
-            return
-        if self._engine is None:
-            return
-        logger.info("Engine reload requested (force=%s, pid=%d, rss=%s)", force, os.getpid(), _rss_mb())
-        if not self._engine_reload_guard.acquire(block=force):
-            logger.info("Engine reload already in progress in another worker, skipping (pid=%d)", os.getpid())
-            return
-        try:
-            if not force and self._engine.size() > 0:
-                # Another worker populated the store while we raced for the lock.
-                return
-            logger.info("Engine reload starting (force=%s, pid=%d, rss=%s)", force, os.getpid(), _rss_mb())
-            cols_sql = ", ".join(f"card.{col}" for col in _ENGINE_COLUMNS_FROM_MODULE)
-            try:
-                with self._conn_pool.connection() as conn:
-                    # Named cursor => server-side: psycopg buffers one batch, not the full result.
-                    with conn.cursor(name="engine_reload") as cursor:
-                        cursor.itersize = _ENGINE_RELOAD_BATCH_SIZE
-                        cursor.execute(f"SELECT {cols_sql} FROM magic.cards AS card")
-                        if not self._engine.reload_begin():
-                            # Another process published a fresh archive while we
-                            # waited for the engine's write lock; it was remapped.
-                            return
-                        try:
-                            while batch := cursor.fetchmany(_ENGINE_RELOAD_BATCH_SIZE):
-                                self._engine.add_batch(batch)
-                            self._engine.reload_commit()
-                        except BaseException:
-                            self._engine.reload_abort()
-                            raise
-            except psycopg_pool.PoolClosed:
-                logger.debug("Connection pool closed during engine reload, skipping (pid=%d)", os.getpid())
-                return
-            logger.info("Engine reloaded with %d cards (pid=%d, rss=%s)", self._engine.size(), os.getpid(), _rss_mb())
-        finally:
-            self._engine_reload_guard.release()
 
     def _resolve_result_fields(self, fields: Sequence[str] | None) -> list[str]:
         """Validate a `fields=` request against RESULT_FIELD_COLUMNS, deduping repeats.
@@ -764,7 +612,7 @@ class APIResource:
 
         if settings.enable_cache:
             cache_key = (direction, limit, offset, orderby, prefer, query, unique, tuple(resolved_fields))
-            gen = self._cache_generation.value
+            gen = self.app_context.cache_generation.value
             try:
                 search_cache = self._search_gen_cache[gen]
             except KeyError:
@@ -785,7 +633,7 @@ class APIResource:
 
         if not settings.enable_engine:
             pass  # feature-gated off: SQL serves everything, the store never loads
-        elif self._engine.size() == 0:
+        elif self.app_context.engine.size() == 0:
             logger.info("Engine store empty, using SQL path for query=%r", query)
             self._trigger_background_reload_if_needed()
         else:
@@ -803,7 +651,7 @@ class APIResource:
                     fields=resolved_fields,
                 )
             except BaseException as e:
-                # BaseException, not Exception: a Rust panic anywhere under `self._engine.query`
+                # BaseException, not Exception: a Rust panic anywhere under `self.app_context.engine.query`
                 # surfaces as pyo3's `PanicException`, which derives from BaseException and so went
                 # straight past this handler — the one whose entire job is to let an engine failure
                 # degrade to the SQL path instead of failing the request. Falcon's own error handling
@@ -879,7 +727,7 @@ class APIResource:
         query_explanation = parsed_query.to_human_explanation() if query else ""
         try:
             with timer("engine_query"):
-                total_cards, cards = self._engine.query(
+                total_cards, cards = self.app_context.engine.query(
                     filters=parsed_query,
                     unique=str(unique),
                     prefer=str(prefer),
@@ -1335,18 +1183,18 @@ class APIResource:
         **_: object,
     ) -> dict[str, dict[str, int]]:
         """Get type and keyword frequency catalogs from the engine."""
-        if self._engine.size() == 0:
+        if self.app_context.engine.size() == 0:
             raise falcon.HTTPServiceUnavailable(
                 title="Service Unavailable",
                 description="Engine is not loaded, please try again later.",
             ) from None
         set_cache_header(falcon_response, duration=timedelta(hours=1))
-        type_counts: dict[str, int] = self._engine.common_card_types()
+        type_counts: dict[str, int] = self.app_context.engine.common_card_types()
         # tribal is the old name for kindred
         kindred_count = type_counts.get("Kindred", 0)
         if kindred_count:
             type_counts["Tribal"] = kindred_count
-        keyword_counts: dict[str, int] = self._engine.common_card_keywords()
+        keyword_counts: dict[str, int] = self.app_context.engine.common_card_keywords()
         keyword_catalog = {keyword.lower(): count for keyword, count in keyword_counts.items()}
         # Sorted keys compress ~5% smaller (adjacent keys share prefixes, so the
         # compressor's back-references stay short) and make the payload deterministic.
@@ -1387,11 +1235,11 @@ class APIResource:
         """
         set_no_store_header(falcon_response)
         num_cards = min(max(num_cards, 1), 1000)
-        if self._engine.size() == 0:
+        if self.app_context.engine.size() == 0:
             self._trigger_background_reload_if_needed()
             cards = []
         else:
-            cards = list(self._engine.sample_preferred(num_cards))
+            cards = list(self.app_context.engine.sample_preferred(num_cards))
         total_cards = len(cards)
         if shape == ResponseShape.COLUMNAR:
             cards = _columnarize_cards(cards)

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -3,19 +3,13 @@
 from __future__ import annotations
 
 import copy
-import datetime
-import hashlib
 import inspect
-import itertools
 import logging
 import multiprocessing
 import os
 import pathlib
-import re
 import threading
 import time
-import urllib.parse
-import uuid
 
 # Imported at runtime, not under TYPE_CHECKING, because route handlers annotate parameters with it and
 # ParamBinder resolves those annotations to real types at registration. Under TYPE_CHECKING the name is
@@ -24,50 +18,41 @@ import uuid
 # unnecessary once handlers carry a route decorator.
 from collections.abc import Sequence  # noqa: TC003
 from datetime import timedelta
-from functools import lru_cache, wraps
 from typing import TYPE_CHECKING, Any, NoReturn
 from typing import cast as typecast
 
-import cachebox
 import falcon
-import minify_html
 import orjson
 import psycopg
 import psycopg_pool
-import requests
 from cachebox import LRUCache, TTLCache
-from cachebox import cached as cachebox_cached
 from psycopg import Connection, Cursor
 
-from api.card_processing import preprocess_card
-from api.db.bulk_upsert import bulk_upsert as _bulk_upsert
+from api.admin_resource import ADMIN_MOUNT_PREFIX, AdminResource
 from api.enums import CardOrdering, PreferOrder, ResponseShape, SortDirection, UniqueOn
 from api.middlewares.timing import record_span
 from api.noscript_helpers import generate_results_count_html, generate_results_html
 from api.parsing import generate_sql_query, parse_scryfall_query
-from api.scryfall_bulk_data_fetcher import BulkDataKey, ScryfallBulkDataFetcher
 from api.settings import settings
-from api.tag_import import import_art_tags as _import_art_tags
-from api.tag_import import import_oracle_tags as _import_oracle_tags
 from api.utils import db_utils, error_monitoring, multiprocessing_utils
 from api.utils.css_utils import build_critical_css
 from api.utils.generation_cache import GenerationCache
-from api.utils.http_utils import make_user_agent
-from api.utils.param_binding import ParamCoercionError, bind_params
-from api.utils.routing import BoundRoute, iter_marked_routes, route
+from api.utils.page_rendering import SITE_NAME_PLACEHOLDER, STATIC_DIR, build_base_html, build_card_html
+from api.utils.param_binding import ParamCoercionError
+from api.utils.routing import build_route_table, build_routes_listing, route
+from api.utils.site_name import hostname_to_site_name
 from api.utils.timer import Timer
-from api.utils.type_conversions import _get_type_name
 from card_engine import ENGINE_COLUMNS as _ENGINE_COLUMNS_FROM_MODULE
 from card_engine import QueryEngine as _QueryEngine
 from card_engine import QueryError as _QueryError
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator
     from multiprocessing.sharedctypes import Synchronized
     from multiprocessing.synchronize import Event as EventType
     from multiprocessing.synchronize import RLock as LockType
 
     from api.parsing.nodes import Query
+    from api.utils.routing import BoundRoute
 
 
 logger = logging.getLogger(__name__)
@@ -84,12 +69,6 @@ def _rss_mb() -> str:
         pass
     return "unknown"
 
-
-FALLBACK_SITE_NAME = "MTG Search"
-
-# Placeholder written into index.html/card.html wherever the site name belongs, so the substitution
-# below can't accidentally match unrelated copy that happens to contain "MTG Search".
-_SITE_NAME_PLACEHOLDER = "%%%SITENAME%%%"
 
 # Postgres prefixes every 2201B message with this, e.g. "invalid regular expression: brackets []
 # not balanced". Stripped before the reason is quoted back, or the error message says it twice.
@@ -123,146 +102,6 @@ def _raise_query_bad_request(*, exc_name: str, query: str, description: str, err
     raise falcon.HTTPBadRequest(title="Invalid Search Query", description=description) from err
 
 
-_STATIC_DIR = pathlib.Path(__file__).parent / "static"
-_INDEX_HTML_PATH = _STATIC_DIR / "index.html"
-_CARD_HTML_PATH = _STATIC_DIR / "card.html"
-_FRAGMENTS_DIR = _STATIC_DIR / "fragments"
-
-
-def _static_hash(filename: str) -> str | None:
-    try:
-        return hashlib.sha256((_STATIC_DIR / filename).read_bytes()).hexdigest()[:12]
-    except FileNotFoundError:
-        return None
-
-
-_STYLES_CSS_HASH = _static_hash("styles.css")
-_APP_MIN_JS_HASH = _static_hash("app.min.js")
-_CARD_JS_HASH = _static_hash("card.js")
-
-# Markup identical across index.html and card.html — read once at import time and spliced into
-# each template's own placeholder comment (<!-- FAVICON --> etc.) by _build_base_html /
-# _build_card_html. Fragments live in fragments/ rather than static/ directly since they are not
-# complete documents and are never served on their own (only files with an action_map entry are
-# reachable over HTTP).
-_FAVICON_HTML = (_FRAGMENTS_DIR / "favicon.html").read_text()
-_PRECONNECTS_HTML = (_FRAGMENTS_DIR / "preconnects.html").read_text()
-_FONTS_HTML = (_FRAGMENTS_DIR / "fonts.html").read_text()
-_CSS_HTML = (_FRAGMENTS_DIR / "css.html").read_text()
-_FOOTER_HTML = (_FRAGMENTS_DIR / "footer.html").read_text()
-
-
-def _inject_shared_fragments(html: str) -> str:
-    """Splice the shared head/footer fragments into their placeholder comments.
-
-    Must run before the CRITICAL_CSS/asset-hash substitutions below: the CSS fragment carries its
-    own inner <!-- CRITICAL_CSS --> placeholder, which only exists in `html` after this replace.
-    """
-    html = html.replace("<!-- FAVICON -->", _FAVICON_HTML)
-    html = html.replace("<!-- PRECONNECTS -->", _PRECONNECTS_HTML)
-    html = html.replace("<!-- FONTS -->", _FONTS_HTML)
-    html = html.replace("<!-- CSS -->", _CSS_HTML)
-    return html.replace("<!-- FOOTER -->", _FOOTER_HTML)
-
-
-# Flip to False to disable HTML minification (e.g. while debugging a minifier-induced issue).
-_MINIFY_HTML_ENABLED = True
-
-
-def _minify_html(html: str) -> str:
-    """Minify HTML to shave a bit more off the page weight on top of gzip/brotli/zstd compression.
-
-    keep_comments=True is required: `_build_base_html`'s cached output still carries per-request
-    placeholders (SERVER_SIDE_RESULTS, SERVER_SIDE_EMBEDDED_DATA) substituted by `search()` after
-    this function returns, and those are plain HTML comments that must survive intact.
-    """
-    if not _MINIFY_HTML_ENABLED:
-        return html
-    return minify_html.minify(html, minify_js=True, minify_css=True, keep_comments=True)
-
-
-# TLDs in this set are stripped from the hostname; others are concatenated into the word.
-# e.g. sylvan-librarian.com -> "Sylvan Librarian"; tolarian-acade.my -> "Tolarian Academy"
-_STRIP_TLDS = frozenset(["app", "biz", "co", "com", "dev", "edu", "gov", "info", "io", "me", "net", "org", "us"])
-# Allowlist: only valid hostname characters (letters, digits, hyphens, dots) after urlparse extracts the host.
-_SAFE_HOSTNAME_RE = re.compile(r"^[a-z0-9.\-]+$")
-_IP_RE = re.compile(r"^\d+\.\d+\.\d+\.\d+$")
-
-
-_MIN_WORD_LEN = 3
-
-
-# TODO: supplement with words from https://api.scryfall.com/catalog/word-bank so MtG-specific
-# terms (e.g. "sylvan", "planeswalker") are recognized even on systems without a full dictionary.
-def _load_word_set() -> frozenset[str]:
-    for path in ("/usr/share/dict/american-english", "/usr/share/dict/words"):
-        try:
-            with pathlib.Path(path).open() as f:
-                return frozenset(w.lower() for w in f.read().splitlines() if w.isalpha() and len(w) >= _MIN_WORD_LEN)
-        except OSError:
-            continue
-    return frozenset()
-
-
-_WORDS: frozenset[str] = _load_word_set()
-
-
-def _split_words(s: str, words: frozenset[str]) -> list[str] | None:
-    """Split s into dictionary words by searching split points from the middle outward.
-
-    Returns a list of words on success, or None if the string cannot be fully partitioned.
-    """
-    # Only attempt dictionary splitting for purely alphabetic strings.
-    if not s.isalpha():
-        return None
-
-    @lru_cache(maxsize=4096)
-    def _split(sub: str) -> tuple[str, ...] | None:
-        if sub in words:
-            return (sub,)
-        n = len(sub)
-        if n < _MIN_WORD_LEN:
-            return None
-        mid = n // 2
-        for k in sorted(range(1, n), key=lambda k: abs(k - mid)):
-            left, right = sub[:k], sub[k:]
-            if left in words:
-                rest = _split(right)
-                if rest is not None:
-                    return (left, *rest)
-            if right in words:
-                rest = _split(left)
-                if rest is not None:
-                    return (*rest, right)
-        return None
-
-    res = _split(s)
-    return list(res) if res is not None else None
-
-
-def hostname_to_site_name(raw_host: str) -> str:
-    """Derive a display name from a Host header value, falling back to FALLBACK_SITE_NAME."""
-    # urlparse requires a scheme; .hostname strips the port and lowercases.
-    hostname = urllib.parse.urlparse(f"http://{raw_host}").hostname or ""
-    return _hostname_to_site_name(hostname[:64])
-
-
-@lru_cache(maxsize=256)
-def _hostname_to_site_name(hostname: str) -> str:
-    if not hostname or hostname == "localhost" or _IP_RE.match(hostname) or not _SAFE_HOSTNAME_RE.match(hostname):
-        return FALLBACK_SITE_NAME
-    parts = hostname.split(".")[-2:]
-    tld = parts[-1].lower()
-    name = parts[0] if tld in _STRIP_TLDS else ".".join(parts)
-    name = name.replace(".", "").replace("-", " ").strip()
-    if " " not in name and _WORDS:
-        split = _split_words(name, _WORDS)
-        if split is not None:
-            name = " ".join(split)
-    name = name.title()
-    return name if any(c.isalnum() for c in name) else FALLBACK_SITE_NAME
-
-
 # Query parameters that must not be forwarded to action handlers.
 DISALLOWED_QUERY_ARGS: frozenset[str] = frozenset(["falcon_response", "request_host"])
 
@@ -272,19 +111,7 @@ DISALLOWED_QUERY_ARGS: frozenset[str] = frozenset(["falcon_response", "request_h
 # more. Callers must not append exception detail to it.
 INTERNAL_ERROR_DESCRIPTION = "An internal error occurred."
 
-# pylint: disable=c-extension-no-member
-NOT_FOUND = 404
-MIN_IMPORT_INTERVAL = 300
-IMPORT_LOCK_TIMEOUT = 2
 MIN_IMPORT_CARDS = 90_000
-# Cards per bulk_upsert call during an import. The whole batch becomes ONE bind parameter: a JSON
-# array that Postgres must receive, cast to jsonb, expand with jsonb_array_elements, and join against
-# magic.cards. So this value sets the server-side peak for the statement, and the corpus grows over
-# time — a size that fit once does not stay fitting. Lowered from 6000 to 3000 after backends were
-# lost mid-statement during import; the extra round trips are not measurable against the import's
-# total, and it halves the logged parameter too (see log_parameter_max_length in the pg config).
-_UPSERT_PAGE_SIZE = 3_000
-
 # Rows per batch streamed into the engine during a reload. The reload's memory
 # floor is the Rust-side build (~305 MB), so the batch only needs to be small
 # relative to that: ~2k rows ≈ 18 MB of dicts. Smaller adds round trips for no
@@ -356,120 +183,9 @@ DEFAULT_RESULT_FIELDS: tuple[str, ...] = (
     "type_line",
 )
 
-# is: values Scryfall ships as BOOLEANS on every bulk card object, synced
-# in one set-based statement from raw_card_blob after each import (see
-# _sync_boolean_is_tags) -- no per-tag API sweep, unlike CUSTOM_IS_TAGS
-# below, and no accumulation in the import loop. card_is_tags key -> raw
-# blob key; adding a field here is the whole change. foil/promo/reprint are
-# deliberately NOT here yet (higher cardinality, memory check first).
-BOOLEAN_IS_TAGS: dict[str, str] = {
-    "reserved": "reserved",
-    "gamechanger": "game_changer",
-}
-
-_SYNC_BOOLEAN_IS_TAGS_SQL = """
-WITH tag_map(tag, blob_key) AS (
-    SELECT key, value FROM jsonb_each_text(%(tag_map)s::jsonb)
-),
-proposed AS (
-    SELECT
-        cards.scryfall_id,
-        (cards.card_is_tags - (SELECT array_agg(tag_map.tag) FROM tag_map))
-            || COALESCE(
-                   (
-                       SELECT jsonb_object_agg(tag_map.tag, true)
-                       FROM tag_map
-                       WHERE cards.raw_card_blob -> tag_map.blob_key = 'true'::jsonb
-                   ),
-                   '{}'::jsonb
-               ) AS proposed_is_tags
-    FROM magic.cards
-)
-UPDATE magic.cards
-SET card_is_tags = proposed.proposed_is_tags
-FROM proposed
-WHERE
-    cards.scryfall_id = proposed.scryfall_id AND
-    cards.card_is_tags IS DISTINCT FROM proposed.proposed_is_tags
-"""
-
-CUSTOM_IS_TAGS = [
-    "historic",  # artifact, legendary, saga
-    "pathway",  # land and name contains pathway
-    "permanent",  # ...
-    "reprint",
-    "spell",  # ...
-    "unique",  # has exactly one printing
-    "old",  # 93/97 frame
-    "new",  # newer frames
-    "foil",  # foil version of a card
-    "nonfoil",  # non-foil version of a card
-    "datestamped",  # can get from the json promo_types array
-    "universesbeyond",  # can get from the json promo_types array
-    # I don't know how to do this, I just don't want to make the normal requests
-    "booster",
-    "default",
-]
-
 # default/atypical are complementary and disjoint
 # so in theory we could query for one and build the other by
 # querying and inverting
-
-LAND_IS_TAGS = [
-    "bikeland",
-    "bondland",
-    "bounceland",
-    "canopyland",
-    "checkland",
-    "creatureland",
-    "fastland",
-    "fetchland",
-    "filterland",
-    "gainland",
-    "manland",
-    "painland",
-    "scryland",
-    "shadowland",
-    "shockland",
-    "slowland",
-    "storageland",
-    "surveilland",
-    "tangoland",
-    "tricycleland",
-    "triland",
-]
-CARD_IS_TAGS = LAND_IS_TAGS + [  # noqa: RUF005
-    "bear",  # easy to make custom, but also small
-    "commander",
-    "outlaw",  # based on creature type
-    "party",  # based on creature type
-    "reserved",
-    "vanilla",
-]
-
-
-def cached(cache: Any, key: Any = None) -> Any:  # noqa: ANN401
-    """Decorator that respects the settings.enable_cache flag at runtime.
-
-    Always creates the cached function, but checks settings at call time
-    to determine whether to use the cache or call the original function.
-    """
-    key_maker = key or cachebox.make_hash_key
-
-    def decorator(func: Any) -> Any:  # noqa: ANN401
-        cached_func = cachebox_cached(cache, key_maker=key_maker)(func)
-
-        @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
-            if settings.enable_cache:
-                return cached_func(*args, **kwargs)
-            return func(*args, **kwargs)
-
-        # Copy attributes from cached_func for compatibility
-        wrapper.cache = cache  # type: ignore[attr-defined]
-        return wrapper
-
-    return decorator
 
 
 def set_cache_header(falcon_response: falcon.Response | None, duration: timedelta) -> None:
@@ -492,46 +208,6 @@ def set_no_store_header(falcon_response: falcon.Response | None) -> None:
     falcon_response.set_header("Cache-Control", "no-store")
 
 
-@cached(cache=LRUCache(maxsize=16))
-def _build_base_html(critical_css: str, site_name: str) -> str:
-    """Read index.html and inject critical CSS and site name. Cached per (critical_css, site_name) pair."""
-    html = _INDEX_HTML_PATH.read_text()
-    html = _inject_shared_fragments(html)
-    html = html.replace("<!-- CRITICAL_CSS -->", critical_css)
-    if _STYLES_CSS_HASH:
-        html = html.replace("/static/styles.css", f"/static/styles.css?v={_STYLES_CSS_HASH}")
-    if _APP_MIN_JS_HASH:
-        html = html.replace("/static/app.min.js", f"/static/app.min.js?v={_APP_MIN_JS_HASH}")
-    return _minify_html(html.replace(_SITE_NAME_PLACEHOLDER, site_name))
-
-
-@cached(cache=LRUCache(maxsize=4))
-def _build_card_html(critical_css: str) -> str:
-    """Read card.html and inject critical CSS and versioned asset URLs."""
-    html = _CARD_HTML_PATH.read_text()
-    html = _inject_shared_fragments(html)
-    html = html.replace("<!-- CRITICAL_CSS -->", critical_css)
-    if _STYLES_CSS_HASH:
-        html = html.replace("/static/styles.css", f"/static/styles.css?v={_STYLES_CSS_HASH}")
-    if _CARD_JS_HASH:
-        html = html.replace("/static/card.js", f"/static/card.js?v={_CARD_JS_HASH}")
-    return _minify_html(html)
-
-
-@cached(cache=LRUCache(maxsize=10_000))
-def get_where_clause(query: str) -> tuple[str, dict]:
-    """Generate SQL WHERE clause and parameters from a search query.
-
-    Args:
-        query: The search query string to parse.
-
-    Returns:
-        Tuple of (SQL WHERE clause, parameter dictionary).
-    """
-    parsed_query = parse_scryfall_query(query)
-    return generate_sql_query(parsed_query)
-
-
 def rewrap(query: str) -> str:
     """Normalize whitespace in a SQL query string.
 
@@ -542,73 +218,6 @@ def rewrap(query: str) -> str:
         The query with normalized whitespace.
     """
     return " ".join(query.strip().split())
-
-
-def _max_positional_args(func: Any) -> float:  # noqa: ANN401
-    """Return how many positional args `func` accepts; inf if it takes *args.
-
-    Computed once per registered action at APIResource.__init__ time (not per-request):
-    inspect.signature() follows a bind_params wrapper's __wrapped__ link
-    (set by functools.update_wrapper), so this sees the real underlying handler's signature.
-    """
-    try:
-        params = inspect.signature(func).parameters.values()
-    except (TypeError, ValueError):
-        return 0.0
-    if any(p.kind == inspect.Parameter.VAR_POSITIONAL for p in params):
-        return float("inf")
-    return float(sum(1 for p in params if p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)))
-
-
-def _build_routes_listing(route_table: dict[str, BoundRoute]) -> dict[str, dict[str, Any]]:
-    """Build the {route: {doc, args, kwargs}} listing served in 404 responses.
-
-    Depends only on the route table's contents, which are fixed once APIResource.__init__ finishes —
-    computed once there rather than on every 404 (inspect.signature() per route isn't free).
-    """
-    routes = {}
-    for endpoint_name, entry in route_table.items():
-        wrapped_func = entry.action
-        # Get the original function from the wrapper
-        original_func = wrapped_func.__wrapped__ if hasattr(wrapped_func, "__wrapped__") else wrapped_func
-
-        # Get function signature
-        sig = inspect.signature(original_func)
-
-        # Extract docstring
-        doc = original_func.__doc__ or ""
-
-        # Parse arguments
-        args = []
-        kwargs = {}
-
-        for param_name, param in sig.parameters.items():
-            if param_name.startswith("_"):
-                continue
-            if param_name in ("self", "falcon_response"):
-                continue
-
-            param_info = {
-                "name": param_name,
-                "type": _get_type_name(param.annotation),
-            }
-
-            if param.default != inspect.Parameter.empty:
-                # It's a keyword argument with default
-                kwargs[param_name] = {
-                    "type": _get_type_name(param.annotation),
-                    "default": param.default,
-                }
-            else:
-                # It's a positional argument
-                args.append(param_info)
-
-        routes[endpoint_name] = {
-            "doc": doc,
-            "args": args,
-            "kwargs": kwargs,
-        }
-    return routes
 
 
 def _columnarize_cards(cards: list[dict[str, Any]]) -> dict[str, list[Any]]:
@@ -645,29 +254,13 @@ class APIResource:
 
         Sets up the database connection pool and action mapping for the API.
         """
-        self._bulk_data_fetcher = ScryfallBulkDataFetcher()
-        self._critical_css: str = build_critical_css(_STATIC_DIR / "styles.css")
+        self._critical_css: str = build_critical_css(STATIC_DIR / "styles.css")
         self._conn_pool: psycopg_pool.ConnectionPool = db_utils.make_pool()
         # Build the route table from methods marked with @route, scanning the class rather than this
         # instance so nothing assigned below can become a route. Each entry carries everything
         # dispatch needs — the wrapped handler, how many positional path segments it absorbs, and
         # what it declared — computed once here rather than per-request in _handle.
-        self.routes: dict[str, BoundRoute] = {}
-        for attr_name, spec in iter_marked_routes(type(self)):
-            handler = getattr(self, attr_name)
-            entry = BoundRoute(
-                action=bind_params(handler),
-                positional_capacity=_max_positional_args(handler),
-                spec=spec,
-            )
-            for path in spec.paths:
-                if path in self.routes:
-                    msg = f"Route path {path!r} is claimed by both {self.routes[path].action.__name__} and {attr_name}"
-                    raise RuntimeError(msg)
-                self.routes[path] = entry
-
-        # Static once the route table is fully populated — see _build_routes_listing.
-        self._not_found_routes = _build_routes_listing(self.routes)
+        self.routes = build_route_table(self)
 
         self._cache_generation: Synchronized = cache_generation or multiprocessing.Value("i", 0)
         self._query_cache: GenerationCache = GenerationCache(
@@ -675,24 +268,23 @@ class APIResource:
             generation=self._cache_generation,
         )
         self._search_gen_cache: LRUCache = LRUCache(maxsize=1)  # generation → TTLCache
-        self._session = requests.Session()
-        self._import_guard: LockType = import_guard
         self._last_import_time: Synchronized = last_import_time or multiprocessing.Value("d", 0.0, lock=True)
-        self._schema_setup_event: EventType = schema_setup_event
-
-        self._session.headers.update({"User-Agent": make_user_agent()})
         self._engine = _QueryEngine()
         self._engine_reload_lock = threading.Lock()
         # Cross-worker guard: the full-table fetch in _reload_engine is memory-hungry,
         # so only one worker process should run it at a time (see _reload_engine).
         self._engine_reload_guard: LockType = engine_reload_guard or multiprocessing.Lock()
         logger.info("Worker with pid %d has conn pool %s", os.getpid(), self._conn_pool)
-        self.setup_schema()
-        self.import_data()  # ensures that database is setup
 
-    def _get_timer(self, req: falcon.Request) -> Timer:
-        """Get the timer for the request."""
-        return req.context.setdefault("timer", Timer())
+        # Mounted after the parent's own state exists, since the child reaches back for the handles
+        # they share. advertise=False is set here rather than on each handler: forgetting it is then
+        # a property of this one call, not a hole in one route.
+        self.admin = AdminResource(self, import_guard=import_guard, schema_setup_event=schema_setup_event)
+        self.routes.update(build_route_table(self.admin, prefix=ADMIN_MOUNT_PREFIX, advertise=False))
+        self._not_found_routes = build_routes_listing(self.routes)
+
+        self.admin.setup_schema()
+        self.admin.import_data()  # ensures that database is setup
 
     def _set_statement_timeout(self, cursor: Cursor, statement_timeout: int) -> None:
         """Validate and set the statement timeout for a database cursor.
@@ -910,69 +502,6 @@ class APIResource:
         set_no_store_header(falcon_response)
         return os.getpid()
 
-    @route()
-    def setup_schema(self, *_: object, **__: object) -> None:
-        """Set up the database schema and apply migrations as needed."""
-        if self._schema_setup_event.is_set():
-            logger.info("Schema already setup (fastpath) in pid %d", os.getpid())
-            return
-
-        filesystem_migrations = db_utils.get_migrations()
-
-        with self._import_guard:
-            if self._schema_setup_event.is_set():
-                logger.info("Schema already setup (slowpath) in pid %d", os.getpid())
-                return
-            logger.info("Setting up schema in pid %d", os.getpid())
-            # read migrations from the db dir...
-            # if any already applied migrations differ from what we want
-            # to apply then drop everything
-            with self._conn_pool.connection() as conn, conn.cursor() as cursor:
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS migrations (
-                        file_name text not null,
-                        file_sha256 text not null,
-                        date_applied timestamp default now(),
-                        file_contents text not null
-                    )""",
-                )
-                cursor.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_migrations_filename ON migrations (file_name)")
-                cursor.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_migrations_file_sha256 ON migrations USING HASH (file_sha256)",
-                )
-
-                cursor.execute("SELECT file_name, file_sha256 FROM migrations ORDER BY date_applied")
-                applied_migrations = [dict(r) for r in cursor]
-
-                already_applied = set()
-                for applied_migration, fs_migration in zip(applied_migrations, filesystem_migrations, strict=False):
-                    if applied_migration.items() <= fs_migration.items():
-                        already_applied.add(applied_migration["file_sha256"])
-                    else:
-                        already_applied.clear()
-                        cursor.execute("DELETE FROM migrations")
-                        cursor.execute("DROP SCHEMA IF EXISTS magic CASCADE")
-                        conn.commit()
-
-                for imigration in filesystem_migrations:
-                    file_sha256 = imigration["file_sha256"]
-                    if file_sha256 in already_applied:
-                        logger.info("%s was already applied...", imigration["file_name"])
-                        continue
-                    logger.info("Applying %s ...", imigration["file_name"])
-                    cursor.execute(imigration["file_contents"])
-                    cursor.execute(
-                        """
-                            INSERT INTO migrations
-                                (  file_name  ,   file_sha256  ,   file_contents  ) VALUES
-                                (%(file_name)s, %(file_sha256)s, %(file_contents)s)""",
-                        imigration,
-                    )
-                    conn.commit()
-
-            self._schema_setup_event.set()
-            logger.info("Schema setup complete in pid %d", os.getpid())
-
     _SETUP_COMPLETE_TTL = 60 * 60  # 1 hour; also invalidated when _last_import_time changes
     _setup_complete_cache: tuple[bool, float, float] | None = None  # (result, expires_at, import_time)
 
@@ -1026,20 +555,6 @@ class APIResource:
                 title="Service Unavailable",
                 description="Setup is not complete, please try again later.",
             ) from None
-
-    def _import_recent(self) -> bool:
-        """Return True if a bulk import completed in the last 5 minutes (or setup is complete when no shared timestamp)."""
-        if self._last_import_time is None:
-            return self._setup_complete()
-        # Unlocked read: c_double is atomic on typical platforms; avoids lock contention on fast path
-        t = self._last_import_time.get_obj().value
-        if not t:
-            logger.info("No import recorded...")
-            return False
-        time_since_import = time.time() - t
-        retval = time_since_import < MIN_IMPORT_INTERVAL
-        logger.info("Last import was %d seconds ago, %s", time_since_import, retval)
-        return retval
 
     def _trigger_background_reload_if_needed(self) -> None:
         if self._engine.size() == 0 and self._engine_reload_lock.acquire(blocking=False):
@@ -1112,86 +627,6 @@ class APIResource:
             logger.info("Engine reloaded with %d cards (pid=%d, rss=%s)", self._engine.size(), os.getpid(), _rss_mb())
         finally:
             self._engine_reload_guard.release()
-
-    def _run_import_under_lock(self) -> None:
-        """Run the import flow; caller must hold the import lock."""
-        if self._import_recent():
-            logger.info("Import recent slowpath...")
-            return
-        self.setup_schema()
-
-        before = time.monotonic()
-
-        result = self._upsert_cards(self._bulk_data_fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
-
-        after_transfer = time.monotonic()
-
-        if result["status"] == "success":
-            if self._last_import_time is not None:
-                self._last_import_time.value = time.time()
-            total_time = after_transfer - before
-            cards_sent = result.get("cards_sent", result["cards_loaded"])
-            rate = cards_sent / total_time if total_time > 0 else 0
-            logger.info(
-                "Loaded %d cards (%d new, %d updated) in %.2f seconds, rate: %.2f cards/s...",
-                result["cards_loaded"],
-                result.get("cards_inserted", 0),
-                result.get("cards_updated", 0),
-                total_time,
-                rate,
-            )
-            # Art tags first: the prefer score's art_style component reads card_art_tags, so
-            # running the backfill ahead of the tag import scored every card as on-style on a
-            # first boot, and nothing rescored until the next import. Oracle tags feed search
-            # rather than scoring, so their position relative to the backfill does not matter.
-            _import_art_tags(self._conn_pool, self._bulk_data_fetcher)
-            self.backfill_prefer_scores()
-            self.backfill_cubecobra_scores()
-            _import_oracle_tags(self._conn_pool, self._bulk_data_fetcher)
-            self._reload_engine(force=True)
-            self._clear_caches()
-            self._last_import_time.value = time.time()
-            self._setup_complete_cache = None
-            # Every step above logs its own duration; this closes the sequence with the wall
-            # clock the operator actually waited, upsert through engine reload.
-            logger.info("Import complete in %.2f seconds", time.monotonic() - before)
-            return
-        logger.error("Failed to import data: %s", result["message"])
-        return
-
-    @cached(
-        cache=TTLCache(maxsize=1, global_ttl=MIN_IMPORT_INTERVAL),
-    )
-    @route()
-    def import_data(self, **_: object) -> None:
-        """Import data from Scryfall and insert into the database."""
-        before = time.monotonic()
-        if self._import_recent():
-            after = time.monotonic()
-            total_time = after - before
-            logger.info("Import recent fastpath took %.2f seconds in pid %d", total_time, os.getpid())
-            # check without taking the lock so the majority of the time we never take the lock
-            return None
-
-        logger.info("Hitting slowpath in pid %d", os.getpid())
-
-        import_lock = self._last_import_time.get_lock()
-
-        acquired = import_lock.acquire(timeout=IMPORT_LOCK_TIMEOUT)
-        if not acquired:
-            if self._setup_complete():
-                logger.info(
-                    "Timed out waiting %.0fs for import lock; setup complete, skipping in pid %d",
-                    IMPORT_LOCK_TIMEOUT,
-                    os.getpid(),
-                )
-                return None
-            # acquire with no timeout...
-            import_lock.acquire()
-        try:
-            return self._run_import_under_lock()
-        finally:
-            import_lock.release()
 
     def _resolve_result_fields(self, fields: Sequence[str] | None) -> list[str]:
         """Validate a `fields=` request against RESULT_FIELD_COLUMNS, deduping repeats.
@@ -1298,14 +733,6 @@ class APIResource:
                 description="Limit must be an integer.",
             )
         return limit
-
-    def _get_where_clause(self, query: str | None) -> tuple[str, dict[str, Any]]:
-        try:
-            where_clause, params = get_where_clause(query)
-        except ValueError as err:
-            # Handle parsing errors from parse_scryfall_query
-            _raise_query_bad_request(exc_name="ValueError", query=query, description=f'Failed to parse query: "{query}"', err=err)
-        return where_clause, params
 
     def _search(  # noqa: PLR0913
         self,
@@ -1707,7 +1134,7 @@ class APIResource:
 
         """
         site_name = hostname_to_site_name(request_host)
-        html_content = _build_base_html(self._critical_css, site_name)
+        html_content = build_base_html(self._critical_css, site_name)
 
         # Check if we have a search query
         search_query = query or q
@@ -1766,18 +1193,6 @@ class APIResource:
         falcon_response.text = html_content
         falcon_response.content_type = "text/html"
 
-    @route()
-    def prefer_score_tuner(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
-        """Return the prefer score tuner page.
-
-        Args:
-        ----
-            falcon_response (falcon.Response): The Falcon response to write to.
-
-        """
-        self._serve_static_file(filename="prefer_score_tuner.html", falcon_response=falcon_response)
-        falcon_response.content_type = "text/html"
-
     @route(paths=("favicon.ico", "static/favicon.ico"))
     def favicon_ico(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
         """Return the favicon.ico file.
@@ -1788,7 +1203,7 @@ class APIResource:
         """
         if falcon_response is None:
             return
-        full_filename = _STATIC_DIR / "favicon.ico"
+        full_filename = STATIC_DIR / "favicon.ico"
         with pathlib.Path(full_filename).open(mode="rb") as f:
             falcon_response.data = contents = f.read()
         falcon_response.content_type = "image/vnd.microsoft.icon"
@@ -1803,7 +1218,7 @@ class APIResource:
         """Return the social preview image."""
         if falcon_response is None:
             return
-        full_filename = _STATIC_DIR / "social-preview.webp"
+        full_filename = STATIC_DIR / "social-preview.webp"
         with full_filename.open(mode="rb") as f:
             contents = f.read()
         falcon_response.data = contents
@@ -1899,8 +1314,8 @@ class APIResource:
         if falcon_response is None:
             return
         site_name = hostname_to_site_name(request_host)
-        html = _build_card_html(self._critical_css)
-        falcon_response.text = html.replace(_SITE_NAME_PLACEHOLDER, site_name)
+        html = build_card_html(self._critical_css)
+        falcon_response.text = html.replace(SITE_NAME_PLACEHOLDER, site_name)
         falcon_response.content_type = "text/html"
         set_cache_header(falcon_response, duration=timedelta(hours=1))
 
@@ -1913,7 +1328,7 @@ class APIResource:
             falcon_response (falcon.Response): The Falcon response to write to.
 
         """
-        full_filename = _STATIC_DIR / filename
+        full_filename = STATIC_DIR / filename
         try:
             with pathlib.Path(full_filename).open() as f:
                 falcon_response.text = f.read()
@@ -1926,17 +1341,6 @@ class APIResource:
         except OSError as e:
             falcon_response.status = falcon.HTTP_500
             falcon_response.text = f"Error reading file {filename}: {e}"
-
-    @route()
-    def get_migrations(self, **_: object) -> list[dict[str, str]]:
-        """Get the migrations from the filesystem.
-
-        Returns:
-        -------
-            List[Dict[str, str]]: List of migration metadata dictionaries.
-
-        """
-        return db_utils.get_migrations()
 
     @route()
     def get_catalog(
@@ -1974,811 +1378,6 @@ class APIResource:
         return self._run_query(
             query=db_utils.read_sql("get_common_keywords"),
         )["result"]
-
-    @route()
-    def backfill_prefer_scores(self, **_: object) -> dict[str, Any]:
-        """Backfill prefer_score and prefer_score_components for all cards.
-
-        This endpoint recalculates the prefer score for all existing cards based on:
-        - Border color (black: 14, white: 0)
-        - Frame version (2015: 42, 2003: 30)
-        - Artwork popularity (logarithmic scaling: 23 * ln(count) / ln(40))
-        - Rarity (common: 16, uncommon: 16, rare: 11, mythic: 0)
-        - Extended art (12 points if present)
-        - Highres scan (8 points if image_status='highres_scan')
-        - Has paper (6 points if 'paper' in games array)
-        - Language (English: 40 points)
-        - Legendary frame (5 points if 'legendary' in frame_effects)
-        - Non-showcase (10 points if 'showcase' not in frame_effects)
-        - Finish (nonfoil: 10, foil: 5, etched: 0)
-        - Artwork set (full-color: 20, black/white: 0)
-
-        Returns:
-            Dict with status and count of cards updated
-        """
-        start = time.monotonic()
-        logger.info("Starting prefer score backfill")
-
-        backfill_sql = db_utils.read_sql("backfill_prefer_scores")
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
-            self._set_statement_timeout(cursor, settings.prefer_score_backfill_timeout_ms)
-            cursor.execute(backfill_sql)
-            updated_count = cursor.rowcount
-
-            # Get count of updated cards
-            cursor.execute("SELECT COUNT(*) as count FROM magic.cards WHERE prefer_score IS NOT NULL")
-            result = cursor.fetchone()
-            total_cards = result["count"] if result else 0
-
-            conn.commit()
-
-        # cards_updated counts only rows whose score actually moved -- the backfill's UPDATE
-        # skips rows already carrying the right value, so a steady-state re-run reports 0 of N
-        # rather than N of N. Both numbers are worth having: the first says how much churned,
-        # the second that the corpus is fully scored.
-        stats = {
-            "duration_seconds": round(time.monotonic() - start, 2),
-            "cards_updated": updated_count,
-            "cards_scored": total_cards,
-        }
-        logger.info("Prefer score backfill complete: %s", stats)
-
-        return {
-            "status": "success",
-            "message": f"Successfully backfilled prefer scores for {updated_count} of {total_cards} cards",
-            **stats,
-        }
-
-    def _fetch_cubecobra_data(self, db_oracle_ids: set[uuid.UUID]) -> dict[uuid.UUID, dict[str, Any]]:
-        """Paginate the CubeCobra top-cards API and return data keyed by oracle_id.
-
-        Returns:
-            Mapping of oracle_id -> {elo, cube_count, pick_count, popularity}.
-        """
-        cubecobra_url = "https://cubecobra.com/tool/api/topcards/"
-        page = 1
-
-        while True:
-            time.sleep(0.5)
-            logger.info("Fetching CubeCobra page %d", page)
-            response = self._session.get(
-                cubecobra_url,
-                params={"p": page, "f": "", "s": "Elo", "d": "descending"},
-                timeout=30,
-            )
-            response.raise_for_status()
-            cards = response.json().get("data") or []
-
-            if not cards:
-                logger.info("Empty page %d - done paginating CubeCobra", page)
-                break
-
-            results: dict[uuid.UUID, dict[str, Any]] = {}
-            for card in cards:
-                oracle_id_str = card.get("oracle_id")
-                if not oracle_id_str:
-                    continue
-                try:
-                    oracle_id = uuid.UUID(oracle_id_str)
-                except ValueError:
-                    logger.warning("CubeCobra returned malformed oracle_id %r on page %d", oracle_id_str, page)
-                    continue
-                if oracle_id in db_oracle_ids:
-                    results[oracle_id] = {
-                        "elo": card.get("elo"),
-                        "cube_count": card.get("cubeCount"),
-                        "pick_count": card.get("pickCount"),
-                    }
-
-            logger.info("CubeCobra page %d: %d cards (total: %d)", page, len(cards), len(results))
-            page += 1
-            yield results
-
-    def _insert_cubecobra_data(self, cubecobra_data: dict[uuid.UUID, dict[str, Any]]) -> int:
-        """Write CubeCobra data into magic.cards, matching on oracle_id.
-
-        Args:
-            cubecobra_data: Mapping of oracle_id -> data dict from _fetch_cubecobra_data().
-
-        Returns:
-            Total number of card rows updated.
-        """
-        records = db_utils.maybe_json(
-            [
-                {
-                    "elo": data["elo"],
-                    "cube_count": data["cube_count"],
-                    "pick_count": data["pick_count"],
-                    "oracle_id": oracle_id,
-                }
-                for oracle_id, data in cubecobra_data.items()
-            ]
-        )
-
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
-            cursor.execute(
-                """
-                WITH incoming AS (
-                    SELECT * FROM jsonb_to_recordset(%(records)s) AS t(
-                        elo real, cube_count integer, pick_count integer, oracle_id uuid
-                    )
-                )
-                UPDATE magic.cards
-                SET
-                    cubecobra_elo        = incoming.elo,
-                    cubecobra_cube_count = incoming.cube_count,
-                    cubecobra_pick_count = incoming.pick_count
-                FROM incoming
-                WHERE magic.cards.oracle_id = incoming.oracle_id
-                """,
-                {"records": records},
-            )
-            total_updated = cursor.rowcount
-            conn.commit()
-
-        return total_updated
-
-    @route()
-    def backfill_cubecobra_scores(self, **_: object) -> dict[str, Any]:
-        """Backfill cubecobra_score for all cards.
-
-        Computes a weighted average of per-dimension PERCENT_RANK values (each in the 0-1
-        range, where 0 is best and 1 is worst) and scales the result to a 0-100 score
-        (0 = best, 100 = worst).
-
-        The per-dimension weights are treated as relative and are internally normalized so
-        that their sum is 100. Callers may supply any non-negative weights; they do not need
-        to sum to 1.0.
-
-        One score per distinct card_name is computed and then propagated to all printings.
-
-        Returns:
-            Dict with status and count of cards updated.
-        """
-        weights = {
-            "w_cube_count": 1,
-            "w_edhrec": 1,
-            "w_elo": 1,
-            "w_pick_count": 1,
-        }
-        start = time.monotonic()
-        scale_factor = sum(weights.values()) / 100.0
-        weights = {k: v / scale_factor for k, v in weights.items()}
-        logger.info("Starting CubeCobra score backfill with weights: %s", weights)
-
-        backfill_sql = db_utils.read_sql("backfill_cubecobra_scores")
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
-            self._set_statement_timeout(cursor, 600_000)
-            cursor.execute(backfill_sql, weights)
-            updated_count = cursor.rowcount
-
-            # The percent ranks are computed over cubecobra_elo and friends, which the normal
-            # import never populates -- they arrive via ingest_cubecobra. Reporting how many
-            # cards actually carry that data distinguishes "ranked the whole corpus" from
-            # "ranked a corpus of all-NULLs", which otherwise look identical in the log.
-            cursor.execute("SELECT COUNT(*) as count FROM magic.cards WHERE cubecobra_elo IS NOT NULL")
-            result = cursor.fetchone()
-            cards_with_data = result["count"] if result else 0
-
-            conn.commit()
-
-        stats = {
-            "duration_seconds": round(time.monotonic() - start, 2),
-            "cards_updated": updated_count,
-            "cards_with_cubecobra_data": cards_with_data,
-        }
-        logger.info("CubeCobra score backfill complete: %s", stats)
-        return {
-            "status": "success",
-            "weights": weights,
-            **stats,
-        }
-
-    @route()
-    def ingest_cubecobra(self, **_: object) -> dict[str, Any]:
-        """Fetch card data from CubeCobra and store it in magic.cards.
-
-        Paginates the CubeCobra top-cards API, then updates all matching rows
-        in magic.cards (matched on oracle_id). Cards not present in CubeCobra
-        are left with NULL values for the cubecobra_* columns.
-
-        Returns:
-            Dict with status and count of rows updated.
-        """
-        logger.info("Starting CubeCobra ingest")
-        # fetch the distinct, non-null oracle ids that are in the db
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
-            cursor.execute(
-                "SELECT DISTINCT oracle_id FROM magic.cards WHERE oracle_id IS NOT NULL",
-            )
-            db_oracle_ids = {r["oracle_id"] for r in cursor.fetchall()}
-
-        for cubecobra_page in self._fetch_cubecobra_data(db_oracle_ids):
-            logger.info("Fetched %d oracle_ids from CubeCobra", len(cubecobra_page))
-            cards_updated = self._insert_cubecobra_data(cubecobra_page)
-        logger.info("CubeCobra ingest complete: %d card rows updated", cards_updated)
-
-        backfill_result = self.backfill_cubecobra_scores()
-        self._clear_caches()
-
-        return {
-            "status": "success",
-            "cards_updated": cards_updated,
-            "scores_backfilled": backfill_result["cards_updated"],
-        }
-
-    def _add_is_tag_to_cards_or_printings(self, *, is_tag: str) -> dict[str, Any]:
-        """Add a specific is: tag to all cards or printings matching that tag using Scryfall search.
-
-        Args:
-        ----
-            is_tag (str): The is: tag to fetch and apply to cards (e.g., 'creature', 'spell').
-
-        Returns:
-        -------
-            Dict[str, Any]: Result summary with updated card count and tag info.
-
-        """
-        # TODO: is tags are not based on card name, but rather specific printing
-        # meaning this needs to not use unique on cards, but instead do unique printing
-        # which means it's gonna be hella slow
-
-        if not is_tag:
-            msg = "is_tag parameter is required"
-            raise ValueError(msg)
-
-        if is_tag in CUSTOM_IS_TAGS:
-            return self._add_is_tag_to_custom(is_tag=is_tag)
-        if is_tag in CARD_IS_TAGS:
-            return self._add_is_tag_to_cards(is_tag=is_tag)
-        return self._add_is_tag_to_printings(is_tag=is_tag)
-
-    def _add_is_tag_to_custom(self, *, is_tag: str) -> dict[str, Any]:
-        """Add a specific is: tag to all custom cards matching that tag using Scryfall search."""
-        # these are special cases where you can phrase the tag as a query over other properties
-        logger.info("Adding is:%s to custom cards", is_tag)
-        return {
-            "cards_updated": 0,
-            "is_tag": is_tag,
-            "message": f"Custom is: tag {is_tag} is not supported",
-            "total_cards_found": 0,
-        }
-
-    def _add_is_tag_to_cards(self, *, is_tag: str) -> dict[str, Any]:
-        """Add a specific is: tag to all cards matching that tag using Scryfall search.
-
-        Args:
-        ----
-            is_tag (str): The is: tag to fetch and apply to cards (e.g., 'creature', 'spell').
-
-        Returns:
-        -------
-            Dict[str, Any]: Result summary with updated card count and tag info.
-
-        """
-        # Fetch cards with this is: tag from Scryfall API (handles pagination)
-        cards = self._scryfall_search(query=f"is:{is_tag}", unique="cards")
-        card_names = {c["name"] for c in cards}
-
-        if not cards:
-            logger.warning("No cards found with is:%s in Scryfall API", is_tag)
-            return {
-                "is_tag": is_tag,
-                "cards_updated": 0,
-                "total_cards_found": 0,
-                "message": f"No cards found with is:{is_tag} in Scryfall API",
-            }
-
-        logger.info("Updating %d cards with is:%s", len(card_names), is_tag)
-        # Update cards in database with the new is: tag
-        updated_count = 0
-        new_tag = orjson.dumps({is_tag: True}).decode("utf-8")
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
-            # Use SQL update with jsonb concatenation to add the is: tag
-            for card_name_batch in itertools.batched(sorted(card_names), 500):
-                cursor.execute(
-                    """
-                    UPDATE
-                        magic.cards
-                    SET
-                        card_is_tags = card_is_tags || %(new_tag)s::jsonb
-                    WHERE
-                        card_name = ANY(%(card_names)s) AND
-                        not(card_is_tags @> %(new_tag)s::jsonb)
-                    """,
-                    {
-                        "card_names": list(card_name_batch),
-                        "new_tag": new_tag,
-                    },
-                )
-                updated_count += cursor.rowcount
-                conn.commit()
-
-        return {
-            "is_tag": is_tag,
-            "cards_updated": updated_count,
-            "total_cards_found": len(card_names),
-            "message": f"Successfully updated {updated_count} cards with is:{is_tag}",
-        }
-
-    def _sync_boolean_is_tags(self, conn: Connection) -> int:
-        """Sync the boolean-backed is: tags (BOOLEAN_IS_TAGS) from raw_card_blob, one-shot.
-
-        Rebuilds each card's managed keys as (existing minus managed) plus the keys whose
-        blob boolean is true, touching only rows whose result actually differs -- so list
-        churn (a card entering or leaving the game-changer roster) converges on every
-        import, and unrelated card_is_tags entries are never disturbed.
-
-        Args:
-        ----
-            conn (Connection): open connection; committed here.
-
-        Returns:
-        -------
-            int: rows whose card_is_tags changed.
-
-        """
-        with conn.cursor() as cursor:
-            cursor.execute(_SYNC_BOOLEAN_IS_TAGS_SQL, {"tag_map": orjson.dumps(BOOLEAN_IS_TAGS).decode("utf-8")})
-            updated_count = cursor.rowcount
-        conn.commit()
-        if updated_count:
-            logger.info("Synced boolean is: tags on %d printings", updated_count)
-        return updated_count
-
-    def _add_is_tag_to_printings(self, *, is_tag: str) -> dict[str, Any]:
-        """Add a specific is: tag to all printings matching that tag using Scryfall search.
-
-        Args:
-        ----
-            is_tag (str): The is: tag to fetch and apply to printings (e.g., 'creature', 'spell').
-
-        Returns:
-        -------
-            Dict[str, Any]: Result summary with updated card count and tag info.
-
-        """
-        # Fetch cards with this is: tag from Scryfall API (handles pagination)
-        printings = self._scryfall_search(query=f"is:{is_tag}", unique="printings")
-
-        if not printings:
-            logger.warning("No printings found with is:%s in Scryfall API", is_tag)
-            return {
-                "is_tag": is_tag,
-                "cards_updated": 0,
-                "total_cards_found": 0,
-                "message": f"No cards found with is:{is_tag} in Scryfall API",
-            }
-
-        logger.info("Updating %d printings with is:%s", len(printings), is_tag)
-        # Update cards in database with the new is: tag
-        updated_count = 0
-        new_tag = orjson.dumps({is_tag: True}).decode("utf-8")
-        scryfall_ids = {p["id"] for p in printings}
-        with self._conn_pool.connection() as conn, conn.cursor() as cursor:
-            # Use SQL update with jsonb concatenation to add the is: tag
-            for scryfall_id_batch in itertools.batched(sorted(scryfall_ids), 500):
-                cursor.execute(
-                    """
-                    UPDATE
-                        magic.cards
-                    SET
-                        card_is_tags = card_is_tags || %(new_tag)s::jsonb
-                    WHERE
-                        scryfall_id = ANY(%(scryfall_ids)s) AND
-                        not(card_is_tags @> %(new_tag)s::jsonb)
-                    """,
-                    {
-                        "scryfall_ids": list(scryfall_id_batch),
-                        "new_tag": new_tag,
-                    },
-                )
-                updated_count += cursor.rowcount
-                conn.commit()
-
-        return {
-            "is_tag": is_tag,
-            "cards_updated": updated_count,
-            "total_cards_found": len(scryfall_ids),
-            "message": f"Successfully updated {updated_count} printings with is:{is_tag}",
-        }
-
-    @route()
-    def discover_is_tags_from_syntax(self, **_: object) -> list[str]:
-        """Discover all available is: tags from Scryfall syntax documentation.
-
-        Returns:
-        -------
-            List[str]: List of all available is: tag names.
-
-        Raises:
-        ------
-            ValueError: If API request fails or returns invalid data.
-
-        """
-        try:
-            response = self._session.get("https://scryfall.com/docs/syntax", timeout=30)
-            response.raise_for_status()
-        except requests.RequestException as e:
-            msg = f"Failed to fetch is: tags from Scryfall syntax: {e}"
-            raise ValueError(msg) from e
-
-        # Extract is: tag names from the documentation
-        # Look for patterns like "is:permanent", "is:spell", etc.
-        is_tag_pattern = r"is:([a-zA-Z_-]+)"
-        matches = re.findall(is_tag_pattern, response.text)
-
-        # Remove duplicates and sort
-        unique_is_tags = sorted({match.lower() for match in matches})
-
-        logger.info("Discovered %d unique is: tags from Scryfall syntax", len(unique_is_tags))
-        return unique_is_tags
-
-    @route()
-    def import_oracle_tags(self, **_: object) -> dict[str, Any]:
-        """Import oracle tags from Scryfall bulk data into oracle_tags, oracle_tag_relationships, and card_oracle_tags."""
-        return _import_oracle_tags(self._conn_pool, self._bulk_data_fetcher)
-
-    @route()
-    def import_art_tags(self, **_: object) -> dict[str, Any]:
-        """Import art tags from Scryfall bulk data into art_tags, art_tag_relationships, and card_art_tags."""
-        return _import_art_tags(self._conn_pool, self._bulk_data_fetcher)
-
-    @route()
-    def import_all_is_tags(self, **_: object) -> dict[str, Any]:
-        """Discover and import all is: tags from Scryfall syntax documentation.
-
-        Returns:
-        -------
-            Dict[str, Any]: Summary of the bulk is: tag import operation.
-
-        """
-        result: dict[str, Any] = {
-            "success": True,
-        }
-        logger.info("Starting bulk is: tag discovery and import")
-
-        try:
-            all_is_tags = self.discover_is_tags_from_syntax()
-        except ValueError as e:
-            result.update(
-                {
-                    "success": False,
-                    "error": str(e),
-                    "message": "Failed to discover is: tags from Scryfall syntax",
-                },
-            )
-            return result
-
-        if not all_is_tags:
-            return {
-                "success": False,
-                "message": "No is: tags discovered from Scryfall syntax",
-            }
-
-        # Import card associations for each is: tag
-        start_time = time.monotonic()
-        imported_tags = []
-        failed_tags = []
-        total_cards_updated = 0
-
-        for idx, is_tag in enumerate(all_is_tags):
-            try:
-                if idx > 0:
-                    elapsed_time = time.monotonic() - start_time
-                    fraction_complete = idx / len(all_is_tags)
-                    estimated_time_remaining = (elapsed_time / fraction_complete) - elapsed_time
-                    estimated_duration = datetime.timedelta(seconds=round(estimated_time_remaining, 1))
-                    logger.info(
-                        "Importing is: tag %d of %d: %20s (ETA: %s)",
-                        idx + 1,
-                        len(all_is_tags),
-                        is_tag,
-                        estimated_duration,
-                    )
-
-                tag_result = self._add_is_tag_to_cards_or_printings(is_tag=is_tag)
-                imported_tags.append(
-                    {
-                        "is_tag": is_tag,
-                        "cards_updated": tag_result["cards_updated"],
-                        "total_cards_found": tag_result["total_cards_found"],
-                    },
-                )
-                total_cards_updated += tag_result["cards_updated"]
-
-            except ValueError as e:
-                logger.warning("Failed to import is: tag '%s': %s", is_tag, e)
-                failed_tags.append({"is_tag": is_tag, "error": str(e)})
-
-        result.update(
-            {
-                "duration": time.monotonic() - start_time,
-                "discovered_is_tags": len(all_is_tags),
-                "imported_is_tags": len(imported_tags),
-                "failed_is_tags": len(failed_tags),
-                "total_cards_updated": total_cards_updated,
-                "imported_tags": imported_tags,
-                "failed_tags": failed_tags,
-                "message": f"Successfully imported {len(imported_tags)} is: tags, {len(failed_tags)} failed",
-            },
-        )
-
-        return result
-
-    @route()
-    def import_card_by_name(
-        self,
-        *,
-        card_name: str,
-        **_: object,
-    ) -> dict[str, Any]:
-        """Import a single card by name from Scryfall API.
-
-        Args:
-        ----
-            card_name (str): The exact name of the card to import.
-
-        Returns:
-        -------
-            Dict[str, Any]: Result summary with import status and card info.
-
-        """
-        if not card_name:
-            msg = "card_name parameter is required"
-            raise ValueError(msg)
-
-        logger.info("Importing card by name: '%s'", card_name)
-
-        # Check if card already exists in database for backward compatibility
-        existing_check = self._run_query(
-            query="SELECT card_name FROM magic.cards WHERE card_name = %(card_name)s",
-            params={"card_name": card_name},
-            explain=False,
-        )
-
-        if existing_check["result"]:
-            return {
-                "card_name": card_name,
-                "status": "already_exists",
-                "message": f"Card '{card_name}' already exists in database",
-            }
-
-        # Use import_cards_by_search with exact name query
-        return self.import_cards_by_search(search_query=f'!"{card_name}"')
-
-    @route()
-    def import_cards_by_search(
-        self,
-        *,
-        search_query: str,
-        **_: object,
-    ) -> dict[str, Any]:
-        """Import cards from Scryfall API using any search query.
-
-        Args:
-        ----
-            search_query (str): The Scryfall search query to execute.
-
-        Returns:
-        -------
-            Dict[str, Any]: Result summary with import status and card info.
-
-        """
-        if not search_query:
-            msg = "search_query parameter is required"
-            raise ValueError(msg)
-
-        logger.info("Importing cards by search: '%s'", search_query)
-
-        # Fetch card data from Scryfall API using the provided search query
-        try:
-            cards = self._scryfall_search(query=search_query)
-            if not cards:
-                return {
-                    "search_query": search_query,
-                    "status": "not_found",
-                    "message": f"No cards found for search query '{search_query}' in Scryfall API",
-                    "cards_loaded": 0,
-                }
-
-        except (requests.RequestException, ValueError, KeyError) as e:
-            logger.error("Error fetching cards for search '%s' from Scryfall: %s", search_query, e)
-            return {
-                "search_query": search_query,
-                "status": "error",
-                "message": f"Error fetching cards from Scryfall: {e}",
-                "cards_loaded": 0,
-            }
-
-        # Insert the cards into the database using the consolidated method
-        load_result = self._upsert_cards(cards)
-
-        if load_result["status"] == "success":
-            self._reload_engine(force=True)
-
-        # Add search_query to the result for consistency
-        load_result["search_query"] = search_query
-
-        return load_result
-
-    def _scryfall_search(self, *, query: str, unique: str = "prints") -> list[dict[str, Any]]:
-        """Search Scryfall API for cards matching the given query.
-
-        This method handles pagination to get the complete list of cards and
-        automatically applies filters for paper format and format legality.
-
-        Args:
-        ----
-            query (str): The search query string for Scryfall.
-            unique (str): The unique parameter to pass to the Scryfall API.
-
-        Returns:
-        -------
-            List[Dict[str, Any]]: List of card data from Scryfall API.
-
-        Raises:
-        ------
-            ValueError: If API request fails or returns invalid data.
-
-        """
-        # Add standard filters for paper format and format legality
-        # Wrap original query in parentheses to ensure proper filter application
-        filters = [
-            "(f:m or f:l or f:c or f:v)",
-            "game:paper",
-            f"unique:{unique}",
-        ]
-        full_query = f"({query}) {' '.join(filters)}"
-
-        base_url = "https://api.scryfall.com/cards/search"
-        params = {"q": full_query, "format": "json"}
-        all_cards = []
-
-        total_cards = "?"
-        try:
-            while True:
-                time.sleep(1 / 10)  # Rate limiting - 10 requests per second max
-                logger.info(
-                    "Making request to Scryfall API: %s %s (have %d of %s total cards)",
-                    base_url,
-                    params,
-                    len(all_cards),
-                    total_cards,
-                )
-                response = self._session.get(base_url, params=params, timeout=30)
-                response.raise_for_status()
-                data = orjson.loads(response.content)
-
-                total_cards = data.get("total_cards", 1) or 1
-
-                if "data" not in data:
-                    break
-
-                # Extract card data from current page
-                page_cards = [card for card in data["data"] if card]
-                all_cards.extend(page_cards)
-
-                # Check if there are more pages
-                if not data.get("has_more", False):
-                    break
-
-                # Get next page URL
-                next_page = data.get("next_page")
-                if not next_page:
-                    break
-
-                # Update base_url and clear params for next page
-                base_url = next_page
-                params = {}
-
-        except requests.RequestException as oops:
-            # Check if it's a 404 error - return empty list
-            if (hasattr(oops, "response") and oops.response and oops.response.status_code == NOT_FOUND) or "404" in str(oops):
-                return all_cards
-            msg = f"Failed to fetch data from Scryfall API: {oops}"
-            raise ValueError(msg) from oops
-
-        return all_cards
-
-    def _upsert_cards(
-        self,
-        cards: Iterable[dict[str, Any]],
-        page_size: int = _UPSERT_PAGE_SIZE,
-    ) -> dict[str, Any]:
-        """Preprocess and upsert an iterable of raw card dicts into magic.cards.
-
-        Preprocessing is applied lazily as cards flow through, so the full dataset
-        is never held in memory. Each batch is upserted via bulk_upsert: new rows
-        are inserted, changed rows are updated, and unchanged rows are skipped.
-
-        Returns a dict with:
-            - cards_inserted: new cards added
-            - cards_updated: existing cards with changed data
-            - cards_loaded: cards_inserted + cards_updated
-            - cards_sent: rows attempted (after preprocessing)
-            - status: "success", "no_cards_before_preprocessing", "no_cards_after_preprocessing", "database_error"
-            - message: descriptive message
-        """
-        self.setup_schema()
-
-        try:
-            with self._conn_pool.connection() as conn:
-                with conn.cursor() as cursor:
-                    self._set_statement_timeout(cursor, 30_000)
-
-                class _CardStream:
-                    """Preprocesses raw cards lazily, tracking stage counts."""
-
-                    def __init__(self) -> None:
-                        self.raw = 0
-                        self.preprocessed = 0
-
-                    def __iter__(self) -> Iterator[dict[str, Any]]:
-                        for card in cards:
-                            self.raw += 1
-                            for processed in preprocess_card(card):
-                                self.preprocessed += 1
-                                yield processed
-
-                stream = _CardStream()
-                cards_inserted = cards_updated = cards_sent = 0
-
-                for page in itertools.batched(stream, page_size):
-                    batch = _bulk_upsert(
-                        conn,
-                        "cards",
-                        list(page),
-                        schema="magic",
-                        conflict_target=["scryfall_id"],
-                        skip_columns=["card_oracle_tags", "card_art_tags", "card_is_tags"],
-                    )
-                    cards_sent += len(page)
-                    cards_inserted += batch["inserted"]
-                    cards_updated += batch["updated"]
-                    logger.info(
-                        "%d inserted, %d updated, %d sent so far",
-                        cards_inserted,
-                        cards_updated,
-                        cards_sent,
-                    )
-
-                conn.commit()
-
-                if cards_sent:
-                    self._sync_boolean_is_tags(conn)
-
-                if cards_sent == 0:
-                    if stream.raw == 0:
-                        status, message = "no_cards_before_preprocessing", "No cards provided for loading"
-                    else:
-                        status, message = "no_cards_after_preprocessing", "No cards remaining after preprocessing"
-                    logger.info("No cards imported: %s (raw=%d preprocessed=%d)", message, stream.raw, stream.preprocessed)
-                    return {"status": status, "cards_loaded": 0, "cards_sent": 0, "message": message}
-
-                cards_loaded = cards_inserted + cards_updated
-                self._clear_caches()
-                return {
-                    "status": "success",
-                    "cards_inserted": cards_inserted,
-                    "cards_updated": cards_updated,
-                    "cards_loaded": cards_loaded,
-                    "cards_sent": cards_sent,
-                    "message": f"Successfully loaded {cards_loaded} cards ({cards_inserted} new, {cards_updated} updated)",
-                }
-
-        except (psycopg.Error, ValueError, KeyError) as e:
-            logger.exception("Error loading cards")
-            return {
-                "status": "database_error",
-                "cards_loaded": 0,
-                "cards_sent": 0,
-                "message": f"Error loading cards: {type(e).__name__}: {e}",
-            }
-
-    def _clear_caches(self) -> None:
-        with self._cache_generation.get_lock():
-            self._cache_generation.value += 1
 
     @route()
     def random_search(

--- a/api/api_worker.py
+++ b/api/api_worker.py
@@ -99,7 +99,9 @@ class ApiWorker(multiprocessing.Process):
             falcon.App: The configured Falcon application instance.
         """
         # Importing here (post-fork) is safer for some servers/clients than importing before forking.
+        from api.admin_resource import AdminContext  # pylint: disable=import-outside-toplevel
         from api.api_resource import APIResource  # pylint: disable=import-outside-toplevel
+        from api.app_context import AppContext  # pylint: disable=import-outside-toplevel
         from api.middlewares import (
             CachingMiddleware,
             CompressionMiddleware,
@@ -131,13 +133,16 @@ class ApiWorker(multiprocessing.Process):
             ],
         )
         api.set_error_serializer(json_error_serializer)  # Use custom JSON error serializer
-        sink = APIResource(
+        # Built here, post-fork: reader/writer pools and the query engine can't cross a fork the
+        # way a multiprocessing.Value/Lock can, so each worker builds its own AppContext from the
+        # primitives the master created before forking.
+        app_context = AppContext(
             cache_generation=cache_generation,
             engine_reload_guard=engine_reload_guard,
-            import_guard=import_guard,
             last_import_time=last_import_time,
-            schema_setup_event=schema_setup_event,
-        )  # Create the main API resource
+        )
+        admin_context = AdminContext(import_guard=import_guard, schema_setup_event=schema_setup_event)
+        sink = APIResource(app_context=app_context, admin_context=admin_context)  # Create the main API resource
         api.add_sink(sink._handle, prefix="/")  # Route all requests to the sink handler
 
         json_handler = falcon.media.JSONHandler(

--- a/api/app_context.py
+++ b/api/app_context.py
@@ -1,0 +1,226 @@
+"""The state and resources shared between peer resources (APIResource, AdminResource, ...).
+
+None of this is owned by any one resource: `reader_pool` and `engine` are read by every
+search-shaped resource, `writer_pool` is used by every resource that imports or backfills data, and
+`cache_generation`/`last_import_time` are the cross-worker-process signal that ties writers to
+readers ("the corpus changed," "check whether setup finished"). A resource that needs one of these
+takes an `AppContext` rather than reaching into a sibling resource for it.
+
+`AppContext` itself is a per-process object: `reader_pool`/`writer_pool`/`engine` are built fresh
+inside whichever worker process constructs it (sockets and the Rust engine's in-memory store can't
+cross a fork the way a `multiprocessing.Value` can), while `cache_generation`/`last_import_time`/
+`engine_reload_guard` are expected to be created once in the master process, before forking, and
+handed to every worker's `AppContext` unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import multiprocessing
+import os
+import pathlib
+import time
+from typing import TYPE_CHECKING
+
+import psycopg_pool
+
+from api.settings import settings
+from api.utils import db_utils
+from card_engine import ENGINE_COLUMNS as _ENGINE_COLUMNS
+from card_engine import QueryEngine as _QueryEngine
+
+if TYPE_CHECKING:
+    from multiprocessing.sharedctypes import Synchronized
+    from multiprocessing.synchronize import Lock as LockType
+
+    from card_engine import QueryEngine
+
+logger = logging.getLogger(__name__)
+
+# A corpus below this size means the import never finished (or hasn't started), not that it's
+# legitimately small -- see `AppContext.setup_complete`.
+MIN_IMPORT_CARDS = 90_000
+
+# How long a `setup_complete` result is trusted before re-checking the database, once the shared
+# last_import_time hasn't changed in the meantime -- see `AppContext.setup_complete`.
+_SETUP_COMPLETE_TTL = 60 * 60  # 1 hour
+
+# Rows per batch streamed into the engine during a reload. The reload's memory floor is the
+# Rust-side build (~305 MB), so the batch only needs to be small relative to that: ~2k rows ≈ 18 MB
+# of dicts. Smaller adds round trips for no measurable gain (see
+# docs/issues/00505-engine-incremental-loading.md).
+_ENGINE_RELOAD_BATCH_SIZE = 2_000
+
+
+def _rss_mb() -> str:
+    """Return current RSS in MB as a string, or 'unknown' if /proc is unavailable."""
+    try:
+        with pathlib.Path("/proc/self/status").open() as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    return f"{int(line.split()[1]) // 1024} MB"
+    except OSError:
+        pass
+    return "unknown"
+
+
+class AppContext:
+    """Cross-cutting state and resources shared by every resource mounted on the app."""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        reader_pool: psycopg_pool.ConnectionPool | None = None,
+        writer_pool: psycopg_pool.ConnectionPool | None = None,
+        engine: QueryEngine | None = None,
+        engine_reload_guard: LockType | None = None,
+        cache_generation: Synchronized | None = None,
+        last_import_time: Synchronized | None = None,
+    ) -> None:
+        """Build the per-worker resources, or accept ones a caller already built.
+
+        Args:
+            reader_pool: Connection pool for search-shaped resources. Built via
+                `db_utils.make_pool()` if not given, matching every other handle here -- a caller
+                (a test, mainly) can inject one without a real pool ever opening a connection.
+            writer_pool: Connection pool for resources that import or backfill data. Built the same
+                way if not given; kept separate from `reader_pool` so a slow bulk write can't
+                starve a live search request for a connection.
+            engine: The in-process query engine both search-shaped resources read from.
+            engine_reload_guard: Cross-process lock serialising engine reloads, so only one worker
+                pays the reload cost at a time.
+            cache_generation: Shared counter bumped to invalidate every worker's query-result cache.
+            last_import_time: Shared timestamp of the last completed import.
+        """
+        self.reader_pool: psycopg_pool.ConnectionPool = reader_pool or db_utils.make_pool()
+        self.writer_pool: psycopg_pool.ConnectionPool = writer_pool or db_utils.make_pool()
+        self.engine: QueryEngine = engine if engine is not None else _QueryEngine()
+        self.engine_reload_guard: LockType = engine_reload_guard or multiprocessing.Lock()
+        self.cache_generation: Synchronized = cache_generation or multiprocessing.Value("i", 0)
+        self.last_import_time: Synchronized = last_import_time or multiprocessing.Value("d", 0.0, lock=True)
+        # Per-process only -- a local TTL cache keyed off the shared last_import_time, not itself a
+        # cross-worker signal (a fresh worker starts with no cached opinion and checks for real).
+        self._setup_complete_cache: tuple[bool, float, float] | None = None
+
+    def setup_complete(self) -> bool:
+        """Return True if the setup is complete."""
+        now = time.monotonic()
+        current_import_time = self.last_import_time.get_obj().value
+        if self._setup_complete_cache is not None:
+            result, expires_at, cached_import_time = self._setup_complete_cache
+            if now < expires_at and current_import_time == cached_import_time:
+                logger.debug(
+                    "setup_complete cache hit: result=%s, expires in %.0fs, pid %d",
+                    result,
+                    expires_at - now,
+                    os.getpid(),
+                )
+                return result
+        try:
+            with self.reader_pool.connection() as conn, conn.cursor() as cursor:
+                cursor.execute("SELECT COUNT(1) AS num_cards FROM magic.cards")
+                cards_found = cursor.fetchall()[0]["num_cards"]
+                result = cards_found > MIN_IMPORT_CARDS
+                if result:
+                    logger.info("Found %d cards in pid %d", cards_found, os.getpid())
+                else:
+                    logger.warning(
+                        "Setup not complete: found %d cards, need more than %d (pid %d)",
+                        cards_found,
+                        MIN_IMPORT_CARDS,
+                        os.getpid(),
+                    )
+        except Exception as oops:
+            logger.error(
+                "Error checking if setup is complete (pid %d): %s: %s",
+                os.getpid(),
+                type(oops).__name__,
+                oops,
+                exc_info=True,
+            )
+            result = False
+        self._setup_complete_cache = (result, now + _SETUP_COMPLETE_TTL, current_import_time)
+        return result
+
+    def invalidate_setup_complete(self) -> None:
+        """Force the next `setup_complete()` call to re-check the database.
+
+        Called after a write that could change the answer (an import completing), rather than
+        waiting for the TTL to expire.
+        """
+        self._setup_complete_cache = None
+
+    def bump_cache_generation(self) -> None:
+        """Invalidate every worker's query-result cache. Call after any write to magic.cards."""
+        with self.cache_generation.get_lock():
+            self.cache_generation.value += 1
+
+    def reload_engine(self, *, force: bool = False) -> None:
+        """Stream all cards from the DB into the Rust engine's card store in batches.
+
+        A server-side cursor feeds the engine's staged reload API
+        (reload_begin / add_batch / reload_commit) one batch at a time, so the
+        Python-side transient is one batch of row dicts (~18 MB at 2k rows)
+        instead of the whole corpus (~840 MB) — measurements in
+        docs/issues/00505-engine-incremental-loading.md. The reload is guarded by a
+        cross-worker lock so only one worker pays the build cost at a time.
+        With force=False (cold-start warming), losers of the race return
+        immediately and pick up the winner's archive via the engine's
+        inode-based remap. With force=True (data just changed), callers wait
+        their turn but skip the rebuild if another worker refreshed the store
+        while they were waiting.
+
+        Reads via `writer_pool`, not `reader_pool`: this is a single giant SELECT (the whole
+        corpus) triggered by a write completing, and the cross-process guard means only one worker
+        ever runs it at a time. Measured 2026-08-21 against a ~98k-card corpus: ~3 seconds
+        end-to-end, not the "minutes" an earlier version of this docstring assumed -- so this isn't
+        a high-stakes call. It's also lower-stakes than a naive pool split suggests either way: the
+        in-process engine serves the large majority of search traffic directly, with no pool
+        involved at all, so reader_pool contention during those ~3 seconds would only ever touch the
+        minority of requests that fall back to SQL. Kept on `writer_pool` anyway on the same
+        reasoning as the pool split itself (a write-triggered bulk operation belongs with other
+        writes, not with reads), just without claiming a bigger effect than the numbers support.
+
+        Args:
+            force: If False, skip entirely when another worker holds the lock or the
+                store is already populated. If True, wait for the lock and always
+                reload (the data just changed, so the archive must be rebuilt).
+        """
+        if not settings.enable_engine:
+            logger.debug("Engine reload skipped: feature-gated off (ENABLE_ENGINE)")
+            return
+        if self.engine is None:
+            return
+        logger.info("Engine reload requested (force=%s, pid=%d, rss=%s)", force, os.getpid(), _rss_mb())
+        if not self.engine_reload_guard.acquire(block=force):
+            logger.info("Engine reload already in progress in another worker, skipping (pid=%d)", os.getpid())
+            return
+        try:
+            if not force and self.engine.size() > 0:
+                # Another worker populated the store while we raced for the lock.
+                return
+            logger.info("Engine reload starting (force=%s, pid=%d, rss=%s)", force, os.getpid(), _rss_mb())
+            cols_sql = ", ".join(f"card.{col}" for col in _ENGINE_COLUMNS)
+            try:
+                with self.writer_pool.connection() as conn:
+                    # Named cursor => server-side: psycopg buffers one batch, not the full result.
+                    with conn.cursor(name="engine_reload") as cursor:
+                        cursor.itersize = _ENGINE_RELOAD_BATCH_SIZE
+                        cursor.execute(f"SELECT {cols_sql} FROM magic.cards AS card")
+                        if not self.engine.reload_begin():
+                            # Another process published a fresh archive while we
+                            # waited for the engine's write lock; it was remapped.
+                            return
+                        try:
+                            while batch := cursor.fetchmany(_ENGINE_RELOAD_BATCH_SIZE):
+                                self.engine.add_batch(batch)
+                            self.engine.reload_commit()
+                        except BaseException:
+                            self.engine.reload_abort()
+                            raise
+            except psycopg_pool.PoolClosed:
+                logger.debug("Connection pool closed during engine reload, skipping (pid=%d)", os.getpid())
+                return
+            logger.info("Engine reloaded with %d cards (pid=%d, rss=%s)", self.engine.size(), os.getpid(), _rss_mb())
+        finally:
+            self.engine_reload_guard.release()

--- a/api/card_processing.py
+++ b/api/card_processing.py
@@ -13,15 +13,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-def extract_image_location_uuid(card: dict[str, Any]) -> str:
-    """Extract the image location UUID from a card."""
-    for image_location in card.get("image_uris", {}).values():
-        if ".jpg" in image_location:
-            return image_location.rpartition("/")[-1].partition(".")[0]
-    msg = f"No image location found for card: {card}"
-    raise AssertionError(msg)
-
-
 # Card types that can exist as a permanent on the battlefield. Devotion (MTG
 # comprehensive rules) is defined only over permanents' mana costs, confirmed
 # against the real Scryfall API (devotion: never matches a pure Instant/Sorcery,
@@ -92,6 +83,33 @@ def extract_collector_number_int(collector_number: str | int | float | None) -> 
         except (ValueError, OverflowError):
             pass
     return None  # Field will be null by default
+
+
+def extract_frame_data_from_raw_card(raw_card: dict) -> dict[str, bool]:
+    """Extract frame data from a raw card dictionary.
+
+    Combines frame version and frame effects into a single JSONB object,
+    following the same pattern as _preprocess_card method.
+
+    Args:
+        raw_card: Raw card dictionary from Scryfall API.
+
+    Returns:
+        Dictionary mapping frame data keys to True.
+    """
+    frame_data = {}
+
+    # Add frame version if present (titlecased for consistency)
+    frame_version = raw_card.get("frame")
+    if frame_version:
+        frame_data[frame_version.title()] = True
+
+    # Add frame effects if present (titlecased for consistency)
+    frame_effects = raw_card.get("frame_effects", [])
+    for effect in frame_effects:
+        frame_data[effect.title()] = True
+
+    return frame_data
 
 
 def preprocess_card(card: dict[str, Any]) -> list[dict[str, Any]]:  # noqa: PLR0915,C901,PLR0912
@@ -199,17 +217,7 @@ def preprocess_card(card: dict[str, Any]) -> list[dict[str, Any]]:  # noqa: PLR0
 
     card["edhrec_rank"] = card.get("edhrec_rank")
 
-    # Extract frame data - combine frame version and frame effects into single JSONB object
-    frame_data = {}
-    # Add frame version if present (titlecased for consistency)
-    frame_version = card.get("frame")
-    if frame_version:
-        frame_data[frame_version.title()] = True
-    # Add frame effects if present (titlecased for consistency)
-    frame_effects = card.get("frame_effects", [])
-    for effect in frame_effects:
-        frame_data[effect.title()] = True
-    card["card_frame_data"] = frame_data
+    card["card_frame_data"] = extract_frame_data_from_raw_card(card)
 
     # Extract pricing data if available - ensure they are floats for jsonb_populate_record
     prices = card.get("prices", {})

--- a/api/middlewares/compression/compression_mod.py
+++ b/api/middlewares/compression/compression_mod.py
@@ -17,22 +17,6 @@ MIN_SIZE: int = 200
 logger = logging.getLogger(__name__)
 
 
-def parse_q_list(
-    accept_encoding: str,
-    server_priorities: dict[str, int],
-) -> list[str]:
-    """Parse the Accept-Encoding header and return a list of encodings sorted by client and server priority.
-
-    Args:
-        accept_encoding (str): The Accept-Encoding header value.
-        server_priorities (dict[str, int]): Mapping of encoding names to server priorities.
-
-    Returns:
-        list[str]: List of encoding names sorted by priority.
-    """
-    # TODO: add client priority
-
-
 class CompressionMiddleware:
     """Middleware for handling response compression using various algorithms."""
 

--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -13,7 +13,6 @@ from api.parsing.db_info import (
     CARD_TYPES,
     COLOR_CODE_TO_NAME,
     COLOR_NAME_TO_CODE,
-    DB_NAME_TO_FIELD_TYPE,
     FORMAT_CODE_TO_NAME,
     FieldType,
     ParserClass,
@@ -60,18 +59,6 @@ color < query
 color @> query AND color <> query # as object
 query ?& color AND not(color ?& query) # as array
 """
-
-
-def get_field_type(attr: str) -> str:
-    """Get the field type for a given attribute name.
-
-    Args:
-        attr: The attribute name to look up.
-
-    Returns:
-        The field type for the attribute, or TEXT if not found.
-    """
-    return DB_NAME_TO_FIELD_TYPE.get(attr, FieldType.TEXT)
 
 
 # Rarity ordering for comparison operations
@@ -270,33 +257,6 @@ def get_frame_data_comparison_object(val: str) -> dict[str, bool]:
     normalized_val = val.title()
 
     return {normalized_val: True}
-
-
-def extract_frame_data_from_raw_card(raw_card: dict) -> dict[str, bool]:
-    """Extract frame data from a raw card dictionary.
-
-    Combines frame version and frame effects into a single JSONB object,
-    following the same pattern as _preprocess_card method.
-
-    Args:
-        raw_card: Raw card dictionary from Scryfall API.
-
-    Returns:
-        Dictionary mapping frame data keys to True.
-    """
-    frame_data = {}
-
-    # Add frame version if present (titlecased for consistency)
-    frame_version = raw_card.get("frame")
-    if frame_version:
-        frame_data[frame_version.title()] = True
-
-    # Add frame effects if present (titlecased for consistency)
-    frame_effects = raw_card.get("frame_effects", [])
-    for effect in frame_effects:
-        frame_data[effect.title()] = True
-
-    return frame_data
 
 
 def get_keywords_comparison_object(val: str) -> dict[str, bool]:

--- a/api/parsing/db_info.py
+++ b/api/parsing/db_info.py
@@ -276,7 +276,6 @@ DB_COLUMNS = [
 KNOWN_CARD_ATTRIBUTES = set()
 NUMERIC_CARD_ATTRIBUTES: set[str] = set()
 SEARCH_NAME_TO_DB_NAME = {}
-DB_NAME_TO_FIELD_TYPE = {}
 
 ALIAS_TO_FIELD_INFOS: dict[str, list[FieldInfo]] = {}
 COLNAME_TO_FIELD_INFOS: dict[str, list[FieldInfo]] = {}
@@ -295,7 +294,6 @@ for col in DB_COLUMNS:
         NUMERIC_CARD_ATTRIBUTES.add(col.db_column_name.lower())
         NUMERIC_CARD_ATTRIBUTES.update(alias.lower() for alias in col.search_aliases)
     SEARCH_NAME_TO_DB_NAME[col.db_column_name.lower()] = col.db_column_name
-    DB_NAME_TO_FIELD_TYPE[col.db_column_name] = col.field_type
 
     for ialias in col.search_aliases:
         SEARCH_NAME_TO_DB_NAME[ialias.lower()] = col.db_column_name
@@ -341,5 +339,3 @@ FORMAT_CODE_TO_NAME = {
     "v": "vintage",
     "h": "historic",
 }
-
-FORMAT_NAME_TO_CODE = {v: k for k, v in FORMAT_CODE_TO_NAME.items()}

--- a/api/parsing/pyparsing_based.py
+++ b/api/parsing/pyparsing_based.py
@@ -55,7 +55,6 @@ ParserElement.enable_packrat(cache_size_limit=2**13)  # 8192 cache entries
 # Constants
 NEGATION_TOKEN_COUNT = 2
 DEFAULT_OPERATORS = one_of(": > < >= <= = !=")
-COMPARISON_OPERATORS = frozenset([":", "=", "!=", ">", "<", ">=", "<="])
 
 _NUMERIC_LITERAL_RE = re.compile(r"^\d+(\.\d+)?$")
 _COMPARISON_OPERATORS = frozenset({">", "<", ">=", "<=", "=", "!=", ":"})

--- a/api/settings.py
+++ b/api/settings.py
@@ -85,7 +85,7 @@ class Settings:
         """Check if the Rust card filter engine serves searches.
 
         Enabled by default. When disabled, the engine is fully inert: _search
-        routes every query to SQL and _reload_engine never runs. Disable via
+        routes every query to SQL and AppContext.reload_engine never runs. Disable via
         ENABLE_ENGINE=false for environments where the full-table fetch cost is
         unacceptable (e.g. low-memory dev machines).
         """

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -61,7 +61,7 @@ def api_resource(postgres_container: None) -> Generator[APIResource]:
         schema_setup_event=multiprocessing.Event(),
     )
     override_attr(api, "_setup_complete", lambda: True)
-    override_attr(api, "_import_recent", lambda: True)
-    api.setup_schema()
+    override_attr(api.admin, "_import_recent", lambda: True)
+    api.admin.setup_schema()
     yield api
     api._conn_pool.close()

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -27,7 +27,7 @@ def engine_enabled_fixture() -> Generator[None]:
 
 @pytest.fixture(name="stub_api_resource")
 def stub_api_resource_fixture() -> Generator[APIResource]:
-    """A fresh APIResource per test, readiness stubbed, connection pool closed afterward.
+    """A fresh APIResource per test, readiness stubbed, both connection pools closed afterward.
 
     Function-scoped on purpose: it replaces per-class `setup_method` construction, and tests using it
     mutate the instance (`_engine`, feature gates), so sharing one across a module would couple them.
@@ -46,6 +46,7 @@ def stub_api_resource_fixture() -> Generator[APIResource]:
     override_attr(api, "_setup_complete", lambda: True)
     yield api
     api._conn_pool.close()
+    api.admin._conn_pool.close()
 
 
 @pytest.fixture(scope="module")
@@ -65,3 +66,4 @@ def api_resource(postgres_container: None) -> Generator[APIResource]:
     api.admin.setup_schema()
     yield api
     api._conn_pool.close()
+    api.admin._conn_pool.close()

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -8,7 +8,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from api.admin_resource import AdminContext
 from api.api_resource import APIResource
+from api.app_context import AppContext
 from api.settings import settings
 from api.tests.support import override_attr
 
@@ -30,7 +32,8 @@ def stub_api_resource_fixture() -> Generator[APIResource]:
     """A fresh APIResource per test, readiness stubbed, both connection pools closed afterward.
 
     Function-scoped on purpose: it replaces per-class `setup_method` construction, and tests using it
-    mutate the instance (`_engine`, feature gates), so sharing one across a module would couple them.
+    mutate the instance (`app_context.engine`, feature gates), so sharing one across a module would
+    couple them.
 
     Two things it deliberately does *not* do:
 
@@ -42,11 +45,11 @@ def stub_api_resource_fixture() -> Generator[APIResource]:
     - It does not set up a schema or touch the database. Tests needing that want the `api_resource`
       fixture below instead.
     """
-    api = APIResource(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
-    override_attr(api, "_setup_complete", lambda: True)
+    api = APIResource(app_context=AppContext(last_import_time=multiprocessing.Value("d", time.time(), lock=True)))
+    override_attr(api.app_context, "setup_complete", lambda: True)
     yield api
-    api._conn_pool.close()
-    api.admin._conn_pool.close()
+    api.app_context.reader_pool.close()
+    api.app_context.writer_pool.close()
 
 
 @pytest.fixture(scope="module")
@@ -58,12 +61,12 @@ def api_resource(postgres_container: None) -> Generator[APIResource]:
     rows they created themselves (unique card names / oracle_ids), never about global counts.
     """
     api = APIResource(
-        last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-        schema_setup_event=multiprocessing.Event(),
+        app_context=AppContext(last_import_time=multiprocessing.Value("d", time.time(), lock=True)),
+        admin_context=AdminContext(schema_setup_event=multiprocessing.Event()),
     )
-    override_attr(api, "_setup_complete", lambda: True)
+    override_attr(api.app_context, "setup_complete", lambda: True)
     override_attr(api.admin, "_import_recent", lambda: True)
     api.admin.setup_schema()
     yield api
-    api._conn_pool.close()
-    api.admin._conn_pool.close()
+    api.app_context.reader_pool.close()
+    api.app_context.writer_pool.close()

--- a/api/tests/support.py
+++ b/api/tests/support.py
@@ -2,24 +2,40 @@
 
 from __future__ import annotations
 
+import multiprocessing
+import time
 from unittest.mock import MagicMock
 
+from api.app_context import AppContext
 
-def mock_conn_pool_kwargs() -> tuple[MagicMock, dict[str, MagicMock]]:
-    """A mock pool plus the APIResource(...) kwargs that inject it as both `_conn_pool`s.
 
-    APIResource.__init__ takes `conn_pool` and `admin_conn_pool` precisely so a test can hand it a
-    mock at construction time; passed the return value here as `**kwargs`, no real
-    psycopg_pool.ConnectionPool is ever opened, so there is nothing to close afterward. One mock
-    covers both attributes, matching how a single `_conn_pool` mock covered every code path before
-    AdminResource had its own pool.
+def mock_app_context(**overrides: object) -> AppContext:
+    """An AppContext with mock pools/engine, for injecting into APIResource(app_context=...).
+
+    No real `psycopg_pool.ConnectionPool` is ever opened, so there is nothing to close afterward.
+    `reader_pool`/`writer_pool` default to one shared `MagicMock()`, matching how a single
+    `_conn_pool` mock covered every code path before AdminResource had its own pool. `last_import_time`
+    defaults to now rather than `AppContext`'s own "nothing imported yet" default: `APIResource.__init__`
+    calls `self.admin.import_data()`, and a stale `last_import_time` would make its fast path
+    (`_import_recent`) miss and kick off a real Scryfall import during construction. Pass an
+    explicit `reader_pool=`/`writer_pool=`/`last_import_time=` (or anything else `AppContext` takes)
+    to override just that field.
+
+    Args:
+        **overrides: Any `AppContext.__init__` keyword to set explicitly instead of defaulting.
 
     Returns:
-        The mock, and a `{"conn_pool": ..., "admin_conn_pool": ...}` dict to spread into the
-        APIResource(...) call.
+        A ready `AppContext`.
     """
     mock_pool = MagicMock()
-    return mock_pool, {"conn_pool": mock_pool, "admin_conn_pool": mock_pool}
+    kwargs: dict[str, object] = {
+        "reader_pool": mock_pool,
+        "writer_pool": mock_pool,
+        "engine": MagicMock(),
+        "last_import_time": multiprocessing.Value("d", time.time(), lock=True),
+    }
+    kwargs.update(overrides)
+    return AppContext(**kwargs)
 
 
 def override_attr(obj: object, name: str, value: object) -> None:

--- a/api/tests/support.py
+++ b/api/tests/support.py
@@ -2,6 +2,25 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
+
+def mock_conn_pool_kwargs() -> tuple[MagicMock, dict[str, MagicMock]]:
+    """A mock pool plus the APIResource(...) kwargs that inject it as both `_conn_pool`s.
+
+    APIResource.__init__ takes `conn_pool` and `admin_conn_pool` precisely so a test can hand it a
+    mock at construction time; passed the return value here as `**kwargs`, no real
+    psycopg_pool.ConnectionPool is ever opened, so there is nothing to close afterward. One mock
+    covers both attributes, matching how a single `_conn_pool` mock covered every code path before
+    AdminResource had its own pool.
+
+    Returns:
+        The mock, and a `{"conn_pool": ..., "admin_conn_pool": ...}` dict to spread into the
+        APIResource(...) call.
+    """
+    mock_pool = MagicMock()
+    return mock_pool, {"conn_pool": mock_pool, "admin_conn_pool": mock_pool}
+
 
 def override_attr(obj: object, name: str, value: object) -> None:
     """Replace an existing attribute on an instance, failing if it is not already there.

--- a/api/tests/test_admin_mount.py
+++ b/api/tests/test_admin_mount.py
@@ -16,6 +16,7 @@ import pytest
 
 from api.admin_resource import ADMIN_MOUNT_PREFIX, AdminResource
 from api.api_resource import APIResource
+from api.app_context import AppContext
 
 # The complete public surface, as a literal. A route appearing or disappearing here is a deliberate
 # act, and this is the guard that makes it one — the failure this whole change exists to prevent was
@@ -61,15 +62,17 @@ EXPECTED_ADMIN_ROUTES = {
 def resource_fixture() -> APIResource:
     """An APIResource with its child mounted, against distinct mocked pools.
 
-    conn_pool and admin_conn_pool are injected separately (rather than left to default) so the
-    parent's and the child's pools are distinct objects, matching that AdminResource now opens its
-    own pool instead of sharing the parent's.
+    reader_pool and writer_pool are injected separately (rather than left to default) so the two
+    are distinct objects, matching that AdminResource reads/writes via its own pool rather than
+    the one search-shaped resources use.
     """
-    return APIResource(
+    app_context = AppContext(
+        reader_pool=MagicMock(),
+        writer_pool=MagicMock(),
+        engine=MagicMock(),
         last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-        conn_pool=MagicMock(),
-        admin_conn_pool=MagicMock(),
     )
+    return APIResource(app_context=app_context)
 
 
 class TestRouteTable:
@@ -144,24 +147,29 @@ class TestDispatch:
 
 
 class TestSharedSurface:
-    """The child reaches the parent for exactly the surface they share."""
+    """Both resources reach into one shared AppContext rather than one holding a reference to the other."""
 
-    def test_child_holds_its_parent(self, resource: APIResource) -> None:
+    def test_admin_holds_no_reference_to_the_parent(self, resource: APIResource) -> None:
         assert isinstance(resource.admin, AdminResource)
-        assert resource.admin._parent is resource
+        assert not hasattr(resource.admin, "_parent")
+
+    def test_both_resources_share_one_app_context(self, resource: APIResource) -> None:
+        assert resource.admin.app_context is resource.app_context
 
     def test_admin_only_handles_live_on_the_child(self, resource: APIResource) -> None:
-        for handle in ("_session", "_bulk_data_fetcher", "_import_guard", "_schema_setup_event"):
+        for handle in ("_session", "_bulk_data_fetcher", "admin_context"):
             assert hasattr(resource.admin, handle), handle
             assert not hasattr(resource, handle), f"{handle} should have moved to the child"
 
-    def test_shared_handles_stay_on_the_parent(self, resource: APIResource) -> None:
-        for handle in ("_cache_generation", "_last_import_time"):
-            assert hasattr(resource, handle), handle
+    def test_admin_context_holds_the_import_serialisation_primitives(self, resource: APIResource) -> None:
+        assert hasattr(resource.admin.admin_context, "import_guard")
+        assert hasattr(resource.admin.admin_context, "schema_setup_event")
 
-    def test_admin_has_its_own_conn_pool(self, resource: APIResource) -> None:
-        # Not a shared handle: each side opens its own psycopg_pool.ConnectionPool, so nothing
-        # here reaches through the parent for a connection, its query cache, or EXPLAIN plumbing.
-        assert hasattr(resource, "_conn_pool")
-        assert hasattr(resource.admin, "_conn_pool")
-        assert resource.admin._conn_pool is not resource._conn_pool
+    def test_shared_signals_live_on_app_context(self, resource: APIResource) -> None:
+        for handle in ("cache_generation", "last_import_time"):
+            assert hasattr(resource.app_context, handle), handle
+
+    def test_admin_reads_and_writes_via_its_own_pool(self, resource: APIResource) -> None:
+        # Each side reads/writes via its own pool, so nothing here needs the reader's query cache
+        # or EXPLAIN plumbing.
+        assert resource.app_context.writer_pool is not resource.app_context.reader_pool

--- a/api/tests/test_admin_mount.py
+++ b/api/tests/test_admin_mount.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import multiprocessing
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import falcon
 import falcon.testing
@@ -59,9 +59,17 @@ EXPECTED_ADMIN_ROUTES = {
 
 @pytest.fixture(name="resource")
 def resource_fixture() -> APIResource:
-    """An APIResource with its child mounted, against a mocked pool."""
-    with patch("api.api_resource.db_utils.make_pool", return_value=MagicMock()):
-        return APIResource(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
+    """An APIResource with its child mounted, against distinct mocked pools.
+
+    conn_pool and admin_conn_pool are injected separately (rather than left to default) so the
+    parent's and the child's pools are distinct objects, matching that AdminResource now opens its
+    own pool instead of sharing the parent's.
+    """
+    return APIResource(
+        last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+        conn_pool=MagicMock(),
+        admin_conn_pool=MagicMock(),
+    )
 
 
 class TestRouteTable:
@@ -148,5 +156,12 @@ class TestSharedSurface:
             assert not hasattr(resource, handle), f"{handle} should have moved to the child"
 
     def test_shared_handles_stay_on_the_parent(self, resource: APIResource) -> None:
-        for handle in ("_conn_pool", "_cache_generation", "_last_import_time"):
+        for handle in ("_cache_generation", "_last_import_time"):
             assert hasattr(resource, handle), handle
+
+    def test_admin_has_its_own_conn_pool(self, resource: APIResource) -> None:
+        # Not a shared handle: each side opens its own psycopg_pool.ConnectionPool, so nothing
+        # here reaches through the parent for a connection, its query cache, or EXPLAIN plumbing.
+        assert hasattr(resource, "_conn_pool")
+        assert hasattr(resource.admin, "_conn_pool")
+        assert resource.admin._conn_pool is not resource._conn_pool

--- a/api/tests/test_admin_mount.py
+++ b/api/tests/test_admin_mount.py
@@ -6,8 +6,6 @@ admin handlers reachable, or advertises them, would otherwise pass every other t
 
 from __future__ import annotations
 
-import multiprocessing
-import time
 from unittest.mock import MagicMock
 
 import falcon
@@ -16,7 +14,7 @@ import pytest
 
 from api.admin_resource import ADMIN_MOUNT_PREFIX, AdminResource
 from api.api_resource import APIResource
-from api.app_context import AppContext
+from api.tests.support import mock_app_context
 
 # The complete public surface, as a literal. A route appearing or disappearing here is a deliberate
 # act, and this is the guard that makes it one — the failure this whole change exists to prevent was
@@ -66,12 +64,7 @@ def resource_fixture() -> APIResource:
     are distinct objects, matching that AdminResource reads/writes via its own pool rather than
     the one search-shaped resources use.
     """
-    app_context = AppContext(
-        reader_pool=MagicMock(),
-        writer_pool=MagicMock(),
-        engine=MagicMock(),
-        last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-    )
+    app_context = mock_app_context(reader_pool=MagicMock(), writer_pool=MagicMock())
     return APIResource(app_context=app_context)
 
 

--- a/api/tests/test_admin_mount.py
+++ b/api/tests/test_admin_mount.py
@@ -1,0 +1,152 @@
+"""Tests for the boundary between the public route table and the mounted admin child.
+
+The point of these is that the mount is a boundary rather than a URL prefix. A change that leaves the
+admin handlers reachable, or advertises them, would otherwise pass every other test in the suite.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import time
+from unittest.mock import MagicMock, patch
+
+import falcon
+import falcon.testing
+import pytest
+
+from api.admin_resource import ADMIN_MOUNT_PREFIX, AdminResource
+from api.api_resource import APIResource
+
+# The complete public surface, as a literal. A route appearing or disappearing here is a deliberate
+# act, and this is the guard that makes it one — the failure this whole change exists to prevent was
+# a handler becoming reachable because registration defaulted to exposing it.
+EXPECTED_PUBLIC_ROUTES = {
+    "_root",
+    "card",
+    "favicon.ico",
+    "get_catalog",
+    "get_common_keywords",
+    "get_pid",
+    "index",
+    "index.html",
+    "random_search",
+    "robots.txt",
+    "search",
+    "static/app.js",
+    "static/app.min.js",
+    "static/card.js",
+    "static/favicon.ico",
+    "static/social-preview.webp",
+    "static/styles.css",
+}
+
+# Handlers that must only ever be reachable behind the mount.
+EXPECTED_ADMIN_ROUTES = {
+    "backfill_cubecobra_scores",
+    "backfill_prefer_scores",
+    "discover_is_tags_from_syntax",
+    "import_all_is_tags",
+    "import_art_tags",
+    "import_card_by_name",
+    "import_cards_by_search",
+    "import_data",
+    "import_oracle_tags",
+    "ingest_cubecobra",
+    "prefer_score_tuner",
+    "setup_schema",
+}
+
+
+@pytest.fixture(name="resource")
+def resource_fixture() -> APIResource:
+    """An APIResource with its child mounted, against a mocked pool."""
+    with patch("api.api_resource.db_utils.make_pool", return_value=MagicMock()):
+        return APIResource(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
+
+
+class TestRouteTable:
+    """What is registered, and where."""
+
+    def test_public_surface_is_exactly_as_expected(self, resource: APIResource) -> None:
+        public = {path for path in resource.routes if not path.startswith(f"{ADMIN_MOUNT_PREFIX}/")}
+        assert public == EXPECTED_PUBLIC_ROUTES
+
+    def test_admin_handlers_are_only_behind_the_mount(self, resource: APIResource) -> None:
+        behind = {
+            path.removeprefix(f"{ADMIN_MOUNT_PREFIX}/") for path in resource.routes if path.startswith(f"{ADMIN_MOUNT_PREFIX}/")
+        }
+        assert behind == EXPECTED_ADMIN_ROUTES
+        assert not EXPECTED_ADMIN_ROUTES & EXPECTED_PUBLIC_ROUTES
+
+    def test_every_admin_route_is_bound_to_the_child(self, resource: APIResource) -> None:
+        # A handler left on the parent would be registered under the prefix but still reachable
+        # unprefixed, which is the shape of the bug this replaced.
+        for path, entry in resource.routes.items():
+            if path.startswith(f"{ADMIN_MOUNT_PREFIX}/"):
+                assert entry.action.__wrapped__.__self__ is resource.admin
+
+
+class TestDelisting:
+    """The 404 listing must not become a directory of what is behind the mount."""
+
+    def test_no_admin_route_is_advertised(self, resource: APIResource) -> None:
+        assert not [name for name in resource._not_found_routes if ADMIN_MOUNT_PREFIX in name]
+
+    def test_listing_matches_the_public_surface(self, resource: APIResource) -> None:
+        assert set(resource._not_found_routes) == EXPECTED_PUBLIC_ROUTES
+
+    def test_mount_declares_itself_unadvertised(self, resource: APIResource) -> None:
+        # Set once at the mount rather than on each handler, so forgetting it is a property of the
+        # single call site instead of a hole in one route.
+        for path, entry in resource.routes.items():
+            assert entry.spec.advertise is not path.startswith(f"{ADMIN_MOUNT_PREFIX}/")
+
+
+class TestDispatch:
+    """What a client can actually reach."""
+
+    def _client(self, resource: APIResource) -> falcon.testing.TestClient:
+        app = falcon.App()
+        app.add_sink(resource._handle, prefix="/")
+        return falcon.testing.TestClient(app)
+
+    @pytest.mark.parametrize(
+        argnames=["name"],
+        argvalues=[(name,) for name in sorted(EXPECTED_ADMIN_ROUTES)],
+    )
+    def test_admin_handler_is_not_reachable_unprefixed(self, resource: APIResource, name: str) -> None:
+        assert self._client(resource).simulate_get(f"/{name}").status == falcon.HTTP_404
+
+    def test_unknown_path_under_the_mount_is_indistinguishable_from_any_other(self, resource: APIResource) -> None:
+        # If the mount answered differently it would confirm its own existence, which is why the
+        # child contributes nothing to the listing and has no 404 of its own.
+        client = self._client(resource)
+        under_mount = client.simulate_get(f"/{ADMIN_MOUNT_PREFIX}/nope")
+        elsewhere = client.simulate_get("/totally/bogus")
+        assert under_mount.status == elsewhere.status == falcon.HTTP_404
+        assert under_mount.text == elsewhere.text
+
+    def test_bare_mount_prefix_is_a_404(self, resource: APIResource) -> None:
+        assert self._client(resource).simulate_get(f"/{ADMIN_MOUNT_PREFIX}/").status == falcon.HTTP_404
+
+    def test_public_routes_still_answer(self, resource: APIResource) -> None:
+        client = self._client(resource)
+        assert client.simulate_get("/get_pid").status == falcon.HTTP_200
+        assert client.simulate_get("/robots.txt").status == falcon.HTTP_200
+
+
+class TestSharedSurface:
+    """The child reaches the parent for exactly the surface they share."""
+
+    def test_child_holds_its_parent(self, resource: APIResource) -> None:
+        assert isinstance(resource.admin, AdminResource)
+        assert resource.admin._parent is resource
+
+    def test_admin_only_handles_live_on_the_child(self, resource: APIResource) -> None:
+        for handle in ("_session", "_bulk_data_fetcher", "_import_guard", "_schema_setup_event"):
+            assert hasattr(resource.admin, handle), handle
+            assert not hasattr(resource, handle), f"{handle} should have moved to the child"
+
+    def test_shared_handles_stay_on_the_parent(self, resource: APIResource) -> None:
+        for handle in ("_conn_pool", "_cache_generation", "_last_import_time"):
+            assert hasattr(resource, handle), handle

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -3,7 +3,6 @@
 import multiprocessing
 import os
 import pathlib
-import time
 import unittest
 import uuid
 from collections.abc import Generator
@@ -16,11 +15,12 @@ import falcon.testing
 import pytest
 
 import api.api_resource as api_resource_module
+from api.admin_resource import AdminContext
 from api.api_resource import INTERNAL_ERROR_DESCRIPTION, APIResource
 from api.enums import ResponseShape
 from api.middlewares.caching_middleware import CachingMiddleware
 from api.settings import settings
-from api.tests.support import mock_conn_pool_kwargs
+from api.tests.support import mock_app_context
 from api.utils.routing import BoundRoute, RouteSpec, route
 from api.utils.site_name import FALLBACK_SITE_NAME
 
@@ -140,11 +140,9 @@ class TestBaseAPIResourceTest:
         """Set up test fixtures."""
         self_reference = request.instance
 
-        self_reference.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
-        self_reference.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self_reference.app_context = mock_app_context()
+        self_reference.mock_conn_pool = self_reference.app_context.reader_pool
+        self_reference.api_resource = APIResource(app_context=self_reference.app_context)
 
 
 class TestAPIResourceInitializationNewStyle(TestBaseAPIResourceTest):
@@ -153,7 +151,7 @@ class TestAPIResourceInitializationNewStyle(TestBaseAPIResourceTest):
     def test_initialization_defaults(self) -> None:
         """Test APIResource initialization with default parameters."""
         api_resource = self.api_resource
-        assert api_resource._conn_pool == self.mock_conn_pool
+        assert api_resource.app_context.reader_pool == self.mock_conn_pool
 
         # Check that action map is populated
         assert "get_pid" in api_resource.routes
@@ -169,11 +167,11 @@ class TestAPIResourceInitializationNewStyle(TestBaseAPIResourceTest):
         """Test APIResource initialization with custom import guard."""
         custom_guard = multiprocessing.RLock()
         api_resource = APIResource(
-            import_guard=custom_guard,
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            app_context=mock_app_context(),
+            admin_context=AdminContext(import_guard=custom_guard),
         )
 
-        assert api_resource.admin._import_guard == custom_guard
+        assert api_resource.admin.admin_context.import_guard == custom_guard
 
     def test_every_public_method_is_still_registered(self) -> None:
         """Test the marker migration left no previously-routed method behind.
@@ -302,7 +300,7 @@ class TestRequestDispatch(TestBaseAPIResourceTest):
             def shadows_search(self, **_: object) -> None: ...
 
         with pytest.raises(RuntimeError, match="claimed by both"):
-            Colliding(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
+            Colliding(app_context=mock_app_context())
 
     @pytest.mark.parametrize(argnames=["path"], argvalues=[("/index",), ("/index.html",)])
     def test_index_path_redirects_instead_of_erroring(self, path: str) -> None:
@@ -363,11 +361,9 @@ class TestAPIResourceCoreMethods(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self.app_context = mock_app_context()
+        self.mock_conn_pool = self.app_context.reader_pool
+        self.api_resource = APIResource(app_context=self.app_context)
 
     def test_get_pid_returns_process_id(self) -> None:
         """Test that get_pid returns the current process ID."""
@@ -381,11 +377,9 @@ class TestAPIResourceRequestHandling(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self.app_context = mock_app_context()
+        self.mock_conn_pool = self.app_context.reader_pool
+        self.api_resource = APIResource(app_context=self.app_context)
 
     def test_raise_not_found_raises_http_not_found(self) -> None:
         """Test _raise_not_found raises HTTPNotFound with route information."""
@@ -594,7 +588,7 @@ class TestSearchResponseShape(TestBaseAPIResourceTest):
         mock_engine = MagicMock()
         mock_engine.size.return_value = 100
         mock_engine.sample_preferred.return_value = iter(self.search_results["cards"])
-        with patch.object(self.api_resource, "_engine", mock_engine):
+        with patch.object(self.api_resource.app_context, "engine", mock_engine):
             result = self.api_resource.random_search(
                 falcon_response=MagicMock(),
                 num_cards=2,
@@ -644,11 +638,9 @@ class TestAPIResourceStaticFileServing(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self.app_context = mock_app_context()
+        self.mock_conn_pool = self.app_context.reader_pool
+        self.api_resource = APIResource(app_context=self.app_context)
 
     def test_index_html_serves_static_file(self) -> None:
         """Test _root serves the index.html file."""
@@ -775,11 +767,9 @@ class TestAPIResourceErrorHandling(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self.app_context = mock_app_context()
+        self.mock_conn_pool = self.app_context.reader_pool
+        self.api_resource = APIResource(app_context=self.app_context)
 
     def test_import_card_by_name_validates_card_name_parameter(self) -> None:
         """Test import_card_by_name validates card_name parameter."""
@@ -808,11 +798,9 @@ class TestAPIResourceCaching(unittest.TestCase):
         # Enable caching for these tests
         settings.enable_cache = True
         # Now create the APIResource with caching enabled
-        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self.app_context = mock_app_context()
+        self.mock_conn_pool = self.app_context.reader_pool
+        self.api_resource = APIResource(app_context=self.app_context)
 
     def tearDown(self) -> None:
         """Restore original cache setting."""
@@ -825,8 +813,8 @@ class TestAPIResourceCaching(unittest.TestCase):
         mock_cursor = MagicMock()
         mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
         with (
-            # _upsert_cards runs on AdminResource's own pool, not the parent's.
-            patch.object(self.api_resource.admin, "_conn_pool") as mock_pool,
+            # _upsert_cards runs via the shared AppContext's writer_pool, not the reader_pool.
+            patch.object(self.api_resource.admin.app_context, "writer_pool") as mock_pool,
             patch(
                 "api.admin_resource._bulk_upsert",
                 return_value={"inserted": 1, "updated": 0, "unchanged": 0},
@@ -865,10 +853,10 @@ class TestAPIResourceCaching(unittest.TestCase):
                 prices={},
             )
 
-            gen_before = self.api_resource._cache_generation.value
+            gen_before = self.api_resource.app_context.cache_generation.value
             self.api_resource.admin._upsert_cards([valid_card])
             # Generation increment is the cross-worker invalidation signal
-            assert self.api_resource._cache_generation.value > gen_before
+            assert self.api_resource.app_context.cache_generation.value > gen_before
 
     def test_random_search_uses_engine_sample_preferred(self) -> None:
         """random_search delegates to engine.sample_preferred() when the engine is loaded."""
@@ -879,7 +867,7 @@ class TestAPIResourceCaching(unittest.TestCase):
         mock_engine.size.return_value = 2
         mock_engine.sample_preferred.return_value = fake_cards
 
-        with patch.object(self.api_resource, "_engine", mock_engine):
+        with patch.object(self.api_resource.app_context, "engine", mock_engine):
             result = self.api_resource.random_search(num_cards=2)
 
         mock_engine.sample_preferred.assert_called_once_with(2)
@@ -894,7 +882,7 @@ class TestAPIResourceCaching(unittest.TestCase):
         mock_engine.size.return_value = 0
 
         with (
-            patch.object(self.api_resource, "_engine", mock_engine),
+            patch.object(self.api_resource.app_context, "engine", mock_engine),
             patch.object(self.api_resource, "_trigger_background_reload_if_needed"),
         ):
             result = self.api_resource.random_search(num_cards=1)
@@ -913,7 +901,7 @@ class TestAPIResourceCaching(unittest.TestCase):
         mock_engine = MagicMock()
         mock_engine.size.return_value = 0
 
-        with patch.object(self.api_resource, "_engine", mock_engine):
+        with patch.object(self.api_resource.app_context, "engine", mock_engine):
             with pytest.raises(falcon.HTTPServiceUnavailable):
                 self.api_resource.get_catalog()
 
@@ -939,7 +927,7 @@ class TestAPIResourceCaching(unittest.TestCase):
             "Haste": 3,
         }
 
-        with patch.object(self.api_resource, "_engine", mock_engine):
+        with patch.object(self.api_resource.app_context, "engine", mock_engine):
             result = self.api_resource.get_catalog()
 
         assert result == {
@@ -978,7 +966,7 @@ class TestAPIResourceCaching(unittest.TestCase):
             "Deathtouch": 2,
         }
 
-        with patch.object(self.api_resource, "_engine", mock_engine):
+        with patch.object(self.api_resource.app_context, "engine", mock_engine):
             result = self.api_resource.get_catalog()
 
         assert list(result["types"]) == ["Aura", "Aurochs", "Kindred", "Tribal", "Wall"]
@@ -994,20 +982,16 @@ class TestAPIResourceCaching(unittest.TestCase):
         assert "test_key" not in self.api_resource._query_cache
 
         # Test that generation increment invalidates the search gen cache
-        gen_before = self.api_resource._cache_generation.value
+        gen_before = self.api_resource.app_context.cache_generation.value
         self.api_resource.admin._clear_caches()
-        assert self.api_resource._cache_generation.value == gen_before + 1
+        assert self.api_resource.app_context.cache_generation.value == gen_before + 1
 
 
 class TestRootSiteNameInjection(unittest.TestCase):
     """Tests that _root injects the derived site name into the HTML."""
 
     def setUp(self) -> None:
-        _, pool_kwargs = mock_conn_pool_kwargs()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self.api_resource = APIResource(app_context=mock_app_context())
 
     def test_valid_hostname_replaces_fallback_in_html(self) -> None:
         mock_response = MagicMock()
@@ -1025,11 +1009,7 @@ class TestCardSiteNameInjection(unittest.TestCase):
     """Tests that card() injects the derived site name into card page HTML."""
 
     def setUp(self) -> None:
-        _, pool_kwargs = mock_conn_pool_kwargs()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self.api_resource = APIResource(app_context=mock_app_context())
 
     def test_valid_hostname_replaces_fallback_in_card_html(self) -> None:
         mock_response = MagicMock()

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -16,18 +16,12 @@ import falcon.testing
 import pytest
 
 import api.api_resource as api_resource_module
-from api.api_resource import (
-    FALLBACK_SITE_NAME,
-    INTERNAL_ERROR_DESCRIPTION,
-    APIResource,
-    _hostname_to_site_name,
-    _split_words,
-    hostname_to_site_name,
-)
+from api.api_resource import INTERNAL_ERROR_DESCRIPTION, APIResource
 from api.enums import ResponseShape
 from api.middlewares.caching_middleware import CachingMiddleware
 from api.settings import settings
 from api.utils.routing import BoundRoute, RouteSpec, route
+from api.utils.site_name import FALLBACK_SITE_NAME
 
 
 def make_bound_route(action: object, *, path: str = "search", positional_capacity: float = 0.0) -> BoundRoute:
@@ -177,7 +171,8 @@ class TestAPIResourceInitializationNewStyle(TestBaseAPIResourceTest):
 
         # Check that caches are initialized
         assert hasattr(api_resource, "_query_cache")
-        assert hasattr(api_resource, "_session")
+        # _session moved to the admin child, which owns the outbound Scryfall/CubeCobra calls.
+        assert hasattr(api_resource.admin, "_session")
 
     def test_initialization_with_custom_import_guard(self) -> None:
         """Test APIResource initialization with custom import guard."""
@@ -187,7 +182,7 @@ class TestAPIResourceInitializationNewStyle(TestBaseAPIResourceTest):
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
         )
 
-        assert api_resource._import_guard == custom_guard
+        assert api_resource.admin._import_guard == custom_guard
 
     def test_every_public_method_is_still_registered(self) -> None:
         """Test the marker migration left no previously-routed method behind.
@@ -797,53 +792,6 @@ class TestAPIResourceStaticFileServing(unittest.TestCase):
         assert mock_response.content_type == "text/plain"
 
 
-class TestHtmlMinification(unittest.TestCase):
-    """_minify_html reduces page weight.
-
-    Must not corrupt the per-request placeholders that _build_base_html's cached output still
-    needs substituted afterward (SERVER_SIDE_RESULTS, SERVER_SIDE_EMBEDDED_DATA).
-    """
-
-    def setUp(self) -> None:
-        self.mock_conn_pool = MagicMock()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-        )
-        self.api_resource._conn_pool = self.mock_conn_pool
-
-    def test_minifies_whitespace_by_default(self) -> None:
-        # minify_html also drops the redundant closing </p> (valid HTML5 tag-omission), hence
-        # "<div><p>x</div>" rather than a literal whitespace-only collapse.
-        assert api_resource_module._minify_html("<div>   <p>x</p>   </div>") == "<div><p>x</div>"
-
-    def test_disabled_flag_returns_input_unchanged(self) -> None:
-        original = api_resource_module._MINIFY_HTML_ENABLED
-        api_resource_module._MINIFY_HTML_ENABLED = False
-        try:
-            html = "<div>   <p>x</p>   </div>"
-            assert api_resource_module._minify_html(html) == html
-        finally:
-            api_resource_module._MINIFY_HTML_ENABLED = original
-
-    def test_server_side_placeholders_survive_minification(self) -> None:
-        mock_response = MagicMock()
-        self.api_resource._root(falcon_response=mock_response)
-        assert "<!-- SERVER_SIDE_RESULTS -->" in mock_response.text
-        assert "<!-- SERVER_SIDE_EMBEDDED_DATA -->" in mock_response.text
-
-    def test_search_results_still_embed_after_minification(self) -> None:
-        mock_response = MagicMock()
-        mock_search_results = {
-            "cards": [{"name": "Elvish Mystic", "set_code": "m14", "collector_number": "1"}],
-            "total_cards": 1,
-            "query": "elf",
-        }
-        with patch.object(self.api_resource, "_search", return_value=mock_search_results):
-            self.api_resource._root(falcon_response=mock_response, q="elf")
-        assert "window.EMBEDDED_SEARCH_RESULTS = {" in mock_response.text
-        assert "Elvish Mystic" in mock_response.text
-
-
 class TestAPIResourceErrorHandling(unittest.TestCase):
     """Test error handling in APIResource methods."""
 
@@ -858,18 +806,18 @@ class TestAPIResourceErrorHandling(unittest.TestCase):
     def test_import_card_by_name_validates_card_name_parameter(self) -> None:
         """Test import_card_by_name validates card_name parameter."""
         with pytest.raises(ValueError, match="card_name parameter is required"):
-            self.api_resource.import_card_by_name(card_name="")
+            self.api_resource.admin.import_card_by_name(card_name="")
 
         with pytest.raises(ValueError, match="card_name parameter is required"):
-            self.api_resource.import_card_by_name(card_name=None)
+            self.api_resource.admin.import_card_by_name(card_name=None)
 
     def test_import_cards_by_search_validates_search_query_parameter(self) -> None:
         """Test import_cards_by_search validates search_query parameter."""
         with pytest.raises(ValueError, match="search_query parameter is required"):
-            self.api_resource.import_cards_by_search(search_query="")
+            self.api_resource.admin.import_cards_by_search(search_query="")
 
         with pytest.raises(ValueError, match="search_query parameter is required"):
-            self.api_resource.import_cards_by_search(search_query=None)
+            self.api_resource.admin.import_cards_by_search(search_query=None)
 
 
 class TestAPIResourceCaching(unittest.TestCase):
@@ -901,7 +849,7 @@ class TestAPIResourceCaching(unittest.TestCase):
         with (
             patch.object(self.api_resource, "_conn_pool") as mock_pool,
             patch(
-                "api.api_resource._bulk_upsert",
+                "api.admin_resource._bulk_upsert",
                 return_value={"inserted": 1, "updated": 0, "unchanged": 0},
             ),
         ):
@@ -924,7 +872,7 @@ class TestAPIResourceCaching(unittest.TestCase):
             )
 
             # Call _upsert_cards directly to test cache clearing
-            self.api_resource._upsert_cards([valid_card])
+            self.api_resource.admin._upsert_cards([valid_card])
 
             # Cache should be cleared after successful load
             assert "test_key" not in self.api_resource._query_cache
@@ -939,7 +887,7 @@ class TestAPIResourceCaching(unittest.TestCase):
             )
 
             gen_before = self.api_resource._cache_generation.value
-            self.api_resource._upsert_cards([valid_card])
+            self.api_resource.admin._upsert_cards([valid_card])
             # Generation increment is the cross-worker invalidation signal
             assert self.api_resource._cache_generation.value > gen_before
 
@@ -1068,149 +1016,8 @@ class TestAPIResourceCaching(unittest.TestCase):
 
         # Test that generation increment invalidates the search gen cache
         gen_before = self.api_resource._cache_generation.value
-        self.api_resource._clear_caches()
+        self.api_resource.admin._clear_caches()
         assert self.api_resource._cache_generation.value == gen_before + 1
-
-
-_HOSTNAME_TESTCASES = {
-    "tolarian_acade_my": {
-        "expected": "Tolarian Academy",
-        "raw_host": "tolarian-acade.my",
-    },
-    "strips_com_tld": {
-        "expected": "Sylvan Librarian",
-        "raw_host": "sylvan-librarian.com",
-    },
-    "strips_port": {
-        "expected": "Sylvan Librarian",
-        "raw_host": "sylvan-librarian.com:443",
-    },
-    "strips_www_prefix": {
-        "expected": "Sylvan Librarian",
-        "raw_host": "www.sylvan-librarian.com",
-    },
-    "strips_subdomain_com": {
-        "expected": "Sylvan Librarian",
-        "raw_host": "foo.sylvan-librarian.com",
-    },
-    "strips_subdomain_non_strip_tld": {
-        "expected": "Tolarian Academy",
-        "raw_host": "foo.tolarian-acade.my",
-    },
-    "localhost_returns_fallback": {
-        "expected": FALLBACK_SITE_NAME,
-        "raw_host": "localhost",
-    },
-    "localhost_with_port_returns_fallback": {
-        "expected": FALLBACK_SITE_NAME,
-        "raw_host": "localhost:8080",
-    },
-    "ip_address_returns_fallback": {
-        "expected": FALLBACK_SITE_NAME,
-        "raw_host": "192.168.1.1",
-    },
-    "ip_with_port_returns_fallback": {
-        "expected": FALLBACK_SITE_NAME,
-        "raw_host": "192.168.1.1:5000",
-    },
-    "empty_returns_fallback": {
-        "expected": FALLBACK_SITE_NAME,
-        "raw_host": "",
-    },
-    "invalid_chars_returns_fallback": {
-        "expected": FALLBACK_SITE_NAME,
-        "raw_host": 'evil"><script>.com',
-    },
-    "all_hyphens_returns_fallback": {
-        "expected": FALLBACK_SITE_NAME,
-        "raw_host": "----",
-    },
-    "all_dots_returns_fallback": {
-        "expected": FALLBACK_SITE_NAME,
-        "raw_host": "...",
-    },
-}
-
-
-_SPLIT_WORDS_TESTCASES: dict[str, dict] = {
-    "whole_word": {
-        "s": "apple",
-        "expected": ["apple"],
-    },
-    "two_words": {
-        "s": "applepie",
-        "expected": ["apple", "pie"],
-    },
-    "three_words": {
-        "s": "applebananacherry",
-        "expected": ["apple", "banana", "cherry"],
-    },
-    "no_split_possible": {
-        "s": "xyzqwerty",
-        "expected": None,
-    },
-    "split_prefers_middle": {
-        # "the" (len 3) at position 0 and "oak" (len 3) at end; "lion" in the middle is found first
-        "s": "thelionoak",
-        "expected": ["the", "lion", "oak"],
-    },
-    "prefers_fewest_words": {
-        # Two valid splits: ["abcde", "fghij"] (k=5, center) and ["abc", "de", "fghij"] (k=3).
-        # Middle-out tries k=5 first and commits to the 2-word split.
-        "s": "abcdefghij",
-        "expected": ["abcde", "fghij"],
-    },
-}
-
-_SMALL_WORDS: frozenset[str] = frozenset(
-    ["apple", "pie", "banana", "cherry", "the", "lion", "oak", "abcde", "fghij", "abc", "de", "sylvan", "librarian"]
-)
-
-
-class TestSplitWords:
-    """Tests for _split_words() using a controlled word set."""
-
-    @pytest.mark.parametrize(
-        argnames=sorted(next(iter(_SPLIT_WORDS_TESTCASES.values()))),
-        argvalues=[[v for k, v in sorted(_SPLIT_WORDS_TESTCASES[name].items())] for name in sorted(_SPLIT_WORDS_TESTCASES)],
-        ids=sorted(_SPLIT_WORDS_TESTCASES),
-    )
-    def test_split_words(self, expected: list[str] | None, s: str) -> None:
-        assert _split_words(s, _SMALL_WORDS) == expected
-
-
-_HOSTNAME_DICT_TESTCASES: dict[str, dict] = {
-    "no_dash_splits_into_words": {
-        "expected": "Sylvan Librarian",
-        "raw_host": "sylvanlibrarian.com",
-    },
-}
-
-
-class TestHostnameSiteNameWithDict:
-    """Tests for hostname_to_site_name() with a controlled word set patched in."""
-
-    @pytest.mark.parametrize(
-        argnames=sorted(next(iter(_HOSTNAME_DICT_TESTCASES.values()))),
-        argvalues=[[v for k, v in sorted(_HOSTNAME_DICT_TESTCASES[name].items())] for name in sorted(_HOSTNAME_DICT_TESTCASES)],
-        ids=sorted(_HOSTNAME_DICT_TESTCASES),
-    )
-    def test_hostname_to_site_name_with_dict(self, monkeypatch: pytest.MonkeyPatch, expected: str, raw_host: str) -> None:
-        monkeypatch.setattr("api.api_resource._WORDS", _SMALL_WORDS)
-        _hostname_to_site_name.cache_clear()
-        assert hostname_to_site_name(raw_host) == expected
-
-
-class TestHostnameSiteName:
-    """Tests for hostname_to_site_name()."""
-
-    @pytest.mark.parametrize(
-        argnames=sorted(next(iter(_HOSTNAME_TESTCASES.values()))),
-        argvalues=[[v for k, v in sorted(_HOSTNAME_TESTCASES[name].items())] for name in sorted(_HOSTNAME_TESTCASES)],
-        ids=sorted(_HOSTNAME_TESTCASES),
-    )
-    def test_hostname_to_site_name(self, expected: str, raw_host: str) -> None:
-        assert hostname_to_site_name(raw_host) == expected
 
 
 class TestRootSiteNameInjection(unittest.TestCase):

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -20,6 +20,7 @@ from api.api_resource import INTERNAL_ERROR_DESCRIPTION, APIResource
 from api.enums import ResponseShape
 from api.middlewares.caching_middleware import CachingMiddleware
 from api.settings import settings
+from api.tests.support import mock_conn_pool_kwargs
 from api.utils.routing import BoundRoute, RouteSpec, route
 from api.utils.site_name import FALLBACK_SITE_NAME
 
@@ -133,27 +134,17 @@ def create_test_card(  # noqa: PLR0913, PLR0917
     return card
 
 
-@pytest.fixture(name="patch_conn_pool")
-def patch_conn_pool_fixture() -> MagicMock:
-    """Patch connection pool."""
-    mock_conn_pool = MagicMock()
-    with patch("api.api_resource.db_utils.make_pool") as mock_pool:
-        mock_pool.return_value = mock_conn_pool
-        yield mock_conn_pool
-
-
 class TestBaseAPIResourceTest:
     @pytest.fixture(autouse=True)
-    def setUp(self, request: pytest.FixtureRequest, patch_conn_pool: MagicMock) -> None:
+    def setUp(self, request: pytest.FixtureRequest) -> None:
         """Set up test fixtures."""
-        del patch_conn_pool
         self_reference = request.instance
 
-        self_reference.mock_conn_pool = MagicMock()
+        self_reference.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
         self_reference.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        self_reference.api_resource._conn_pool = self_reference.mock_conn_pool
 
 
 class TestAPIResourceInitializationNewStyle(TestBaseAPIResourceTest):
@@ -372,11 +363,11 @@ class TestAPIResourceCoreMethods(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool = MagicMock()
+        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        self.api_resource._conn_pool = self.mock_conn_pool
 
     def test_get_pid_returns_process_id(self) -> None:
         """Test that get_pid returns the current process ID."""
@@ -390,11 +381,11 @@ class TestAPIResourceRequestHandling(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool = MagicMock()
+        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        self.api_resource._conn_pool = self.mock_conn_pool
 
     def test_raise_not_found_raises_http_not_found(self) -> None:
         """Test _raise_not_found raises HTTPNotFound with route information."""
@@ -653,24 +644,11 @@ class TestAPIResourceStaticFileServing(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool = MagicMock()
+        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        self.api_resource._conn_pool = self.mock_conn_pool
-
-    def test_serve_static_file_reads_file_content(self) -> None:
-        """Test _serve_static_file reads and serves file content."""
-        mock_response = MagicMock()
-
-        with patch("api.api_resource.pathlib.Path") as mock_path:
-            mock_file = MagicMock()
-            mock_file.open.return_value.__enter__.return_value.read.return_value = "file content"
-            mock_path.return_value = mock_file
-
-            self.api_resource._serve_static_file(filename="test.html", falcon_response=mock_response)
-
-            assert mock_response.text == "file content"
 
     def test_index_html_serves_static_file(self) -> None:
         """Test _root serves the index.html file."""
@@ -797,11 +775,11 @@ class TestAPIResourceErrorHandling(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool = MagicMock()
+        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        self.api_resource._conn_pool = self.mock_conn_pool
 
     def test_import_card_by_name_validates_card_name_parameter(self) -> None:
         """Test import_card_by_name validates card_name parameter."""
@@ -830,11 +808,11 @@ class TestAPIResourceCaching(unittest.TestCase):
         # Enable caching for these tests
         settings.enable_cache = True
         # Now create the APIResource with caching enabled
-        self.mock_conn_pool = MagicMock()
+        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        self.api_resource._conn_pool = self.mock_conn_pool
 
     def tearDown(self) -> None:
         """Restore original cache setting."""
@@ -847,7 +825,8 @@ class TestAPIResourceCaching(unittest.TestCase):
         mock_cursor = MagicMock()
         mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
         with (
-            patch.object(self.api_resource, "_conn_pool") as mock_pool,
+            # _upsert_cards runs on AdminResource's own pool, not the parent's.
+            patch.object(self.api_resource.admin, "_conn_pool") as mock_pool,
             patch(
                 "api.admin_resource._bulk_upsert",
                 return_value={"inserted": 1, "updated": 0, "unchanged": 0},
@@ -1024,10 +1003,11 @@ class TestRootSiteNameInjection(unittest.TestCase):
     """Tests that _root injects the derived site name into the HTML."""
 
     def setUp(self) -> None:
+        _, pool_kwargs = mock_conn_pool_kwargs()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        self.api_resource._conn_pool = MagicMock()
 
     def test_valid_hostname_replaces_fallback_in_html(self) -> None:
         mock_response = MagicMock()
@@ -1045,10 +1025,11 @@ class TestCardSiteNameInjection(unittest.TestCase):
     """Tests that card() injects the derived site name into card page HTML."""
 
     def setUp(self) -> None:
+        _, pool_kwargs = mock_conn_pool_kwargs()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        self.api_resource._conn_pool = MagicMock()
 
     def test_valid_hostname_replaces_fallback_in_card_html(self) -> None:
         mock_response = MagicMock()

--- a/api/tests/test_app_context.py
+++ b/api/tests/test_app_context.py
@@ -1,0 +1,139 @@
+"""Tests for AppContext's setup-complete cache, cache-generation bump, and engine reload."""
+
+from __future__ import annotations
+
+import multiprocessing
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api.app_context import MIN_IMPORT_CARDS, AppContext
+
+
+def _mock_pool_returning(num_cards: int) -> MagicMock:
+    """A mock connection pool whose COUNT(1) query returns num_cards."""
+    pool = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchall.return_value = [{"num_cards": num_cards}]
+    pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = cursor
+    return pool
+
+
+class TestSetupComplete(unittest.TestCase):
+    def _make_context(self, *, num_cards: int) -> AppContext:
+        return AppContext(
+            reader_pool=_mock_pool_returning(num_cards),
+            writer_pool=MagicMock(),
+            engine=MagicMock(),
+            last_import_time=multiprocessing.Value("d", 1.0, lock=True),
+        )
+
+    def test_returns_true_above_threshold(self) -> None:
+        ctx = self._make_context(num_cards=MIN_IMPORT_CARDS + 1)
+        assert ctx.setup_complete() is True
+
+    def test_returns_false_below_threshold(self) -> None:
+        ctx = self._make_context(num_cards=MIN_IMPORT_CARDS - 1)
+        assert ctx.setup_complete() is False
+
+    def test_caches_result_within_ttl(self) -> None:
+        ctx = self._make_context(num_cards=MIN_IMPORT_CARDS + 1)
+        ctx.setup_complete()
+        ctx.reader_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value.fetchall.return_value = [
+            {"num_cards": 0},
+        ]
+        # Second call within the TTL must not re-query -- it should still see the cached True.
+        assert ctx.setup_complete() is True
+
+    def test_changed_last_import_time_invalidates_cache(self) -> None:
+        ctx = self._make_context(num_cards=MIN_IMPORT_CARDS + 1)
+        assert ctx.setup_complete() is True
+        ctx.last_import_time.value = 2.0
+        ctx.reader_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value.fetchall.return_value = [
+            {"num_cards": 0},
+        ]
+        assert ctx.setup_complete() is False
+
+    def test_invalidate_setup_complete_forces_recheck(self) -> None:
+        ctx = self._make_context(num_cards=MIN_IMPORT_CARDS + 1)
+        assert ctx.setup_complete() is True
+        ctx.invalidate_setup_complete()
+        ctx.reader_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value.fetchall.return_value = [
+            {"num_cards": 0},
+        ]
+        assert ctx.setup_complete() is False
+
+    def test_returns_false_on_database_error(self) -> None:
+        pool = MagicMock()
+        pool.connection.side_effect = RuntimeError("connection refused")
+        ctx = AppContext(reader_pool=pool, writer_pool=MagicMock(), engine=MagicMock())
+        assert ctx.setup_complete() is False
+
+
+class TestBumpCacheGeneration(unittest.TestCase):
+    def test_increments_the_shared_counter(self) -> None:
+        ctx = AppContext(
+            reader_pool=MagicMock(),
+            writer_pool=MagicMock(),
+            engine=MagicMock(),
+            cache_generation=multiprocessing.Value("i", 0),
+        )
+        ctx.bump_cache_generation()
+        ctx.bump_cache_generation()
+        assert ctx.cache_generation.value == 2
+
+
+class TestReloadEngine(unittest.TestCase):
+    def _make_context(self) -> tuple[AppContext, MagicMock, MagicMock]:
+        reader_pool = MagicMock()
+        writer_pool = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchmany.side_effect = [[{"scryfall_id": "x"}], []]
+        writer_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = cursor
+        engine = MagicMock()
+        engine.size.return_value = 0
+        engine.reload_begin.return_value = True
+        ctx = AppContext(reader_pool=reader_pool, writer_pool=writer_pool, engine=engine)
+        return ctx, reader_pool, writer_pool
+
+    def test_skipped_when_engine_feature_disabled(self) -> None:
+        ctx, _, writer_pool = self._make_context()
+        with patch("api.app_context.settings") as mock_settings:
+            mock_settings.enable_engine = False
+            ctx.reload_engine(force=True)
+        writer_pool.connection.assert_not_called()
+
+    def test_reads_via_writer_pool_not_reader_pool(self) -> None:
+        ctx, reader_pool, writer_pool = self._make_context()
+        with patch("api.app_context.settings") as mock_settings:
+            mock_settings.enable_engine = True
+            ctx.reload_engine(force=True)
+        writer_pool.connection.assert_called_once()
+        reader_pool.connection.assert_not_called()
+        ctx.engine.reload_commit.assert_called_once()
+
+    def test_skips_rebuild_when_not_forced_and_already_populated(self) -> None:
+        ctx, _, writer_pool = self._make_context()
+        ctx.engine.size.return_value = 1
+        with patch("api.app_context.settings") as mock_settings:
+            mock_settings.enable_engine = True
+            ctx.reload_engine(force=False)
+        writer_pool.connection.assert_not_called()
+
+    def test_releases_guard_on_failure(self) -> None:
+        ctx, _, writer_pool = self._make_context()
+        writer_pool.connection.side_effect = RuntimeError("boom")
+        with patch("api.app_context.settings") as mock_settings:
+            mock_settings.enable_engine = True
+            with pytest.raises(RuntimeError):
+                ctx.reload_engine(force=True)
+        # A second call must not block forever on a guard the first call failed to release.
+        writer_pool.connection.side_effect = None
+        with patch("api.app_context.settings") as mock_settings:
+            mock_settings.enable_engine = True
+            ctx.reload_engine(force=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/tests/test_app_context_cross_process.py
+++ b/api/tests/test_app_context_cross_process.py
@@ -18,9 +18,8 @@ from __future__ import annotations
 
 import multiprocessing
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
 
-from api.app_context import AppContext
+from api.tests.support import mock_app_context
 
 if TYPE_CHECKING:
     from multiprocessing.sharedctypes import Synchronized
@@ -30,22 +29,16 @@ if TYPE_CHECKING:
 _JOIN_TIMEOUT = 5
 
 
-def _mock_app_context(**overrides: object) -> AppContext:
-    kwargs: dict[str, object] = {"reader_pool": MagicMock(), "writer_pool": MagicMock(), "engine": MagicMock()}
-    kwargs.update(overrides)
-    return AppContext(**kwargs)
-
-
 def _child_bumps_cache_generation(cache_generation: Synchronized) -> None:
-    _mock_app_context(cache_generation=cache_generation).bump_cache_generation()
+    mock_app_context(cache_generation=cache_generation).bump_cache_generation()
 
 
 def _child_writes_last_import_time(last_import_time: Synchronized, value: float) -> None:
-    _mock_app_context(last_import_time=last_import_time).last_import_time.value = value
+    mock_app_context(last_import_time=last_import_time).last_import_time.value = value
 
 
 def _child_holds_the_guard(guard: LockType, acquired: EventType, release: EventType) -> None:
-    ctx = _mock_app_context(engine_reload_guard=guard)
+    ctx = mock_app_context(engine_reload_guard=guard)
     ctx.engine_reload_guard.acquire()
     acquired.set()
     release.wait(timeout=_JOIN_TIMEOUT)
@@ -65,7 +58,7 @@ class TestSharedSignalsCrossProcesses:
         assert process.exitcode == 0
         # A *different* AppContext instance, in this (parent) process, built from the same shared
         # Value -- not the one the child mutated -- must see the child's write.
-        parent_ctx = _mock_app_context(cache_generation=cache_generation)
+        parent_ctx = mock_app_context(cache_generation=cache_generation)
         assert parent_ctx.cache_generation.value == 1
 
     def test_last_import_time_write_is_visible_across_processes(self) -> None:
@@ -76,7 +69,7 @@ class TestSharedSignalsCrossProcesses:
         process.join(timeout=_JOIN_TIMEOUT)
 
         assert process.exitcode == 0
-        parent_ctx = _mock_app_context(last_import_time=last_import_time)
+        parent_ctx = mock_app_context(last_import_time=last_import_time)
         assert parent_ctx.last_import_time.value == 12345.0
 
     def test_engine_reload_guard_serialises_across_processes(self) -> None:
@@ -89,7 +82,7 @@ class TestSharedSignalsCrossProcesses:
         try:
             assert acquired.wait(timeout=_JOIN_TIMEOUT), "child never signalled that it holds the guard"
 
-            parent_ctx = _mock_app_context(engine_reload_guard=guard)
+            parent_ctx = mock_app_context(engine_reload_guard=guard)
             # The child holds the lock from a different process: a non-blocking acquire here must fail.
             assert parent_ctx.engine_reload_guard.acquire(block=False) is False
 

--- a/api/tests/test_app_context_cross_process.py
+++ b/api/tests/test_app_context_cross_process.py
@@ -1,0 +1,106 @@
+"""Tests that AppContext's shared signals actually cross a real process boundary.
+
+`api/app_context.py`'s docstring claims `cache_generation`/`last_import_time`/`engine_reload_guard`
+are "expected to be created once in the master process ... and handed to every worker's AppContext
+unchanged." Every other AppContext test builds one instance and calls methods on it directly, which
+never exercises that claim -- a bug that broke cross-process visibility (e.g. passing a *copy* of a
+`multiprocessing.Value` instead of the object itself) would still pass every one of those tests.
+
+These tests spawn a real child process via `multiprocessing.get_context("fork")` -- fork, not the
+platform default (`spawn` on macOS), so behavior matches production, which forks workers under
+Linux/Docker either way. Each side builds its OWN `AppContext`, sharing only the primitive under
+test, with `reader_pool`/`writer_pool`/`engine` mocked out on both sides since those are explicitly
+*not* meant to survive a fork (see the AppContext docstring) and are irrelevant to what's being
+proven here.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from api.app_context import AppContext
+
+if TYPE_CHECKING:
+    from multiprocessing.sharedctypes import Synchronized
+    from multiprocessing.synchronize import Event as EventType
+    from multiprocessing.synchronize import Lock as LockType
+
+_JOIN_TIMEOUT = 5
+
+
+def _mock_app_context(**overrides: object) -> AppContext:
+    kwargs: dict[str, object] = {"reader_pool": MagicMock(), "writer_pool": MagicMock(), "engine": MagicMock()}
+    kwargs.update(overrides)
+    return AppContext(**kwargs)
+
+
+def _child_bumps_cache_generation(cache_generation: Synchronized) -> None:
+    _mock_app_context(cache_generation=cache_generation).bump_cache_generation()
+
+
+def _child_writes_last_import_time(last_import_time: Synchronized, value: float) -> None:
+    _mock_app_context(last_import_time=last_import_time).last_import_time.value = value
+
+
+def _child_holds_the_guard(guard: LockType, acquired: EventType, release: EventType) -> None:
+    ctx = _mock_app_context(engine_reload_guard=guard)
+    ctx.engine_reload_guard.acquire()
+    acquired.set()
+    release.wait(timeout=_JOIN_TIMEOUT)
+    ctx.engine_reload_guard.release()
+
+
+class TestSharedSignalsCrossProcesses:
+    """Two AppContexts in two OS processes, sharing only the primitive under test."""
+
+    def test_cache_generation_bump_is_visible_across_processes(self) -> None:
+        fork_ctx = multiprocessing.get_context("fork")
+        cache_generation = multiprocessing.Value("i", 0)
+        process = fork_ctx.Process(target=_child_bumps_cache_generation, args=(cache_generation,))
+        process.start()
+        process.join(timeout=_JOIN_TIMEOUT)
+
+        assert process.exitcode == 0
+        # A *different* AppContext instance, in this (parent) process, built from the same shared
+        # Value -- not the one the child mutated -- must see the child's write.
+        parent_ctx = _mock_app_context(cache_generation=cache_generation)
+        assert parent_ctx.cache_generation.value == 1
+
+    def test_last_import_time_write_is_visible_across_processes(self) -> None:
+        fork_ctx = multiprocessing.get_context("fork")
+        last_import_time = multiprocessing.Value("d", 0.0, lock=True)
+        process = fork_ctx.Process(target=_child_writes_last_import_time, args=(last_import_time, 12345.0))
+        process.start()
+        process.join(timeout=_JOIN_TIMEOUT)
+
+        assert process.exitcode == 0
+        parent_ctx = _mock_app_context(last_import_time=last_import_time)
+        assert parent_ctx.last_import_time.value == 12345.0
+
+    def test_engine_reload_guard_serialises_across_processes(self) -> None:
+        fork_ctx = multiprocessing.get_context("fork")
+        guard = multiprocessing.Lock()
+        acquired = fork_ctx.Event()
+        release = fork_ctx.Event()
+        process = fork_ctx.Process(target=_child_holds_the_guard, args=(guard, acquired, release))
+        process.start()
+        try:
+            assert acquired.wait(timeout=_JOIN_TIMEOUT), "child never signalled that it holds the guard"
+
+            parent_ctx = _mock_app_context(engine_reload_guard=guard)
+            # The child holds the lock from a different process: a non-blocking acquire here must fail.
+            assert parent_ctx.engine_reload_guard.acquire(block=False) is False
+
+            release.set()
+            process.join(timeout=_JOIN_TIMEOUT)
+            assert process.exitcode == 0
+
+            # Released now -- the parent (which never itself held it) can take it.
+            assert parent_ctx.engine_reload_guard.acquire(block=False) is True
+            parent_ctx.engine_reload_guard.release()
+        finally:
+            if process.is_alive():
+                process.terminate()
+                process.join()

--- a/api/tests/test_card_ordering.py
+++ b/api/tests/test_card_ordering.py
@@ -19,8 +19,8 @@ def _compiled_sql(stub_api_resource: APIResource, ordering: CardOrdering) -> str
     """Return the compiled SQL string via the SQL path directly."""
     parsed_query = parse_scryfall_query("cmc=1")
     with (
-        patch.object(stub_api_resource, "_conn_pool") as mock_pool,
-        patch.object(stub_api_resource, "_setup_complete", return_value=True),
+        patch.object(stub_api_resource.app_context, "reader_pool") as mock_pool,
+        patch.object(stub_api_resource.app_context, "setup_complete", return_value=True),
     ):
         mock_cursor = MagicMock()
         mock_cursor.fetchall.return_value = [{"total_cards_count": 0, "name": None}]

--- a/api/tests/test_card_processing.py
+++ b/api/tests/test_card_processing.py
@@ -7,8 +7,7 @@ import pathlib
 import uuid
 from typing import Any
 
-from api.card_processing import preprocess_card
-from api.parsing.card_query_nodes import extract_frame_data_from_raw_card
+from api.card_processing import extract_frame_data_from_raw_card, preprocess_card
 
 # Project root directory for accessing sample data
 _PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent

--- a/api/tests/test_cubecobra_and_prefer_scores.py
+++ b/api/tests/test_cubecobra_and_prefer_scores.py
@@ -38,7 +38,7 @@ class TestInsertCubecobraData:
 
         assert rows_updated >= 1
 
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 "SELECT cubecobra_elo, cubecobra_cube_count, cubecobra_pick_count FROM magic.cards WHERE oracle_id = %s LIMIT 1",
                 (oracle_id,),
@@ -161,7 +161,7 @@ class TestBackfillPreferScores:
         oracle_id = _insert_card(api_resource, make_raw_card(name=f"Prefer Score Check {uuid.uuid4()}"))
         api_resource.admin.backfill_prefer_scores()
 
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute("SELECT prefer_score FROM magic.cards WHERE oracle_id = %s LIMIT 1", (oracle_id,))
             row = cursor.fetchone()
 

--- a/api/tests/test_cubecobra_and_prefer_scores.py
+++ b/api/tests/test_cubecobra_and_prefer_scores.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 def _insert_card(api: APIResource, raw: dict) -> uuid.UUID:
     """Insert a raw card and return its oracle_id as a UUID."""
-    api._upsert_cards([raw])
+    api.admin._upsert_cards([raw])
     (processed,) = preprocess_card(raw)
     return uuid.UUID(processed["oracle_id"])
 
@@ -34,7 +34,7 @@ class TestInsertCubecobraData:
         oracle_id = _insert_card(api_resource, make_raw_card(name="Cubecobra Insert Test"))
 
         cubecobra_data = {oracle_id: {"elo": 1200.5, "cube_count": 42, "pick_count": 100}}
-        rows_updated = api_resource._insert_cubecobra_data(cubecobra_data)
+        rows_updated = api_resource.admin._insert_cubecobra_data(cubecobra_data)
 
         assert rows_updated >= 1
 
@@ -52,11 +52,11 @@ class TestInsertCubecobraData:
 
     def test_unknown_oracle_id_updates_zero_rows(self, api_resource: APIResource) -> None:
         unknown = uuid.uuid4()
-        rows_updated = api_resource._insert_cubecobra_data({unknown: {"elo": 999.0, "cube_count": 1, "pick_count": 1}})
+        rows_updated = api_resource.admin._insert_cubecobra_data({unknown: {"elo": 999.0, "cube_count": 1, "pick_count": 1}})
         assert rows_updated == 0
 
     def test_empty_dict_updates_zero_rows(self, api_resource: APIResource) -> None:
-        rows_updated = api_resource._insert_cubecobra_data({})
+        rows_updated = api_resource.admin._insert_cubecobra_data({})
         assert rows_updated == 0
 
     def test_multiple_cards_updated_in_one_call(self, api_resource: APIResource) -> None:
@@ -67,7 +67,7 @@ class TestInsertCubecobraData:
             oid1: {"elo": 1100.0, "cube_count": 10, "pick_count": 20},
             oid2: {"elo": 900.0, "cube_count": 5, "pick_count": 8},
         }
-        rows_updated = api_resource._insert_cubecobra_data(cubecobra_data)
+        rows_updated = api_resource.admin._insert_cubecobra_data(cubecobra_data)
         assert rows_updated == 2
 
 
@@ -86,12 +86,12 @@ class TestFetchCubecobraData:
         oracle_id = uuid.uuid4()
         page1 = [{"oracle_id": str(oracle_id), "elo": 1500, "cubeCount": 30, "pickCount": 60}]
 
-        with patch.object(api_resource, "_session") as mock_session, patch("api.api_resource.time.sleep"):
+        with patch.object(api_resource.admin, "_session") as mock_session, patch("api.api_resource.time.sleep"):
             mock_session.get.side_effect = [
                 self._mock_response(page1),
                 self._mock_response([]),  # empty page terminates
             ]
-            pages = list(api_resource._fetch_cubecobra_data({oracle_id}))
+            pages = list(api_resource.admin._fetch_cubecobra_data({oracle_id}))
 
         assert len(pages) == 1
         assert oracle_id in pages[0]
@@ -105,9 +105,9 @@ class TestFetchCubecobraData:
             {"oracle_id": str(unknown), "elo": 800, "cubeCount": 2, "pickCount": 4},
         ]
 
-        with patch.object(api_resource, "_session") as mock_session, patch("api.api_resource.time.sleep"):
+        with patch.object(api_resource.admin, "_session") as mock_session, patch("api.api_resource.time.sleep"):
             mock_session.get.side_effect = [self._mock_response(page1), self._mock_response([])]
-            pages = list(api_resource._fetch_cubecobra_data({known}))
+            pages = list(api_resource.admin._fetch_cubecobra_data({known}))
 
         assert known in pages[0]
         assert unknown not in pages[0]
@@ -121,18 +121,18 @@ class TestFetchCubecobraData:
             [],  # terminator
         ]
 
-        with patch.object(api_resource, "_session") as mock_session, patch("api.api_resource.time.sleep"):
+        with patch.object(api_resource.admin, "_session") as mock_session, patch("api.api_resource.time.sleep"):
             mock_session.get.side_effect = [self._mock_response(p) for p in pages_data]
-            pages = list(api_resource._fetch_cubecobra_data(set(oids)))
+            pages = list(api_resource.admin._fetch_cubecobra_data(set(oids)))
 
         assert len(pages) == 3
 
     def test_empty_db_oracle_ids_yields_empty_pages(self, api_resource: APIResource) -> None:
         page1 = [{"oracle_id": str(uuid.uuid4()), "elo": 1, "cubeCount": 1, "pickCount": 1}]
 
-        with patch.object(api_resource, "_session") as mock_session, patch("api.api_resource.time.sleep"):
+        with patch.object(api_resource.admin, "_session") as mock_session, patch("api.api_resource.time.sleep"):
             mock_session.get.side_effect = [self._mock_response(page1), self._mock_response([])]
-            pages = list(api_resource._fetch_cubecobra_data(set()))
+            pages = list(api_resource.admin._fetch_cubecobra_data(set()))
 
         # All cards filtered out, but we still get one page dict (empty)
         assert all(len(p) == 0 for p in pages)
@@ -145,21 +145,21 @@ class TestFetchCubecobraData:
 
 class TestBackfillPreferScores:
     def test_returns_success_status(self, api_resource: APIResource) -> None:
-        result = api_resource.backfill_prefer_scores()
+        result = api_resource.admin.backfill_prefer_scores()
         assert result["status"] == "success"
 
     def test_returns_cards_updated_count(self, api_resource: APIResource) -> None:
         _insert_card(api_resource, make_raw_card(name=f"Prefer Score Card {uuid.uuid4()}"))
-        result = api_resource.backfill_prefer_scores()
+        result = api_resource.admin.backfill_prefer_scores()
         assert result["cards_updated"] >= 1
 
     def test_message_includes_count(self, api_resource: APIResource) -> None:
-        result = api_resource.backfill_prefer_scores()
+        result = api_resource.admin.backfill_prefer_scores()
         assert str(result["cards_updated"]) in result["message"]
 
     def test_prefer_score_populated_in_db(self, api_resource: APIResource) -> None:
         oracle_id = _insert_card(api_resource, make_raw_card(name=f"Prefer Score Check {uuid.uuid4()}"))
-        api_resource.backfill_prefer_scores()
+        api_resource.admin.backfill_prefer_scores()
 
         with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute("SELECT prefer_score FROM magic.cards WHERE oracle_id = %s LIMIT 1", (oracle_id,))
@@ -171,18 +171,18 @@ class TestBackfillPreferScores:
     def test_second_run_updates_zero_rows(self, api_resource: APIResource) -> None:
         """Re-running the backfill on already-scored cards should touch no rows."""
         _insert_card(api_resource, make_raw_card(name=f"Idempotent Score Card {uuid.uuid4()}"))
-        api_resource.backfill_prefer_scores()
+        api_resource.admin.backfill_prefer_scores()
 
-        result = api_resource.backfill_prefer_scores()
+        result = api_resource.admin.backfill_prefer_scores()
 
         assert result["cards_updated"] == 0
 
     def test_reports_duration_and_scored_count(self, api_resource: APIResource) -> None:
         """cards_scored counts the whole scored corpus, not just the rows this run moved."""
         _insert_card(api_resource, make_raw_card(name=f"Stats Card {uuid.uuid4()}"))
-        api_resource.backfill_prefer_scores()
+        api_resource.admin.backfill_prefer_scores()
 
-        result = api_resource.backfill_prefer_scores()
+        result = api_resource.admin.backfill_prefer_scores()
 
         assert result["duration_seconds"] >= 0
         # Nothing moved on the second run, but the corpus is still fully scored.
@@ -197,13 +197,13 @@ class TestBackfillPreferScores:
 
 class TestBackfillCubecobraScores:
     def test_returns_success_status(self, api_resource: APIResource) -> None:
-        result = api_resource.backfill_cubecobra_scores()
+        result = api_resource.admin.backfill_cubecobra_scores()
         assert result["status"] == "success"
 
     def test_reports_duration_and_counts(self, api_resource: APIResource) -> None:
         _insert_card(api_resource, make_raw_card(name=f"Cubecobra Stats Card {uuid.uuid4()}"))
 
-        result = api_resource.backfill_cubecobra_scores()
+        result = api_resource.admin.backfill_cubecobra_scores()
 
         assert result["duration_seconds"] >= 0
         assert result["cards_updated"] >= 0
@@ -216,8 +216,8 @@ class TestBackfillCubecobraScores:
         from one computed over an all-NULL corpus.
         """
         oracle_id = _insert_card(api_resource, make_raw_card(name=f"Cubecobra Data Card {uuid.uuid4()}"))
-        before = api_resource.backfill_cubecobra_scores()["cards_with_cubecobra_data"]
+        before = api_resource.admin.backfill_cubecobra_scores()["cards_with_cubecobra_data"]
 
-        api_resource._insert_cubecobra_data({oracle_id: {"elo": 1500.0, "cube_count": 7, "pick_count": 9}})
+        api_resource.admin._insert_cubecobra_data({oracle_id: {"elo": 1500.0, "cube_count": 7, "pick_count": 9}})
 
-        assert api_resource.backfill_cubecobra_scores()["cards_with_cubecobra_data"] == before + 1
+        assert api_resource.admin.backfill_cubecobra_scores()["cards_with_cubecobra_data"] == before + 1

--- a/api/tests/test_datatype_mismatch.py
+++ b/api/tests/test_datatype_mismatch.py
@@ -21,6 +21,7 @@ import pytest
 from psycopg.pq import DiagnosticField
 
 from api.api_resource import APIResource, regex_error_reason
+from api.app_context import AppContext
 from api.tests.helpers import search_kwargs
 
 
@@ -30,15 +31,15 @@ class TestDatatypeMismatchHandling:
     def setup_method(self) -> None:
         """Set up test fixtures."""
         self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            app_context=AppContext(last_import_time=multiprocessing.Value("d", time.time(), lock=True)),
         )
 
     def teardown_method(self) -> None:
         """Clean up test fixtures."""
         if hasattr(self, "api_resource") and self.api_resource:
             # Close both connection pools to prevent thread pool warnings
-            self.api_resource._conn_pool.close()
-            self.api_resource.admin._conn_pool.close()
+            self.api_resource.app_context.reader_pool.close()
+            self.api_resource.app_context.writer_pool.close()
 
     def test_search_sql_handles_datatype_mismatch(self) -> None:
         """Test that DatatypeMismatch in _search_sql raises HTTPBadRequest."""
@@ -103,14 +104,14 @@ class TestInvalidRegularExpressionHandling:
     def setup_method(self) -> None:
         """Set up test fixtures."""
         self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            app_context=AppContext(last_import_time=multiprocessing.Value("d", time.time(), lock=True)),
         )
 
     def teardown_method(self) -> None:
         """Clean up test fixtures."""
         if hasattr(self, "api_resource") and self.api_resource:
-            self.api_resource._conn_pool.close()
-            self.api_resource.admin._conn_pool.close()
+            self.api_resource.app_context.reader_pool.close()
+            self.api_resource.app_context.writer_pool.close()
 
     def test_search_sql_handles_invalid_regular_expression(self) -> None:
         """An unparseable regex is the user's error, so it must be a 400 and not a 500.
@@ -149,14 +150,14 @@ class TestDataErrorHandling:
     def setup_method(self) -> None:
         """Set up test fixtures."""
         self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            app_context=AppContext(last_import_time=multiprocessing.Value("d", time.time(), lock=True)),
         )
 
     def teardown_method(self) -> None:
         """Clean up test fixtures."""
         if hasattr(self, "api_resource") and self.api_resource:
-            self.api_resource._conn_pool.close()
-            self.api_resource.admin._conn_pool.close()
+            self.api_resource.app_context.reader_pool.close()
+            self.api_resource.app_context.writer_pool.close()
 
     def test_search_sql_handles_division_by_zero(self) -> None:
         """power/0>1 parses cleanly but divides by zero at runtime — a 400, not a 500."""

--- a/api/tests/test_datatype_mismatch.py
+++ b/api/tests/test_datatype_mismatch.py
@@ -36,8 +36,9 @@ class TestDatatypeMismatchHandling:
     def teardown_method(self) -> None:
         """Clean up test fixtures."""
         if hasattr(self, "api_resource") and self.api_resource:
-            # Close the connection pool to prevent thread pool warnings
+            # Close both connection pools to prevent thread pool warnings
             self.api_resource._conn_pool.close()
+            self.api_resource.admin._conn_pool.close()
 
     def test_search_sql_handles_datatype_mismatch(self) -> None:
         """Test that DatatypeMismatch in _search_sql raises HTTPBadRequest."""
@@ -109,6 +110,7 @@ class TestInvalidRegularExpressionHandling:
         """Clean up test fixtures."""
         if hasattr(self, "api_resource") and self.api_resource:
             self.api_resource._conn_pool.close()
+            self.api_resource.admin._conn_pool.close()
 
     def test_search_sql_handles_invalid_regular_expression(self) -> None:
         """An unparseable regex is the user's error, so it must be a 400 and not a 500.
@@ -154,6 +156,7 @@ class TestDataErrorHandling:
         """Clean up test fixtures."""
         if hasattr(self, "api_resource") and self.api_resource:
             self.api_resource._conn_pool.close()
+            self.api_resource.admin._conn_pool.close()
 
     def test_search_sql_handles_division_by_zero(self) -> None:
         """power/0>1 parses cleanly but divides by zero at runtime — a 400, not a 500."""

--- a/api/tests/test_import_card_by_name.py
+++ b/api/tests/test_import_card_by_name.py
@@ -11,6 +11,7 @@ import orjson
 import pytest
 import requests
 
+from api.admin_resource import AdminResource
 from api.api_resource import APIResource
 
 
@@ -28,29 +29,14 @@ class TestImportCardByName(unittest.TestCase):
     def test_import_card_by_name_validates_input(self) -> None:
         """Test that import_card_by_name validates card_name parameter."""
         with pytest.raises(ValueError) as context:
-            self.api_resource.import_card_by_name(card_name="")
+            self.api_resource.admin.import_card_by_name(card_name="")
 
         assert str(context.value) == "card_name parameter is required"
 
         with pytest.raises(ValueError) as context:
-            self.api_resource.import_card_by_name(card_name=None)
+            self.api_resource.admin.import_card_by_name(card_name=None)
 
         assert str(context.value) == "card_name parameter is required"
-
-    def test_import_card_by_name_function_exists(self) -> None:
-        """Test that import_card_by_name method exists and is callable."""
-        assert hasattr(self.api_resource, "import_card_by_name")
-        assert callable(self.api_resource.import_card_by_name)
-
-    def test_scryfall_search_function_exists(self) -> None:
-        """Test that _scryfall_search method exists."""
-        assert hasattr(self.api_resource, "_scryfall_search")
-        assert callable(self.api_resource._scryfall_search)
-
-    def test_upsert_cards_function_exists(self) -> None:
-        """Test that _upsert_cards method exists."""
-        assert hasattr(self.api_resource, "_upsert_cards")
-        assert callable(self.api_resource._upsert_cards)
 
     @patch("requests.Session.get")
     def test_scryfall_search_returns_empty_for_404(self, mock_get: MagicMock) -> None:
@@ -60,7 +46,7 @@ class TestImportCardByName(unittest.TestCase):
         mock_response.raise_for_status.side_effect = requests.HTTPError("404 Not Found")
         mock_get.return_value = mock_response
 
-        result = self.api_resource._scryfall_search(query="name:'NonexistentCard'")
+        result = self.api_resource.admin._scryfall_search(query="name:'NonexistentCard'")
 
         assert result == []
 
@@ -77,7 +63,7 @@ class TestImportCardByName(unittest.TestCase):
         )
         mock_get.return_value = mock_response
 
-        result = self.api_resource._scryfall_search(query="name:'Lightning Bolt'")
+        result = self.api_resource.admin._scryfall_search(query="name:'Lightning Bolt'")
 
         assert result == [{"name": "Lightning Bolt", "cmc": 1}]
         mock_get.assert_called_once_with(
@@ -95,7 +81,7 @@ class TestImportCardByName(unittest.TestCase):
         mock_get.side_effect = requests.RequestException("Network error")
 
         with pytest.raises(ValueError, match="Failed to fetch data from Scryfall API"):
-            self.api_resource._scryfall_search(query="name:'Lightning Bolt'")
+            self.api_resource.admin._scryfall_search(query="name:'Lightning Bolt'")
 
     @patch.object(APIResource, "_run_query")
     def test_import_card_by_name_returns_already_exists_for_existing_card(self, mock_run_query: MagicMock) -> None:
@@ -103,14 +89,14 @@ class TestImportCardByName(unittest.TestCase):
         # Mock _run_query to return existing card
         mock_run_query.return_value = {"result": [{"card_name": "Lightning Bolt"}]}
 
-        result = self.api_resource.import_card_by_name(card_name="Lightning Bolt")
+        result = self.api_resource.admin.import_card_by_name(card_name="Lightning Bolt")
 
         assert result["status"] == "already_exists"
         assert result["card_name"] == "Lightning Bolt"
         assert "already exists in database" in result["message"]
 
     @patch.object(APIResource, "_run_query")
-    @patch.object(APIResource, "_scryfall_search")
+    @patch.object(AdminResource, "_scryfall_search")
     def test_import_card_by_name_returns_not_found_for_missing_card(
         self,
         mock_search: MagicMock,
@@ -123,14 +109,14 @@ class TestImportCardByName(unittest.TestCase):
         # Mock Scryfall API to return empty list (not found)
         mock_search.return_value = []
 
-        result = self.api_resource.import_card_by_name(card_name="NonexistentCard")
+        result = self.api_resource.admin.import_card_by_name(card_name="NonexistentCard")
 
         assert result["status"] == "not_found"
         assert result["search_query"] == '!"NonexistentCard"'
         assert "No cards found for search query" in result["message"]
 
     @patch.object(APIResource, "_run_query")
-    @patch.object(APIResource, "_scryfall_search")
+    @patch.object(AdminResource, "_scryfall_search")
     def test_import_card_by_name_returns_error_for_scryfall_exceptions(
         self,
         mock_search: MagicMock,
@@ -143,14 +129,14 @@ class TestImportCardByName(unittest.TestCase):
         # Mock Scryfall API to raise exception
         mock_search.side_effect = ValueError("API Error")
 
-        result = self.api_resource.import_card_by_name(card_name="TestCard")
+        result = self.api_resource.admin.import_card_by_name(card_name="TestCard")
 
         assert result["status"] == "error"
         assert result["search_query"] == '!"TestCard"'
         assert "Error fetching cards from Scryfall" in result["message"]
 
     @patch.object(APIResource, "_run_query")
-    @patch.object(APIResource, "_scryfall_search")
+    @patch.object(AdminResource, "_scryfall_search")
     @patch("api.card_processing.preprocess_card")
     def test_import_card_by_name_returns_filtered_out_for_invalid_cards(
         self,
@@ -168,7 +154,7 @@ class TestImportCardByName(unittest.TestCase):
         # Mock preprocessing to return None (filtered out)
         mock_preprocess.return_value = []
 
-        result = self.api_resource.import_card_by_name(card_name="TestCard")
+        result = self.api_resource.admin.import_card_by_name(card_name="TestCard")
         assert result == {
             "status": "no_cards_after_preprocessing",
             "cards_loaded": 0,

--- a/api/tests/test_import_card_by_name.py
+++ b/api/tests/test_import_card_by_name.py
@@ -13,6 +13,7 @@ import requests
 
 from api.admin_resource import AdminResource
 from api.api_resource import APIResource
+from api.tests.support import mock_conn_pool_kwargs
 
 
 class TestImportCardByName(unittest.TestCase):
@@ -20,11 +21,16 @@ class TestImportCardByName(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool = MagicMock()
+        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        self.api_resource._conn_pool = self.mock_conn_pool
+        self.mock_cursor = MagicMock()
+        self.mock_cursor.fetchone.return_value = None
+        self.mock_conn_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = (
+            self.mock_cursor
+        )
 
     def test_import_card_by_name_validates_input(self) -> None:
         """Test that import_card_by_name validates card_name parameter."""
@@ -83,11 +89,10 @@ class TestImportCardByName(unittest.TestCase):
         with pytest.raises(ValueError, match="Failed to fetch data from Scryfall API"):
             self.api_resource.admin._scryfall_search(query="name:'Lightning Bolt'")
 
-    @patch.object(APIResource, "_run_query")
-    def test_import_card_by_name_returns_already_exists_for_existing_card(self, mock_run_query: MagicMock) -> None:
+    def test_import_card_by_name_returns_already_exists_for_existing_card(self) -> None:
         """Test that import_card_by_name returns already_exists status for existing cards."""
-        # Mock _run_query to return existing card
-        mock_run_query.return_value = {"result": [{"card_name": "Lightning Bolt"}]}
+        # Mock the existence-check query to find a row
+        self.mock_cursor.fetchone.return_value = {"card_name": "Lightning Bolt"}
 
         result = self.api_resource.admin.import_card_by_name(card_name="Lightning Bolt")
 
@@ -95,17 +100,12 @@ class TestImportCardByName(unittest.TestCase):
         assert result["card_name"] == "Lightning Bolt"
         assert "already exists in database" in result["message"]
 
-    @patch.object(APIResource, "_run_query")
     @patch.object(AdminResource, "_scryfall_search")
     def test_import_card_by_name_returns_not_found_for_missing_card(
         self,
         mock_search: MagicMock,
-        mock_run_query: MagicMock,
     ) -> None:
         """Test that import_card_by_name returns not_found status when card doesn't exist in Scryfall."""
-        # Mock _run_query to return no existing card
-        mock_run_query.return_value = {"result": []}
-
         # Mock Scryfall API to return empty list (not found)
         mock_search.return_value = []
 
@@ -115,17 +115,12 @@ class TestImportCardByName(unittest.TestCase):
         assert result["search_query"] == '!"NonexistentCard"'
         assert "No cards found for search query" in result["message"]
 
-    @patch.object(APIResource, "_run_query")
     @patch.object(AdminResource, "_scryfall_search")
     def test_import_card_by_name_returns_error_for_scryfall_exceptions(
         self,
         mock_search: MagicMock,
-        mock_run_query: MagicMock,
     ) -> None:
         """Test that import_card_by_name returns error status for Scryfall API exceptions."""
-        # Mock _run_query to return no existing card
-        mock_run_query.return_value = {"result": []}
-
         # Mock Scryfall API to raise exception
         mock_search.side_effect = ValueError("API Error")
 
@@ -135,19 +130,14 @@ class TestImportCardByName(unittest.TestCase):
         assert result["search_query"] == '!"TestCard"'
         assert "Error fetching cards from Scryfall" in result["message"]
 
-    @patch.object(APIResource, "_run_query")
     @patch.object(AdminResource, "_scryfall_search")
     @patch("api.card_processing.preprocess_card")
     def test_import_card_by_name_returns_filtered_out_for_invalid_cards(
         self,
         mock_preprocess: MagicMock,
         mock_search: MagicMock,
-        mock_run_query: MagicMock,
     ) -> None:
         """Test that import_card_by_name returns filtered_out status for cards filtered during preprocessing."""
-        # Mock _run_query to return no existing card
-        mock_run_query.return_value = {"result": []}
-
         # Mock Scryfall API to return card data
         mock_search.return_value = [{"name": "TestCard", "legalities": {"standard": "not_legal"}}]
 

--- a/api/tests/test_import_card_by_name.py
+++ b/api/tests/test_import_card_by_name.py
@@ -2,8 +2,6 @@
 
 # ruff: noqa: PT011
 
-import multiprocessing
-import time
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -13,7 +11,7 @@ import requests
 
 from api.admin_resource import AdminResource
 from api.api_resource import APIResource
-from api.tests.support import mock_conn_pool_kwargs
+from api.tests.support import mock_app_context
 
 
 class TestImportCardByName(unittest.TestCase):
@@ -21,11 +19,9 @@ class TestImportCardByName(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self.app_context = mock_app_context()
+        self.mock_conn_pool = self.app_context.reader_pool
+        self.api_resource = APIResource(app_context=self.app_context)
         self.mock_cursor = MagicMock()
         self.mock_cursor.fetchone.return_value = None
         self.mock_conn_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = (

--- a/api/tests/test_import_cards_by_search.py
+++ b/api/tests/test_import_cards_by_search.py
@@ -11,6 +11,7 @@ import pytest
 
 from api.admin_resource import AdminResource
 from api.api_resource import APIResource
+from api.tests.support import mock_conn_pool_kwargs
 
 
 class TestImportCardsBySearch(unittest.TestCase):
@@ -18,11 +19,11 @@ class TestImportCardsBySearch(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool = MagicMock()
+        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        self.api_resource._conn_pool = self.mock_conn_pool
 
     def test_import_cards_by_search_validates_input(self) -> None:
         """Test that import_cards_by_search validates search_query parameter."""

--- a/api/tests/test_import_cards_by_search.py
+++ b/api/tests/test_import_cards_by_search.py
@@ -2,8 +2,6 @@
 
 # ruff: noqa: PT011
 
-import multiprocessing
-import time
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -11,7 +9,7 @@ import pytest
 
 from api.admin_resource import AdminResource
 from api.api_resource import APIResource
-from api.tests.support import mock_conn_pool_kwargs
+from api.tests.support import mock_app_context
 
 
 class TestImportCardsBySearch(unittest.TestCase):
@@ -19,11 +17,9 @@ class TestImportCardsBySearch(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self.app_context = mock_app_context()
+        self.mock_conn_pool = self.app_context.reader_pool
+        self.api_resource = APIResource(app_context=self.app_context)
 
     def test_import_cards_by_search_validates_input(self) -> None:
         """Test that import_cards_by_search validates search_query parameter."""
@@ -77,7 +73,7 @@ class TestImportCardsBySearch(unittest.TestCase):
             "message": "Successfully loaded 2 cards",
         }
 
-        with patch.object(self.api_resource, "_reload_engine"):
+        with patch.object(self.api_resource.app_context, "reload_engine"):
             result = self.api_resource.admin.import_cards_by_search(search_query="cmc<=2")
 
         assert result["status"] == "success"
@@ -90,7 +86,7 @@ class TestImportCardsBySearch(unittest.TestCase):
         with (
             patch.object(self.api_resource.admin, "_scryfall_search") as mock_search,
             patch.object(self.api_resource.admin, "_upsert_cards") as mock_load,
-            patch.object(self.api_resource, "_reload_engine"),
+            patch.object(self.api_resource.app_context, "reload_engine"),
         ):
             # Mock Scryfall API to return Sun Titan cards by Todd Lockwood
             mock_search.return_value = [

--- a/api/tests/test_import_cards_by_search.py
+++ b/api/tests/test_import_cards_by_search.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from api.admin_resource import AdminResource
 from api.api_resource import APIResource
 
 
@@ -23,51 +24,46 @@ class TestImportCardsBySearch(unittest.TestCase):
         )
         self.api_resource._conn_pool = self.mock_conn_pool
 
-    def test_import_cards_by_search_function_exists(self) -> None:
-        """Test that import_cards_by_search method exists and is callable."""
-        assert hasattr(self.api_resource, "import_cards_by_search")
-        assert callable(self.api_resource.import_cards_by_search)
-
     def test_import_cards_by_search_validates_input(self) -> None:
         """Test that import_cards_by_search validates search_query parameter."""
         with pytest.raises(ValueError) as context:
-            self.api_resource.import_cards_by_search(search_query="")
+            self.api_resource.admin.import_cards_by_search(search_query="")
 
         assert str(context.value) == "search_query parameter is required"
 
         with pytest.raises(ValueError) as context:
-            self.api_resource.import_cards_by_search(search_query=None)
+            self.api_resource.admin.import_cards_by_search(search_query=None)
 
         assert str(context.value) == "search_query parameter is required"
 
-    @patch.object(APIResource, "_scryfall_search")
+    @patch.object(AdminResource, "_scryfall_search")
     def test_import_cards_by_search_returns_not_found_for_empty_results(self, mock_search: MagicMock) -> None:
         """Test that import_cards_by_search returns not_found status when no cards are found."""
         # Mock Scryfall API to return empty list
         mock_search.return_value = []
 
-        result = self.api_resource.import_cards_by_search(search_query="name:NonexistentCard")
+        result = self.api_resource.admin.import_cards_by_search(search_query="name:NonexistentCard")
 
         assert result["status"] == "not_found"
         assert result["search_query"] == "name:NonexistentCard"
         assert "No cards found for search query" in result["message"]
         assert result["cards_loaded"] == 0
 
-    @patch.object(APIResource, "_scryfall_search")
+    @patch.object(AdminResource, "_scryfall_search")
     def test_import_cards_by_search_returns_error_for_scryfall_exceptions(self, mock_search: MagicMock) -> None:
         """Test that import_cards_by_search returns error status for Scryfall API exceptions."""
         # Mock Scryfall API to raise exception
         mock_search.side_effect = ValueError("API Error")
 
-        result = self.api_resource.import_cards_by_search(search_query="name:TestCard")
+        result = self.api_resource.admin.import_cards_by_search(search_query="name:TestCard")
 
         assert result["status"] == "error"
         assert result["search_query"] == "name:TestCard"
         assert "Error fetching cards from Scryfall" in result["message"]
         assert result["cards_loaded"] == 0
 
-    @patch.object(APIResource, "_scryfall_search")
-    @patch.object(APIResource, "_upsert_cards")
+    @patch.object(AdminResource, "_scryfall_search")
+    @patch.object(AdminResource, "_upsert_cards")
     def test_import_cards_by_search_returns_success_for_valid_cards(self, mock_load: MagicMock, mock_search: MagicMock) -> None:
         """Test that import_cards_by_search returns success status for valid cards."""
         mock_search.return_value = [
@@ -81,7 +77,7 @@ class TestImportCardsBySearch(unittest.TestCase):
         }
 
         with patch.object(self.api_resource, "_reload_engine"):
-            result = self.api_resource.import_cards_by_search(search_query="cmc<=2")
+            result = self.api_resource.admin.import_cards_by_search(search_query="cmc<=2")
 
         assert result["status"] == "success"
         assert result["search_query"] == "cmc<=2"
@@ -91,8 +87,8 @@ class TestImportCardsBySearch(unittest.TestCase):
     def test_import_cards_by_search_handles_artist_search_example(self) -> None:
         """Test the example artist search mentioned in the issue."""
         with (
-            patch.object(self.api_resource, "_scryfall_search") as mock_search,
-            patch.object(self.api_resource, "_upsert_cards") as mock_load,
+            patch.object(self.api_resource.admin, "_scryfall_search") as mock_search,
+            patch.object(self.api_resource.admin, "_upsert_cards") as mock_load,
             patch.object(self.api_resource, "_reload_engine"),
         ):
             # Mock Scryfall API to return Sun Titan cards by Todd Lockwood
@@ -112,7 +108,7 @@ class TestImportCardsBySearch(unittest.TestCase):
                 "message": "Successfully loaded 1 cards",
             }
 
-            result = self.api_resource.import_cards_by_search(search_query="artist:lockwood game:paper sun titan")
+            result = self.api_resource.admin.import_cards_by_search(search_query="artist:lockwood game:paper sun titan")
 
             assert result["status"] == "success"
             assert result["search_query"] == "artist:lockwood game:paper sun titan"

--- a/api/tests/test_integration_testcontainers.py
+++ b/api/tests/test_integration_testcontainers.py
@@ -14,7 +14,9 @@ import psycopg
 import pytest
 from testcontainers.postgres import PostgresContainer
 
+from api.admin_resource import AdminContext
 from api.api_resource import APIResource
+from api.app_context import AppContext
 from api.enums import CardOrdering, ResponseShape, SortDirection
 from api.tests.helpers import search_kwargs
 from api.tests.support import override_attr
@@ -110,14 +112,14 @@ class TestContainerIntegration:
         # Create APIResource instance
         schema_setup_event = multiprocessing.Event()
         api = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            schema_setup_event=schema_setup_event,
+            app_context=AppContext(last_import_time=multiprocessing.Value("d", time.time(), lock=True)),
+            admin_context=AdminContext(schema_setup_event=schema_setup_event),
         )
 
         def always_true() -> bool:
             return True
 
-        override_attr(api, "_setup_complete", always_true)
+        override_attr(api.app_context, "setup_complete", always_true)
         override_attr(api.admin, "_import_recent", always_true)
 
         # Set up the schema using real migrations
@@ -127,20 +129,18 @@ class TestContainerIntegration:
         test_dir = pathlib.Path(__file__).parent
         data_file = test_dir / "fixtures" / "test_data.sql"
 
-        with api._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(data_file.read_text())
             conn.commit()
 
-        api._reload_engine(force=True)
+        api.app_context.reload_engine(force=True)
 
         # Yield the fully configured APIResource for tests to use
         yield api
 
         # Clean up connection pools
-        if hasattr(api, "_conn_pool"):
-            api._conn_pool.close()
-        if hasattr(api.admin, "_conn_pool"):
-            api.admin._conn_pool.close()
+        api.app_context.reader_pool.close()
+        api.app_context.writer_pool.close()
 
     def test_query_parsing_with_database(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test query parsing and execution against real database."""
@@ -368,7 +368,7 @@ class TestContainerIntegration:
         assert import_result["status"] == "success"
         assert import_result["cards_loaded"] >= 35
 
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute("SELECT COUNT(*) as count FROM magic.cards WHERE card_name = %s", (card_name,))
             count_result = cursor.fetchone()
             card_count = count_result["count"] if count_result else 0
@@ -405,7 +405,7 @@ class TestContainerIntegration:
             assert import_result["cards_loaded"] == 3, f"Expected 3 cards loaded, got {import_result['cards_loaded']}"
 
         # Verify the card exists in database and has set information
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 "SELECT card_name, card_set_code FROM magic.cards WHERE card_name = %s",
                 (card_name,),
@@ -520,7 +520,7 @@ class TestContainerIntegration:
             "Black Lotus": 50.0,
             "Serra Angel": 90.0,
         }
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             for name, score in scores.items():
                 cursor.execute(
                     "UPDATE magic.cards SET cubecobra_score = %s WHERE card_name = %s",
@@ -532,11 +532,11 @@ class TestContainerIntegration:
         # store would shadow this test DB's data: swap in a private store for
         # this test (the api_resource fixture is class-scoped, so restore it).
         shm_path = pathlib.Path(tempfile.gettempdir()) / f"sylvan_librarian_it_{uuid.uuid4().hex}"
-        saved_engine = api_resource._engine
-        api_resource._engine = QueryEngine(shm_path=str(shm_path))
+        saved_engine = api_resource.app_context.engine
+        api_resource.app_context.engine = QueryEngine(shm_path=str(shm_path))
         try:
             # Reload the engine so it picks up the direct DB update
-            api_resource._reload_engine(force=True)
+            api_resource.app_context.reload_engine(force=True)
 
             result = api_resource._search_engine(
                 **search_kwargs("cmc>=0", limit=100, orderby=CardOrdering.CUBECOBRA, direction=SortDirection.ASC)
@@ -550,6 +550,6 @@ class TestContainerIntegration:
             names = [card["name"] for card in result["cards"] if card["name"] in scores]
             assert names == ["Serra Angel", "Black Lotus", "Lightning Bolt"]
         finally:
-            api_resource._engine = saved_engine
+            api_resource.app_context.engine = saved_engine
             shm_path.unlink(missing_ok=True)
             shm_path.with_suffix(".lock").unlink(missing_ok=True)

--- a/api/tests/test_integration_testcontainers.py
+++ b/api/tests/test_integration_testcontainers.py
@@ -136,9 +136,11 @@ class TestContainerIntegration:
         # Yield the fully configured APIResource for tests to use
         yield api
 
-        # Clean up connection pool
+        # Clean up connection pools
         if hasattr(api, "_conn_pool"):
             api._conn_pool.close()
+        if hasattr(api.admin, "_conn_pool"):
+            api.admin._conn_pool.close()
 
     def test_query_parsing_with_database(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test query parsing and execution against real database."""

--- a/api/tests/test_integration_testcontainers.py
+++ b/api/tests/test_integration_testcontainers.py
@@ -118,10 +118,10 @@ class TestContainerIntegration:
             return True
 
         override_attr(api, "_setup_complete", always_true)
-        override_attr(api, "_import_recent", always_true)
+        override_attr(api.admin, "_import_recent", always_true)
 
         # Set up the schema using real migrations
-        api.setup_schema()
+        api.admin.setup_schema()
 
         # Load test data
         test_dir = pathlib.Path(__file__).parent
@@ -360,7 +360,7 @@ class TestContainerIntegration:
         card_name = "Beast Within"
 
         # Import the card using the import_card_by_name method
-        import_result = api_resource.import_card_by_name(card_name=card_name)
+        import_result = api_resource.admin.import_card_by_name(card_name=card_name)
 
         # Check that the import was successful
         assert import_result["status"] == "success"
@@ -394,7 +394,7 @@ class TestContainerIntegration:
         card_name = "Mox Ruby"  # A well-known card from Alpha/Beta
 
         # Import the card using the import_card_by_name method
-        import_result = api_resource.import_card_by_name(card_name=card_name)
+        import_result = api_resource.admin.import_card_by_name(card_name=card_name)
 
         # Check that the import was successful (or already exists, which is also fine for this test)
         assert import_result["status"] in ["success", "already_exists"], f"Import failed: {import_result}"
@@ -457,7 +457,7 @@ class TestContainerIntegration:
     def test_artist_search_integration(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test end-to-end artist search functionality with real database."""
         # Import Brainstorm card which has "Willian Murai" as artist
-        import_result = api_resource.import_card_by_name(card_name="Brainstorm")
+        import_result = api_resource.admin.import_card_by_name(card_name="Brainstorm")
 
         # Check if import was successful
         if import_result.get("status") != "success":

--- a/api/tests/test_page_rendering.py
+++ b/api/tests/test_page_rendering.py
@@ -2,15 +2,13 @@
 
 from __future__ import annotations
 
-import multiprocessing
-import time
 import unittest
 from unittest.mock import MagicMock, patch
 
 import falcon
 
 from api.api_resource import APIResource
-from api.tests.support import mock_conn_pool_kwargs
+from api.tests.support import mock_app_context
 from api.utils import page_rendering
 
 
@@ -46,11 +44,9 @@ class TestHtmlMinification(unittest.TestCase):
     """
 
     def setUp(self) -> None:
-        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            **pool_kwargs,
-        )
+        self.app_context = mock_app_context()
+        self.mock_conn_pool = self.app_context.reader_pool
+        self.api_resource = APIResource(app_context=self.app_context)
 
     def test_minifies_whitespace_by_default(self) -> None:
         # minify_html also drops the redundant closing </p> (valid HTML5 tag-omission), hence

--- a/api/tests/test_page_rendering.py
+++ b/api/tests/test_page_rendering.py
@@ -1,0 +1,58 @@
+"""Tests for assembling the server-rendered HTML pages."""
+
+from __future__ import annotations
+
+import multiprocessing
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+from api.api_resource import APIResource
+from api.utils import page_rendering
+
+
+class TestHtmlMinification(unittest.TestCase):
+    """_minify_html reduces page weight.
+
+    Must not corrupt the per-request placeholders that _build_base_html's cached output still
+    needs substituted afterward (SERVER_SIDE_RESULTS, SERVER_SIDE_EMBEDDED_DATA).
+    """
+
+    def setUp(self) -> None:
+        self.mock_conn_pool = MagicMock()
+        self.api_resource = APIResource(
+            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+        )
+        self.api_resource._conn_pool = self.mock_conn_pool
+
+    def test_minifies_whitespace_by_default(self) -> None:
+        # minify_html also drops the redundant closing </p> (valid HTML5 tag-omission), hence
+        # "<div><p>x</div>" rather than a literal whitespace-only collapse.
+        assert page_rendering._minify_html("<div>   <p>x</p>   </div>") == "<div><p>x</div>"
+
+    def test_disabled_flag_returns_input_unchanged(self) -> None:
+        original = page_rendering._MINIFY_HTML_ENABLED
+        page_rendering._MINIFY_HTML_ENABLED = False
+        try:
+            html = "<div>   <p>x</p>   </div>"
+            assert page_rendering._minify_html(html) == html
+        finally:
+            page_rendering._MINIFY_HTML_ENABLED = original
+
+    def test_server_side_placeholders_survive_minification(self) -> None:
+        mock_response = MagicMock()
+        self.api_resource._root(falcon_response=mock_response)
+        assert "<!-- SERVER_SIDE_RESULTS -->" in mock_response.text
+        assert "<!-- SERVER_SIDE_EMBEDDED_DATA -->" in mock_response.text
+
+    def test_search_results_still_embed_after_minification(self) -> None:
+        mock_response = MagicMock()
+        mock_search_results = {
+            "cards": [{"name": "Elvish Mystic", "set_code": "m14", "collector_number": "1"}],
+            "total_cards": 1,
+            "query": "elf",
+        }
+        with patch.object(self.api_resource, "_search", return_value=mock_search_results):
+            self.api_resource._root(falcon_response=mock_response, q="elf")
+        assert "window.EMBEDDED_SEARCH_RESULTS = {" in mock_response.text
+        assert "Elvish Mystic" in mock_response.text

--- a/api/tests/test_page_rendering.py
+++ b/api/tests/test_page_rendering.py
@@ -7,8 +7,35 @@ import time
 import unittest
 from unittest.mock import MagicMock, patch
 
+import falcon
+
 from api.api_resource import APIResource
+from api.tests.support import mock_conn_pool_kwargs
 from api.utils import page_rendering
+
+
+class TestServeStaticFile(unittest.TestCase):
+    """serve_static_file reads a file under STATIC_DIR and writes it to the response."""
+
+    def test_reads_file_content(self) -> None:
+        mock_response = MagicMock()
+
+        with patch("api.utils.page_rendering.pathlib.Path") as mock_path:
+            mock_file = MagicMock()
+            mock_file.open.return_value.__enter__.return_value.read.return_value = "file content"
+            mock_path.return_value = mock_file
+
+            page_rendering.serve_static_file(filename="test.html", falcon_response=mock_response)
+
+            assert mock_response.text == "file content"
+
+    def test_missing_file_serves_404(self) -> None:
+        mock_response = MagicMock()
+
+        page_rendering.serve_static_file(filename="does-not-exist.html", falcon_response=mock_response)
+
+        assert mock_response.status == falcon.HTTP_404
+        assert "does-not-exist.html" in mock_response.text
 
 
 class TestHtmlMinification(unittest.TestCase):
@@ -19,11 +46,11 @@ class TestHtmlMinification(unittest.TestCase):
     """
 
     def setUp(self) -> None:
-        self.mock_conn_pool = MagicMock()
+        self.mock_conn_pool, pool_kwargs = mock_conn_pool_kwargs()
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            **pool_kwargs,
         )
-        self.api_resource._conn_pool = self.mock_conn_pool
 
     def test_minifies_whitespace_by_default(self) -> None:
         # minify_html also drops the redundant closing </p> (valid HTML5 tag-omission), hence

--- a/api/tests/test_parsing_errors.py
+++ b/api/tests/test_parsing_errors.py
@@ -59,10 +59,10 @@ class TestSearchRouting:
     @pytest.fixture(autouse=True)
     def _api(self, stub_api_resource: APIResource) -> None:
         self.api_resource = stub_api_resource
-        self.api_resource._engine = MagicMock()
+        self.api_resource.app_context.engine = MagicMock()
 
     def test_routes_to_sql_when_engine_empty(self) -> None:
-        self.api_resource._engine.size.return_value = 0
+        self.api_resource.app_context.engine.size.return_value = 0
         sentinel = {"cards": [], "total_cards": 0, "query": "name:opt"}
         with (
             patch.object(self.api_resource, "_search_sql", return_value=sentinel) as mock_sql,
@@ -74,7 +74,7 @@ class TestSearchRouting:
         assert result is sentinel
 
     def test_routes_to_engine_when_engine_has_data(self) -> None:
-        self.api_resource._engine.size.return_value = 87
+        self.api_resource.app_context.engine.size.return_value = 87
         sentinel = {"cards": [], "total_cards": 0, "query": "name:opt"}
         with (
             patch.object(self.api_resource, "_search_engine", return_value=sentinel) as mock_engine,
@@ -86,7 +86,7 @@ class TestSearchRouting:
         assert result is sentinel
 
     def test_falls_back_to_sql_when_engine_raises(self) -> None:
-        self.api_resource._engine.size.return_value = 87
+        self.api_resource.app_context.engine.size.return_value = 87
         sentinel = {"cards": [], "total_cards": 0, "query": "name:opt"}
         with (
             patch.object(self.api_resource, "_search_engine", side_effect=RuntimeError("engine failed")),
@@ -108,7 +108,7 @@ class TestSearchRouting:
         class _Panic(BaseException):
             pass
 
-        self.api_resource._engine.size.return_value = 87
+        self.api_resource.app_context.engine.size.return_value = 87
         sentinel = {"cards": [], "total_cards": 0, "query": "name:opt"}
         with (
             patch.object(self.api_resource, "_search_engine", side_effect=_Panic("engine panicked")),
@@ -129,7 +129,7 @@ class TestSearchRouting:
         """
         from card_engine import QueryError  # noqa: PLC0415
 
-        self.api_resource._engine.size.return_value = 87
+        self.api_resource.app_context.engine.size.return_value = 87
         sentinel = {"cards": [], "total_cards": 0, "query": "o:/^[/"}
         with (
             patch.object(
@@ -159,7 +159,7 @@ class TestSearchRouting:
         construction: QueryError is card_engine's own exception type, so an HTTPBadRequest raised for
         some other reason must still surface as an alertable failure.
         """
-        self.api_resource._engine.size.return_value = 87
+        self.api_resource.app_context.engine.size.return_value = 87
         sentinel = {"cards": [], "total_cards": 0, "query": "name:opt"}
         with (
             patch.object(
@@ -180,7 +180,7 @@ class TestSearchRouting:
 
     def test_a_real_engine_failure_still_warns_with_a_traceback(self, caplog: pytest.LogCaptureFixture) -> None:
         """Quieting the declined-query case must not quiet an engine that actually broke."""
-        self.api_resource._engine.size.return_value = 87
+        self.api_resource.app_context.engine.size.return_value = 87
         sentinel = {"cards": [], "total_cards": 0, "query": "name:opt"}
         with (
             patch.object(self.api_resource, "_search_engine", side_effect=RuntimeError("engine failed")),
@@ -196,7 +196,7 @@ class TestSearchRouting:
     @pytest.mark.parametrize(argnames=["exc"], argvalues=[(KeyboardInterrupt,), (SystemExit,)])
     def test_interpreter_shutdown_signals_still_propagate(self, exc: type[BaseException]) -> None:
         """Widening the catch to BaseException must not swallow Ctrl-C or interpreter exit."""
-        self.api_resource._engine.size.return_value = 87
+        self.api_resource.app_context.engine.size.return_value = 87
         with (
             patch.object(self.api_resource, "_search_engine", side_effect=exc()),
             patch.object(self.api_resource, "_search_sql") as mock_sql,
@@ -211,7 +211,7 @@ class TestSearchRouting:
         assert exc_info.value.title == "Invalid Limit"
 
     def test_raises_service_unavailable_when_setup_incomplete(self) -> None:
-        override_attr(self.api_resource, "_setup_complete", lambda: False)
+        override_attr(self.api_resource.app_context, "setup_complete", lambda: False)
         with pytest.raises(falcon.HTTPServiceUnavailable) as exc_info:
             self.api_resource._search(query="name:opt")
         assert exc_info.value.title == "Service Unavailable"
@@ -269,19 +269,19 @@ class TestSearchEngineDirect:
     @pytest.fixture(autouse=True)
     def _api(self, stub_api_resource: APIResource) -> None:
         self.api_resource = stub_api_resource
-        self.api_resource._engine = MagicMock()
+        self.api_resource.app_context.engine = MagicMock()
 
     def test_total_cards_and_cards_forwarded(self) -> None:
         mock_cards = [{"name": "Lightning Bolt"}, {"name": "Counterspell"}]
-        self.api_resource._engine.query.return_value = (2, mock_cards)
+        self.api_resource.app_context.engine.query.return_value = (2, mock_cards)
         result = self.api_resource._search_engine(**search_kwargs("type:instant"))
         assert result["total_cards"] == 2
         assert result["cards"] == mock_cards
 
     def test_engine_called_with_limit(self) -> None:
-        self.api_resource._engine.query.return_value = (0, [])
+        self.api_resource.app_context.engine.query.return_value = (0, [])
         self.api_resource._search_engine(**search_kwargs("name:opt", limit=5))
-        call_kwargs = self.api_resource._engine.query.call_args.kwargs
+        call_kwargs = self.api_resource.app_context.engine.query.call_args.kwargs
         assert call_kwargs["limit"] == 5
 
     def test_query_error_propagates_unwrapped(self) -> None:
@@ -293,7 +293,7 @@ class TestSearchEngineDirect:
         """
         from card_engine import QueryError  # noqa: PLC0415
 
-        self.api_resource._engine.query.side_effect = QueryError("cannot build")
+        self.api_resource.app_context.engine.query.side_effect = QueryError("cannot build")
         with pytest.raises(QueryError):
             self.api_resource._search_engine(**search_kwargs("o:/^[/"))
 
@@ -332,17 +332,17 @@ class TestResultFieldRouting:
     @pytest.fixture(autouse=True)
     def _api(self, stub_api_resource: APIResource) -> None:
         self.api_resource = stub_api_resource
-        self.api_resource._engine = MagicMock()
+        self.api_resource.app_context.engine = MagicMock()
 
     def test_fields_passed_to_sql_path(self) -> None:
-        self.api_resource._engine.size.return_value = 0
+        self.api_resource.app_context.engine.size.return_value = 0
         sentinel = {"cards": [], "total_cards": 0, "query": ""}
         with patch.object(self.api_resource, "_search_sql", return_value=sentinel) as mock_sql:
             self.api_resource._search(query="", fields=["name", "illustration_id"])
         assert mock_sql.call_args.kwargs["fields"] == ["name", "illustration_id"]
 
     def test_fields_passed_to_engine_path(self) -> None:
-        self.api_resource._engine.size.return_value = 87
+        self.api_resource.app_context.engine.size.return_value = 87
         sentinel = {"cards": [], "total_cards": 0, "query": ""}
         with patch.object(self.api_resource, "_search_engine", return_value=sentinel) as mock_engine:
             self.api_resource._search(query="", fields=["name", "price_usd"])
@@ -355,7 +355,7 @@ class TestEngineFeatureGate:
     @pytest.fixture(autouse=True)
     def _api(self, stub_api_resource: APIResource) -> Generator[None]:
         self.api_resource = stub_api_resource
-        self.api_resource._engine = MagicMock()
+        self.api_resource.app_context.engine = MagicMock()
         saved_enable_engine = settings.enable_engine
         yield
         settings.enable_engine = saved_enable_engine
@@ -368,7 +368,7 @@ class TestEngineFeatureGate:
 
     def test_disabled_routes_to_sql_even_with_populated_store(self) -> None:
         settings.enable_engine = False
-        self.api_resource._engine.size.return_value = 87
+        self.api_resource.app_context.engine.size.return_value = 87
         with (
             patch.object(self.api_resource, "_run_query", return_value=self._mock_result()),
             patch.object(self.api_resource, "_search_engine") as mock_engine,
@@ -383,19 +383,19 @@ class TestEngineFeatureGate:
         settings.enable_engine = False
         with patch.object(self.api_resource, "_run_query", return_value=self._mock_result()):
             self.api_resource._search(query="name:opt", limit=10)
-        self.api_resource._engine.size.assert_not_called()
-        self.api_resource._engine.query.assert_not_called()
+        self.api_resource.app_context.engine.size.assert_not_called()
+        self.api_resource.app_context.engine.query.assert_not_called()
 
     def test_disabled_reload_is_a_noop(self) -> None:
         settings.enable_engine = False
-        with patch.object(self.api_resource, "_conn_pool") as mock_pool:
-            self.api_resource._reload_engine()
+        with patch.object(self.api_resource.app_context, "writer_pool") as mock_pool:
+            self.api_resource.app_context.reload_engine()
         mock_pool.connection.assert_not_called()
-        self.api_resource._engine.reload.assert_not_called()
+        self.api_resource.app_context.engine.reload.assert_not_called()
 
     def test_enabled_routes_to_engine(self) -> None:
         settings.enable_engine = True
-        self.api_resource._engine.size.return_value = 87
+        self.api_resource.app_context.engine.size.return_value = 87
         sentinel = {"cards": [], "total_cards": 0, "query": "name:opt"}
         with patch.object(self.api_resource, "_search_engine", return_value=sentinel) as mock_engine:
             result = self.api_resource._search(query="name:opt", limit=10)
@@ -405,15 +405,15 @@ class TestEngineFeatureGate:
     def test_enabled_reload_streams_batches(self) -> None:
         settings.enable_engine = True
         # Empty store, or the populated-store fast path skips the reload.
-        self.api_resource._engine.size.return_value = 0
-        self.api_resource._engine.reload_begin.return_value = True
+        self.api_resource.app_context.engine.size.return_value = 0
+        self.api_resource.app_context.engine.reload_begin.return_value = True
         batch1, batch2 = [{"card_name": "A"}], [{"card_name": "B"}]
-        with patch.object(self.api_resource, "_conn_pool") as mock_pool:
+        with patch.object(self.api_resource.app_context, "writer_pool") as mock_pool:
             mock_cursor = MagicMock()
             mock_cursor.fetchmany.side_effect = [batch1, batch2, []]
             mock_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
-            self.api_resource._reload_engine()
-        engine = self.api_resource._engine
+            self.api_resource.app_context.reload_engine()
+        engine = self.api_resource.app_context.engine
         engine.reload_begin.assert_called_once()
         assert [c.args[0] for c in engine.add_batch.call_args_list] == [batch1, batch2]
         engine.reload_commit.assert_called_once()
@@ -421,28 +421,28 @@ class TestEngineFeatureGate:
 
     def test_enabled_reload_skips_when_another_worker_published(self) -> None:
         settings.enable_engine = True
-        self.api_resource._engine.size.return_value = 0
-        self.api_resource._engine.reload_begin.return_value = False
-        with patch.object(self.api_resource, "_conn_pool") as mock_pool:
+        self.api_resource.app_context.engine.size.return_value = 0
+        self.api_resource.app_context.engine.reload_begin.return_value = False
+        with patch.object(self.api_resource.app_context, "writer_pool") as mock_pool:
             mock_cursor = MagicMock()
             mock_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
-            self.api_resource._reload_engine()
-        self.api_resource._engine.add_batch.assert_not_called()
-        self.api_resource._engine.reload_commit.assert_not_called()
+            self.api_resource.app_context.reload_engine()
+        self.api_resource.app_context.engine.add_batch.assert_not_called()
+        self.api_resource.app_context.engine.reload_commit.assert_not_called()
 
     def test_enabled_reload_aborts_on_failure(self) -> None:
         settings.enable_engine = True
-        self.api_resource._engine.size.return_value = 0
-        self.api_resource._engine.reload_begin.return_value = True
-        self.api_resource._engine.add_batch.side_effect = RuntimeError("boom")
-        with patch.object(self.api_resource, "_conn_pool") as mock_pool:
+        self.api_resource.app_context.engine.size.return_value = 0
+        self.api_resource.app_context.engine.reload_begin.return_value = True
+        self.api_resource.app_context.engine.add_batch.side_effect = RuntimeError("boom")
+        with patch.object(self.api_resource.app_context, "writer_pool") as mock_pool:
             mock_cursor = MagicMock()
             mock_cursor.fetchmany.side_effect = [[{"card_name": "A"}], []]
             mock_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
             with pytest.raises(RuntimeError, match="boom"):
-                self.api_resource._reload_engine()
-        self.api_resource._engine.reload_abort.assert_called_once()
-        self.api_resource._engine.reload_commit.assert_not_called()
+                self.api_resource.app_context.reload_engine()
+        self.api_resource.app_context.engine.reload_abort.assert_called_once()
+        self.api_resource.app_context.engine.reload_commit.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/api/tests/test_prefer_order.py
+++ b/api/tests/test_prefer_order.py
@@ -6,6 +6,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from api.api_resource import APIResource
+from api.app_context import AppContext
 from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
 from api.parsing import parse_scryfall_query
 from api.utils.timer import Timer
@@ -22,20 +23,20 @@ class TestPreferOrder(unittest.TestCase):
         here calls an import path afterwards, so no suppression override is needed.
         """
         self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            app_context=AppContext(last_import_time=multiprocessing.Value("d", time.time(), lock=True)),
         )
 
     def tearDown(self) -> None:
         """Close the connection pools this test case opened."""
-        self.api_resource._conn_pool.close()
-        self.api_resource.admin._conn_pool.close()
+        self.api_resource.app_context.reader_pool.close()
+        self.api_resource.app_context.writer_pool.close()
 
     def _search_sql(self, query: str, prefer: PreferOrder) -> dict:
         """Run _search_sql directly, bypassing engine dispatch."""
         parsed_query = parse_scryfall_query(query)
         with (
-            patch.object(self.api_resource, "_conn_pool") as mock_pool,
-            patch.object(self.api_resource, "_setup_complete", return_value=True),
+            patch.object(self.api_resource.app_context, "reader_pool") as mock_pool,
+            patch.object(self.api_resource.app_context, "setup_complete", return_value=True),
         ):
             mock_cursor = MagicMock()
             mock_cursor.fetchall.return_value = [{"total_cards_count": 0, "name": None}]

--- a/api/tests/test_prefer_order.py
+++ b/api/tests/test_prefer_order.py
@@ -26,8 +26,9 @@ class TestPreferOrder(unittest.TestCase):
         )
 
     def tearDown(self) -> None:
-        """Close the connection pool this test case opened."""
+        """Close the connection pools this test case opened."""
         self.api_resource._conn_pool.close()
+        self.api_resource.admin._conn_pool.close()
 
     def _search_sql(self, query: str, prefer: PreferOrder) -> dict:
         """Run _search_sql directly, bypassing engine dispatch."""

--- a/api/tests/test_site_name.py
+++ b/api/tests/test_site_name.py
@@ -1,0 +1,147 @@
+"""Tests for deriving a display name from the Host header."""
+
+from __future__ import annotations
+
+import pytest
+
+from api.utils.site_name import FALLBACK_SITE_NAME, _hostname_to_site_name, _split_words, hostname_to_site_name
+
+_HOSTNAME_TESTCASES = {
+    "tolarian_acade_my": {
+        "expected": "Tolarian Academy",
+        "raw_host": "tolarian-acade.my",
+    },
+    "strips_com_tld": {
+        "expected": "Sylvan Librarian",
+        "raw_host": "sylvan-librarian.com",
+    },
+    "strips_port": {
+        "expected": "Sylvan Librarian",
+        "raw_host": "sylvan-librarian.com:443",
+    },
+    "strips_www_prefix": {
+        "expected": "Sylvan Librarian",
+        "raw_host": "www.sylvan-librarian.com",
+    },
+    "strips_subdomain_com": {
+        "expected": "Sylvan Librarian",
+        "raw_host": "foo.sylvan-librarian.com",
+    },
+    "strips_subdomain_non_strip_tld": {
+        "expected": "Tolarian Academy",
+        "raw_host": "foo.tolarian-acade.my",
+    },
+    "localhost_returns_fallback": {
+        "expected": FALLBACK_SITE_NAME,
+        "raw_host": "localhost",
+    },
+    "localhost_with_port_returns_fallback": {
+        "expected": FALLBACK_SITE_NAME,
+        "raw_host": "localhost:8080",
+    },
+    "ip_address_returns_fallback": {
+        "expected": FALLBACK_SITE_NAME,
+        "raw_host": "192.168.1.1",
+    },
+    "ip_with_port_returns_fallback": {
+        "expected": FALLBACK_SITE_NAME,
+        "raw_host": "192.168.1.1:5000",
+    },
+    "empty_returns_fallback": {
+        "expected": FALLBACK_SITE_NAME,
+        "raw_host": "",
+    },
+    "invalid_chars_returns_fallback": {
+        "expected": FALLBACK_SITE_NAME,
+        "raw_host": 'evil"><script>.com',
+    },
+    "all_hyphens_returns_fallback": {
+        "expected": FALLBACK_SITE_NAME,
+        "raw_host": "----",
+    },
+    "all_dots_returns_fallback": {
+        "expected": FALLBACK_SITE_NAME,
+        "raw_host": "...",
+    },
+}
+
+
+_SPLIT_WORDS_TESTCASES: dict[str, dict] = {
+    "whole_word": {
+        "s": "apple",
+        "expected": ["apple"],
+    },
+    "two_words": {
+        "s": "applepie",
+        "expected": ["apple", "pie"],
+    },
+    "three_words": {
+        "s": "applebananacherry",
+        "expected": ["apple", "banana", "cherry"],
+    },
+    "no_split_possible": {
+        "s": "xyzqwerty",
+        "expected": None,
+    },
+    "split_prefers_middle": {
+        # "the" (len 3) at position 0 and "oak" (len 3) at end; "lion" in the middle is found first
+        "s": "thelionoak",
+        "expected": ["the", "lion", "oak"],
+    },
+    "prefers_fewest_words": {
+        # Two valid splits: ["abcde", "fghij"] (k=5, center) and ["abc", "de", "fghij"] (k=3).
+        # Middle-out tries k=5 first and commits to the 2-word split.
+        "s": "abcdefghij",
+        "expected": ["abcde", "fghij"],
+    },
+}
+
+_SMALL_WORDS: frozenset[str] = frozenset(
+    ["apple", "pie", "banana", "cherry", "the", "lion", "oak", "abcde", "fghij", "abc", "de", "sylvan", "librarian"]
+)
+
+
+class TestSplitWords:
+    """Tests for _split_words() using a controlled word set."""
+
+    @pytest.mark.parametrize(
+        argnames=sorted(next(iter(_SPLIT_WORDS_TESTCASES.values()))),
+        argvalues=[[v for k, v in sorted(_SPLIT_WORDS_TESTCASES[name].items())] for name in sorted(_SPLIT_WORDS_TESTCASES)],
+        ids=sorted(_SPLIT_WORDS_TESTCASES),
+    )
+    def test_split_words(self, expected: list[str] | None, s: str) -> None:
+        assert _split_words(s, _SMALL_WORDS) == expected
+
+
+_HOSTNAME_DICT_TESTCASES: dict[str, dict] = {
+    "no_dash_splits_into_words": {
+        "expected": "Sylvan Librarian",
+        "raw_host": "sylvanlibrarian.com",
+    },
+}
+
+
+class TestHostnameSiteNameWithDict:
+    """Tests for hostname_to_site_name() with a controlled word set patched in."""
+
+    @pytest.mark.parametrize(
+        argnames=sorted(next(iter(_HOSTNAME_DICT_TESTCASES.values()))),
+        argvalues=[[v for k, v in sorted(_HOSTNAME_DICT_TESTCASES[name].items())] for name in sorted(_HOSTNAME_DICT_TESTCASES)],
+        ids=sorted(_HOSTNAME_DICT_TESTCASES),
+    )
+    def test_hostname_to_site_name_with_dict(self, monkeypatch: pytest.MonkeyPatch, expected: str, raw_host: str) -> None:
+        monkeypatch.setattr("api.utils.site_name._WORDS", _SMALL_WORDS)
+        _hostname_to_site_name.cache_clear()
+        assert hostname_to_site_name(raw_host) == expected
+
+
+class TestHostnameSiteName:
+    """Tests for hostname_to_site_name()."""
+
+    @pytest.mark.parametrize(
+        argnames=sorted(next(iter(_HOSTNAME_TESTCASES.values()))),
+        argvalues=[[v for k, v in sorted(_HOSTNAME_TESTCASES[name].items())] for name in sorted(_HOSTNAME_TESTCASES)],
+        ids=sorted(_HOSTNAME_TESTCASES),
+    )
+    def test_hostname_to_site_name(self, expected: str, raw_host: str) -> None:
+        assert hostname_to_site_name(raw_host) == expected

--- a/api/tests/test_tagging.py
+++ b/api/tests/test_tagging.py
@@ -59,14 +59,6 @@ class TestBuildUuidToSlug:
 
 
 class TestAPIResourceEndpoints:
-    def test_import_oracle_tags_registered(self) -> None:
-        assert hasattr(APIResource, "import_oracle_tags")
-        assert callable(APIResource.import_oracle_tags)
-
-    def test_import_art_tags_registered(self) -> None:
-        assert hasattr(APIResource, "import_art_tags")
-        assert callable(APIResource.import_art_tags)
-
     def test_old_graphql_methods_removed(self) -> None:
         assert not hasattr(APIResource, "discover_tags_from_scryfall")
         assert not hasattr(APIResource, "discover_tags_from_graphql")

--- a/api/tests/test_type_conversion.py
+++ b/api/tests/test_type_conversion.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from api.api_resource import APIResource
+from api.app_context import AppContext
 from api.utils.type_conversions import make_type_converting_wrapper
 
 
@@ -112,11 +113,11 @@ class TestTypeConversion:
     def test_action_map_uses_type_converting_wrappers(self) -> None:
         """Test that APIResource action map uses type converting wrappers."""
         with (
-            patch("api.api_resource.db_utils.make_pool"),
+            patch("api.app_context.db_utils.make_pool"),
             patch("api.admin_resource.requests.Session"),
         ):
             api_resource = APIResource(
-                last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+                app_context=AppContext(last_import_time=multiprocessing.Value("d", time.time(), lock=True)),
             )
 
             # Check that import_oracle_tags is wrapped

--- a/api/tests/test_type_conversion.py
+++ b/api/tests/test_type_conversion.py
@@ -113,18 +113,18 @@ class TestTypeConversion:
         """Test that APIResource action map uses type converting wrappers."""
         with (
             patch("api.api_resource.db_utils.make_pool"),
-            patch("api.api_resource.requests.Session"),
+            patch("api.admin_resource.requests.Session"),
         ):
             api_resource = APIResource(
                 last_import_time=multiprocessing.Value("d", time.time(), lock=True),
             )
 
             # Check that import_oracle_tags is wrapped
-            assert "import_oracle_tags" in api_resource.routes
+            assert "_admin/import_oracle_tags" in api_resource.routes
 
             # The wrapped function should be different from the original
-            original_method = api_resource.import_oracle_tags
-            wrapped_method = api_resource.routes["import_oracle_tags"].action
+            original_method = api_resource.admin.import_oracle_tags
+            wrapped_method = api_resource.routes["_admin/import_oracle_tags"].action
 
             # They should not be the same function object
             assert wrapped_method is not original_method

--- a/api/tests/test_upsert_cards.py
+++ b/api/tests/test_upsert_cards.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import psycopg
 
+from api.admin_resource import AdminResource
 from api.api_resource import APIResource
 from api.card_processing import preprocess_card
 from api.db.bulk_upsert import bulk_upsert
@@ -28,33 +29,33 @@ class TestUpsertCardsStatus:
     """_upsert_cards returns the correct status string for each no-cards scenario."""
 
     def test_empty_list_returns_no_cards_before_preprocessing(self, api_resource: APIResource) -> None:
-        result = api_resource._upsert_cards([])
+        result = api_resource.admin._upsert_cards([])
         assert result["status"] == "no_cards_before_preprocessing"
         assert result["cards_loaded"] == 0
         assert result["cards_sent"] == 0
 
     def test_empty_generator_returns_no_cards_before_preprocessing(self, api_resource: APIResource) -> None:
-        result = api_resource._upsert_cards(x for x in [])
+        result = api_resource.admin._upsert_cards(x for x in [])
         assert result["status"] == "no_cards_before_preprocessing"
 
     def test_preprocessing_filters_all_cards_returns_no_cards_after_preprocessing(self, api_resource: APIResource) -> None:
         """When preprocess_card returns [] for all inputs, status is no_cards_after_preprocessing."""
-        with patch("api.api_resource.preprocess_card", return_value=[]):
-            result = api_resource._upsert_cards([make_raw_card()])
+        with patch("api.admin_resource.preprocess_card", return_value=[]):
+            result = api_resource.admin._upsert_cards([make_raw_card()])
         assert result["status"] == "no_cards_after_preprocessing"
         assert result["cards_loaded"] == 0
 
     def test_unchanged_card_on_reimport_loads_zero(self, api_resource: APIResource) -> None:
         """Re-submitting an identical card produces success with zero loads (unchanged, no write)."""
         card = make_raw_card(name="Already Present Card")
-        api_resource._upsert_cards([card])  # first insert
+        api_resource.admin._upsert_cards([card])  # first insert
 
-        result = api_resource._upsert_cards([card])  # second attempt
+        result = api_resource.admin._upsert_cards([card])  # second attempt
         assert result["status"] == "success"
         assert result["cards_loaded"] == 0
 
     def test_success_result_includes_cards_sent(self, api_resource: APIResource) -> None:
-        result = api_resource._upsert_cards([make_raw_card(name="Cards Sent Test")])
+        result = api_resource.admin._upsert_cards([make_raw_card(name="Cards Sent Test")])
         assert result["status"] == "success"
         assert result["cards_sent"] >= 1
         assert "cards_loaded" in result
@@ -81,13 +82,13 @@ class TestBooleanIsTags:
     def test_reserved_boolean_lands_as_is_tag(self, api_resource: APIResource) -> None:
         card = make_raw_card(name="Reserved Import Test")
         card["reserved"] = True
-        api_resource._upsert_cards([card])
+        api_resource.admin._upsert_cards([card])
         assert _is_tags_for(api_resource, card["id"]).get("reserved") is True
 
     def test_game_changer_boolean_lands_as_gamechanger(self, api_resource: APIResource) -> None:
         card = make_raw_card(name="Bracket Import Test")
         card["game_changer"] = True
-        api_resource._upsert_cards([card])
+        api_resource.admin._upsert_cards([card])
         tags = _is_tags_for(api_resource, card["id"])
         assert tags.get("gamechanger") is True
         assert "reserved" not in tags
@@ -100,16 +101,16 @@ class TestBooleanIsTags:
         # the first import's object would re-store the stale blob.
         card = make_raw_card(name="Debracketed Test")
         card["game_changer"] = True
-        api_resource._upsert_cards([card])
+        api_resource.admin._upsert_cards([card])
         reimport = make_raw_card(card_id=card["id"], name="Debracketed Test")
         reimport["oracle_text"] = "changed so the reimport writes"
-        api_resource._upsert_cards([reimport])
+        api_resource.admin._upsert_cards([reimport])
         assert "gamechanger" not in _is_tags_for(api_resource, card["id"])
 
     def test_sync_preserves_unrelated_is_tags(self, api_resource: APIResource) -> None:
         card = make_raw_card(name="Historic Bystander Test")
         card["reserved"] = True
-        api_resource._upsert_cards([card])
+        api_resource.admin._upsert_cards([card])
         with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 """UPDATE magic.cards SET card_is_tags = card_is_tags || '{"historic": true}'::jsonb
@@ -120,7 +121,7 @@ class TestBooleanIsTags:
         reimport = make_raw_card(card_id=card["id"], name="Historic Bystander Test")
         reimport["reserved"] = True
         reimport["oracle_text"] = "changed so the reimport writes"
-        api_resource._upsert_cards([reimport])
+        api_resource.admin._upsert_cards([reimport])
         tags = _is_tags_for(api_resource, card["id"])
         assert tags.get("historic") is True
         assert tags.get("reserved") is True
@@ -137,17 +138,17 @@ class TestCardStreamCounting:
     def test_multiple_preprocessed_but_all_unchanged_loads_zero(self, api_resource: APIResource) -> None:
         """Raw > 0 and preprocessed > 0 but all unchanged → success with cards_loaded=0."""
         cards = [make_raw_card(name=f"Count Card {i}") for i in range(3)]
-        api_resource._upsert_cards(cards)  # seed the DB
+        api_resource.admin._upsert_cards(cards)  # seed the DB
 
-        result = api_resource._upsert_cards(cards)
+        result = api_resource.admin._upsert_cards(cards)
         assert result["status"] == "success"
         assert result["cards_loaded"] == 0
 
     def test_preprocessing_filter_distinguished_from_empty_input(self, api_resource: APIResource) -> None:
         """no_cards_after_preprocessing is distinct from no_cards_before_preprocessing."""
-        with patch("api.api_resource.preprocess_card", return_value=[]):
-            filtered = api_resource._upsert_cards([make_raw_card(), make_raw_card()])
-        empty = api_resource._upsert_cards([])
+        with patch("api.admin_resource.preprocess_card", return_value=[]):
+            filtered = api_resource.admin._upsert_cards([make_raw_card(), make_raw_card()])
+        empty = api_resource.admin._upsert_cards([])
 
         assert filtered["status"] == "no_cards_after_preprocessing"
         assert empty["status"] == "no_cards_before_preprocessing"
@@ -163,7 +164,7 @@ class TestMultiBatchLoad:
 
     def test_all_cards_inserted_across_batches(self, api_resource: APIResource) -> None:
         cards = [make_raw_card(name=f"Batch Card {uuid.uuid4()}") for _ in range(7)]
-        result = api_resource._upsert_cards(cards, page_size=3)
+        result = api_resource.admin._upsert_cards(cards, page_size=3)
         assert result["status"] == "success"
         assert result["cards_loaded"] == 7
         assert result["cards_sent"] == 7
@@ -171,16 +172,16 @@ class TestMultiBatchLoad:
     def test_batch_boundary_at_exact_multiple(self, api_resource: APIResource) -> None:
         """page_size=4, 8 cards → two full batches of 4."""
         cards = [make_raw_card(name=f"Exact Batch {uuid.uuid4()}") for _ in range(8)]
-        result = api_resource._upsert_cards(cards, page_size=4)
+        result = api_resource.admin._upsert_cards(cards, page_size=4)
         assert result["status"] == "success"
         assert result["cards_loaded"] == 8
 
     def test_unchanged_cards_not_loaded_across_batch_boundary(self, api_resource: APIResource) -> None:
         existing = [make_raw_card(name=f"Existing {uuid.uuid4()}") for _ in range(3)]
-        api_resource._upsert_cards(existing, page_size=10)
+        api_resource.admin._upsert_cards(existing, page_size=10)
 
         new_cards = [make_raw_card(name=f"New {uuid.uuid4()}") for _ in range(4)]
-        result = api_resource._upsert_cards(existing + new_cards, page_size=3)
+        result = api_resource.admin._upsert_cards(existing + new_cards, page_size=3)
         assert result["status"] == "success"
         assert result["cards_loaded"] == 4
         assert result["cards_sent"] == 7  # all cards are sent; existing ones just produce 0 loads
@@ -201,10 +202,10 @@ class TestErrorRecovery:
 
     def test_error_mid_batch_returns_database_error(self, api_resource: APIResource, caplog: pytest.LogCaptureFixture) -> None:
         with (
-            patch("api.api_resource._bulk_upsert", side_effect=self._raise_data_error),
-            caplog.at_level(logging.ERROR, logger="api.api_resource"),
+            patch("api.admin_resource._bulk_upsert", side_effect=self._raise_data_error),
+            caplog.at_level(logging.ERROR, logger="api.admin_resource"),
         ):
-            result = api_resource._upsert_cards([make_raw_card(name="Doomed Card")])
+            result = api_resource.admin._upsert_cards([make_raw_card(name="Doomed Card")])
 
         assert result["status"] == "database_error"
         assert result["cards_loaded"] == 0
@@ -216,11 +217,11 @@ class TestErrorRecovery:
 
     def test_import_succeeds_after_earlier_failure(self, api_resource: APIResource) -> None:
         """The pool is reusable after a failed import: the next import on the same pool succeeds."""
-        with patch("api.api_resource._bulk_upsert", side_effect=self._raise_data_error):
-            failed = api_resource._upsert_cards([make_raw_card(name="First Try Fails")])
+        with patch("api.admin_resource._bulk_upsert", side_effect=self._raise_data_error):
+            failed = api_resource.admin._upsert_cards([make_raw_card(name="First Try Fails")])
         assert failed["status"] == "database_error"
 
-        recovered = api_resource._upsert_cards([make_raw_card(name="Second Try Succeeds")])
+        recovered = api_resource.admin._upsert_cards([make_raw_card(name="Second Try Succeeds")])
         assert recovered["status"] == "success"
         assert recovered["cards_loaded"] == 1
 
@@ -236,7 +237,7 @@ class TestRunImportUnderLockStreaming:
     def _make_api(self) -> APIResource:
         # Patch out setup_schema and import_data during construction: __init__ calls both, and an
         # unpatched import_data with last_import_time=0.0 performs a real full Scryfall import.
-        with patch.object(APIResource, "setup_schema"), patch.object(APIResource, "import_data"):
+        with patch.object(AdminResource, "setup_schema"), patch.object(AdminResource, "import_data"):
             api = APIResource(last_import_time=multiprocessing.Value("d", 0.0, lock=True))
         api._conn_pool.close()
         api._conn_pool = MagicMock()
@@ -245,17 +246,17 @@ class TestRunImportUnderLockStreaming:
     def test_calls_stream_data_for_key(self) -> None:
         api = self._make_api()
         with (
-            patch.object(api, "_import_recent", return_value=False),
-            patch.object(api, "setup_schema"),
+            patch.object(api.admin, "_import_recent", return_value=False),
+            patch.object(api.admin, "setup_schema"),
             patch.object(
-                api,
+                api.admin,
                 "_upsert_cards",
                 return_value={"status": "no_cards_before_preprocessing", "cards_loaded": 0, "message": ""},
             ),
-            patch.object(api._bulk_data_fetcher, "stream_data_for_key") as mock_stream,
+            patch.object(api.admin._bulk_data_fetcher, "stream_data_for_key") as mock_stream,
         ):
             mock_stream.return_value = iter([])
-            api._run_import_under_lock()
+            api.admin._run_import_under_lock()
         mock_stream.assert_called_once_with(BulkDataKey.DEFAULT_CARDS)
 
     def test_stream_iterator_passed_directly_to_upsert_cards(self) -> None:
@@ -263,16 +264,16 @@ class TestRunImportUnderLockStreaming:
         api = self._make_api()
         sentinel = iter([{"id": "sentinel"}])
         with (
-            patch.object(api, "_import_recent", return_value=False),
-            patch.object(api, "setup_schema"),
-            patch.object(api._bulk_data_fetcher, "stream_data_for_key", return_value=sentinel),
+            patch.object(api.admin, "_import_recent", return_value=False),
+            patch.object(api.admin, "setup_schema"),
+            patch.object(api.admin._bulk_data_fetcher, "stream_data_for_key", return_value=sentinel),
             patch.object(
-                api,
+                api.admin,
                 "_upsert_cards",
                 return_value={"status": "no_cards_before_preprocessing", "cards_loaded": 0, "message": ""},
             ) as mock_staging,
         ):
-            api._run_import_under_lock()
+            api.admin._run_import_under_lock()
         args, _ = mock_staging.call_args
         assert args[0] is sentinel
 
@@ -317,18 +318,18 @@ class TestUpsertBehavior:
         """Group 2: re-submitting identical data produces zero loads."""
         card_id = str(uuid.uuid4())
         card = make_raw_card(card_id=card_id)
-        api_resource._upsert_cards([card])
+        api_resource.admin._upsert_cards([card])
 
-        result = api_resource._upsert_cards([card])
+        result = api_resource.admin._upsert_cards([card])
         assert result["cards_inserted"] == 0
         assert result["cards_updated"] == 0
 
     def test_changed_card_is_updated(self, api_resource: APIResource) -> None:
         """Group 3: re-submitting a card with changed data updates the stored row."""
         card_id = str(uuid.uuid4())
-        api_resource._upsert_cards([make_raw_card(card_id=card_id)])
+        api_resource.admin._upsert_cards([make_raw_card(card_id=card_id)])
 
-        result = api_resource._upsert_cards([make_raw_card(card_id=card_id, rarity="rare")])
+        result = api_resource.admin._upsert_cards([make_raw_card(card_id=card_id, rarity="rare")])
         assert result["cards_inserted"] == 0
         assert result["cards_updated"] == 1
 
@@ -340,7 +341,7 @@ class TestUpsertBehavior:
     def test_changed_card_preserves_backfilled_columns(self, api_resource: APIResource) -> None:
         """Group 3: updating a changed card leaves prefer_score and card_is_tags intact."""
         card_id = str(uuid.uuid4())
-        api_resource._upsert_cards([make_raw_card(card_id=card_id)])
+        api_resource.admin._upsert_cards([make_raw_card(card_id=card_id)])
 
         with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
@@ -349,7 +350,7 @@ class TestUpsertBehavior:
             )
             conn.commit()
 
-        api_resource._upsert_cards([make_raw_card(card_id=card_id, rarity="rare")])
+        api_resource.admin._upsert_cards([make_raw_card(card_id=card_id, rarity="rare")])
 
         with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute("SELECT prefer_score, card_is_tags FROM magic.cards WHERE scryfall_id = %s", (card_id,))

--- a/api/tests/test_upsert_cards.py
+++ b/api/tests/test_upsert_cards.py
@@ -6,7 +6,7 @@ import logging
 import multiprocessing
 import uuid
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import psycopg
 
@@ -16,6 +16,7 @@ from api.card_processing import preprocess_card
 from api.db.bulk_upsert import bulk_upsert
 from api.scryfall_bulk_data_fetcher import BulkDataKey
 from api.tests.helpers import make_raw_card
+from api.tests.support import mock_conn_pool_kwargs
 
 if TYPE_CHECKING:
     import pytest
@@ -237,11 +238,9 @@ class TestRunImportUnderLockStreaming:
     def _make_api(self) -> APIResource:
         # Patch out setup_schema and import_data during construction: __init__ calls both, and an
         # unpatched import_data with last_import_time=0.0 performs a real full Scryfall import.
+        _, pool_kwargs = mock_conn_pool_kwargs()
         with patch.object(AdminResource, "setup_schema"), patch.object(AdminResource, "import_data"):
-            api = APIResource(last_import_time=multiprocessing.Value("d", 0.0, lock=True))
-        api._conn_pool.close()
-        api._conn_pool = MagicMock()
-        return api
+            return APIResource(last_import_time=multiprocessing.Value("d", 0.0, lock=True), **pool_kwargs)
 
     def test_calls_stream_data_for_key(self) -> None:
         api = self._make_api()

--- a/api/tests/test_upsert_cards.py
+++ b/api/tests/test_upsert_cards.py
@@ -16,7 +16,7 @@ from api.card_processing import preprocess_card
 from api.db.bulk_upsert import bulk_upsert
 from api.scryfall_bulk_data_fetcher import BulkDataKey
 from api.tests.helpers import make_raw_card
-from api.tests.support import mock_conn_pool_kwargs
+from api.tests.support import mock_app_context
 
 if TYPE_CHECKING:
     import pytest
@@ -68,7 +68,7 @@ class TestUpsertCardsStatus:
 
 
 def _is_tags_for(api_resource: APIResource, scryfall_id: str) -> dict:
-    with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+    with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
         cursor.execute(
             "SELECT card_is_tags FROM magic.cards WHERE scryfall_id = %(sid)s",
             {"sid": scryfall_id},
@@ -112,7 +112,7 @@ class TestBooleanIsTags:
         card = make_raw_card(name="Historic Bystander Test")
         card["reserved"] = True
         api_resource.admin._upsert_cards([card])
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 """UPDATE magic.cards SET card_is_tags = card_is_tags || '{"historic": true}'::jsonb
                    WHERE scryfall_id = %(sid)s""",
@@ -238,9 +238,9 @@ class TestRunImportUnderLockStreaming:
     def _make_api(self) -> APIResource:
         # Patch out setup_schema and import_data during construction: __init__ calls both, and an
         # unpatched import_data with last_import_time=0.0 performs a real full Scryfall import.
-        _, pool_kwargs = mock_conn_pool_kwargs()
+        app_context = mock_app_context(last_import_time=multiprocessing.Value("d", 0.0, lock=True))
         with patch.object(AdminResource, "setup_schema"), patch.object(AdminResource, "import_data"):
-            return APIResource(last_import_time=multiprocessing.Value("d", 0.0, lock=True), **pool_kwargs)
+            return APIResource(app_context=app_context)
 
     def test_calls_stream_data_for_key(self) -> None:
         api = self._make_api()
@@ -289,7 +289,7 @@ class TestBulkUpsertDedup:
         card_id = str(uuid.uuid4())
         (row_a,) = preprocess_card(make_raw_card(card_id=card_id, rarity="common"))
         (row_b,) = preprocess_card(make_raw_card(card_id=card_id, rarity="rare"))
-        with api_resource._conn_pool.connection() as conn:
+        with api_resource.app_context.reader_pool.connection() as conn:
             result = bulk_upsert(
                 conn,
                 "cards",
@@ -299,7 +299,7 @@ class TestBulkUpsertDedup:
             )
             conn.commit()
         assert result["inserted"] == 1
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute("SELECT card_rarity_text FROM magic.cards WHERE scryfall_id = %s", (card_id,))
             row = cursor.fetchone()
         assert row["card_rarity_text"] == "rare"
@@ -332,7 +332,7 @@ class TestUpsertBehavior:
         assert result["cards_inserted"] == 0
         assert result["cards_updated"] == 1
 
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute("SELECT card_rarity_text FROM magic.cards WHERE scryfall_id = %s", (card_id,))
             row = cursor.fetchone()
         assert row["card_rarity_text"] == "rare"
@@ -342,7 +342,7 @@ class TestUpsertBehavior:
         card_id = str(uuid.uuid4())
         api_resource.admin._upsert_cards([make_raw_card(card_id=card_id)])
 
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
                 "UPDATE magic.cards SET prefer_score = 42.0, card_is_tags = '{\"is:instant\": true}'::jsonb WHERE scryfall_id = %s",
                 (card_id,),
@@ -351,7 +351,7 @@ class TestUpsertBehavior:
 
         api_resource.admin._upsert_cards([make_raw_card(card_id=card_id, rarity="rare")])
 
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        with api_resource.app_context.reader_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute("SELECT prefer_score, card_is_tags FROM magic.cards WHERE scryfall_id = %s", (card_id,))
             row = cursor.fetchone()
         assert row["prefer_score"] == 42.0

--- a/api/tests/test_utility_functions.py
+++ b/api/tests/test_utility_functions.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from api.api_resource import get_where_clause, rewrap
+from api.api_resource import rewrap
 from api.utils.error_monitoring import can_serialize
 
 
@@ -44,14 +44,3 @@ def test_rewrap_normalizes_whitespace() -> None:
     assert rewrap("SELECT\n*\nFROM\ntable") == "SELECT * FROM table"
     assert rewrap("SELECT\t*\tFROM\ttable") == "SELECT * FROM table"
     assert rewrap("  \n  SELECT  \n  *  \n  FROM  \n  table  \n  ") == "SELECT * FROM table"
-
-
-def test_get_where_clause_caching() -> None:
-    """Test that get_where_clause uses caching."""
-    # This tests the @cached decorator functionality
-    query = "cmc:3"
-    result1 = get_where_clause(query)
-    result2 = get_where_clause(query)
-
-    # Results should be identical (cached)
-    assert result1 == result2

--- a/api/utils/caching.py
+++ b/api/utils/caching.py
@@ -1,0 +1,41 @@
+"""A cache decorator that honours the runtime enable_cache setting.
+
+`cachebox.cached` binds its decision at decoration time, which happens at import. This wraps it so
+the setting is consulted per call instead, letting a deployment or a test turn caching off without
+reimporting anything. The cached function is built either way, so flipping the setting back on does
+not have to rebuild it.
+"""
+
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any
+
+import cachebox
+from cachebox import cached as cachebox_cached
+
+from api.settings import settings
+
+
+def cached(cache: Any, key: Any = None) -> Any:  # noqa: ANN401
+    """Decorator that respects the settings.enable_cache flag at runtime.
+
+    Always creates the cached function, but checks settings at call time
+    to determine whether to use the cache or call the original function.
+    """
+    key_maker = key or cachebox.make_hash_key
+
+    def decorator(func: Any) -> Any:  # noqa: ANN401
+        cached_func = cachebox_cached(cache, key_maker=key_maker)(func)
+
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+            if settings.enable_cache:
+                return cached_func(*args, **kwargs)
+            return func(*args, **kwargs)
+
+        # Copy attributes from cached_func for compatibility
+        wrapper.cache = cache  # type: ignore[attr-defined]
+        return wrapper
+
+    return decorator

--- a/api/utils/db_utils.py
+++ b/api/utils/db_utils.py
@@ -83,6 +83,25 @@ def configure_connection(conn: psycopg.Connection) -> None:
     conn.row_factory = psycopg.rows.dict_row
 
 
+def set_statement_timeout(cursor: psycopg.Cursor, statement_timeout: int) -> None:
+    """Validate and set the statement timeout for a database cursor.
+
+    PostgreSQL SET commands don't support parameterized values, so we must
+    validate the value before using it in string interpolation.
+
+    Args:
+        cursor: Database cursor to execute the SET command on
+        statement_timeout: The statement timeout value in milliseconds
+
+    Raises:
+        ValueError: If statement_timeout is not a non-negative integer
+    """
+    if not isinstance(statement_timeout, int) or statement_timeout < 0:
+        msg = f"statement_timeout must be a non-negative integer, got: {statement_timeout}"
+        raise ValueError(msg)
+    cursor.execute(f"set statement_timeout = {statement_timeout}")
+
+
 def make_pool() -> psycopg_pool.ConnectionPool:
     """Create and return a psycopg3 ConnectionPool for PostgreSQL connections."""
     creds = get_pg_creds()

--- a/api/utils/error_monitoring.py
+++ b/api/utils/error_monitoring.py
@@ -89,4 +89,3 @@ def can_serialize(iobj: object) -> bool:
         return len(s) < max_json_object_length
     except TypeError:
         return False
-    return True

--- a/api/utils/page_rendering.py
+++ b/api/utils/page_rendering.py
@@ -1,0 +1,119 @@
+"""Assemble the two server-rendered HTML pages from their templates.
+
+Both pages are built from a template plus shared fragments, with critical CSS inlined and asset URLs
+given a content-hash query string so a deploy invalidates a stale browser cache without renaming
+files. Building is cached per distinct input, since the result depends only on the critical CSS and
+the site name — not on the request.
+
+Hashes are computed once at import. A file that changes underneath a running process therefore keeps
+serving its old query string, which is correct: the process is also still serving the old bytes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import pathlib
+
+import minify_html
+from cachebox import LRUCache
+
+from api.utils.caching import cached
+
+# api/utils/page_rendering.py -> api/static. Anchored on the package directory rather than counting
+# parents from __file__, so moving this module within the package does not silently repoint it.
+STATIC_DIR = pathlib.Path(__file__).resolve().parents[1] / "static"
+_FRAGMENTS_DIR = STATIC_DIR / "fragments"
+_INDEX_HTML_PATH = STATIC_DIR / "index.html"
+_CARD_HTML_PATH = STATIC_DIR / "card.html"
+
+# Placeholder written into index.html/card.html wherever the site name belongs, so the substitution
+# below can't accidentally match unrelated copy that happens to contain "MTG Search".
+SITE_NAME_PLACEHOLDER = "%%%SITENAME%%%"
+
+# Markup identical across index.html and card.html — read once at import time and spliced into each
+# template's own placeholder comment (<!-- FAVICON --> etc.) by build_base_html / build_card_html.
+# Fragments live in fragments/ rather than static/ directly since they are not complete documents and
+# are never served on their own (only files with a route entry are reachable over HTTP).
+_FAVICON_HTML = (_FRAGMENTS_DIR / "favicon.html").read_text()
+_PRECONNECTS_HTML = (_FRAGMENTS_DIR / "preconnects.html").read_text()
+_FONTS_HTML = (_FRAGMENTS_DIR / "fonts.html").read_text()
+_CSS_HTML = (_FRAGMENTS_DIR / "css.html").read_text()
+_FOOTER_HTML = (_FRAGMENTS_DIR / "footer.html").read_text()
+
+
+def _static_hash(filename: str) -> str | None:
+    """Return a short content hash for a static file, or None if it is not built yet.
+
+    Args:
+        filename: Name of the file under STATIC_DIR.
+
+    Returns:
+        The first 12 hex characters of its sha256, or None. app.min.js is generated, so a checkout
+        that has not run the minifier legitimately has no hash for it.
+    """
+    try:
+        return hashlib.sha256((STATIC_DIR / filename).read_bytes()).hexdigest()[:12]
+    except FileNotFoundError:
+        return None
+
+
+# Feed the cache-busting ?v= query strings. Computed once at import, so a file replaced underneath a
+# running process keeps its old hash — which is correct, since the process serves the old bytes too.
+_STYLES_CSS_HASH = _static_hash("styles.css")
+_APP_MIN_JS_HASH = _static_hash("app.min.js")
+_CARD_JS_HASH = _static_hash("card.js")
+
+
+def _inject_shared_fragments(html: str) -> str:
+    """Splice the shared head/footer fragments into their placeholder comments.
+
+    Must run before the CRITICAL_CSS/asset-hash substitutions below: the CSS fragment carries its
+    own inner <!-- CRITICAL_CSS --> placeholder, which only exists in `html` after this replace.
+    """
+    html = html.replace("<!-- FAVICON -->", _FAVICON_HTML)
+    html = html.replace("<!-- PRECONNECTS -->", _PRECONNECTS_HTML)
+    html = html.replace("<!-- FONTS -->", _FONTS_HTML)
+    html = html.replace("<!-- CSS -->", _CSS_HTML)
+    return html.replace("<!-- FOOTER -->", _FOOTER_HTML)
+
+
+# Flip to False to disable HTML minification (e.g. while debugging a minifier-induced issue).
+_MINIFY_HTML_ENABLED = True
+
+
+def _minify_html(html: str) -> str:
+    """Minify HTML to shave a bit more off the page weight on top of gzip/brotli/zstd compression.
+
+    keep_comments=True is required: `build_base_html`'s cached output still carries per-request
+    placeholders (SERVER_SIDE_RESULTS, SERVER_SIDE_EMBEDDED_DATA) substituted by `search()` after
+    this function returns, and those are plain HTML comments that must survive intact.
+    """
+    if not _MINIFY_HTML_ENABLED:
+        return html
+    return minify_html.minify(html, minify_js=True, minify_css=True, keep_comments=True)
+
+
+@cached(cache=LRUCache(maxsize=16))
+def build_base_html(critical_css: str, site_name: str) -> str:
+    """Read index.html and inject critical CSS and site name. Cached per (critical_css, site_name) pair."""
+    html = _INDEX_HTML_PATH.read_text()
+    html = _inject_shared_fragments(html)
+    html = html.replace("<!-- CRITICAL_CSS -->", critical_css)
+    if _STYLES_CSS_HASH:
+        html = html.replace("/static/styles.css", f"/static/styles.css?v={_STYLES_CSS_HASH}")
+    if _APP_MIN_JS_HASH:
+        html = html.replace("/static/app.min.js", f"/static/app.min.js?v={_APP_MIN_JS_HASH}")
+    return _minify_html(html.replace(SITE_NAME_PLACEHOLDER, site_name))
+
+
+@cached(cache=LRUCache(maxsize=4))
+def build_card_html(critical_css: str) -> str:
+    """Read card.html and inject critical CSS and versioned asset URLs."""
+    html = _CARD_HTML_PATH.read_text()
+    html = _inject_shared_fragments(html)
+    html = html.replace("<!-- CRITICAL_CSS -->", critical_css)
+    if _STYLES_CSS_HASH:
+        html = html.replace("/static/styles.css", f"/static/styles.css?v={_STYLES_CSS_HASH}")
+    if _CARD_JS_HASH:
+        html = html.replace("/static/card.js", f"/static/card.js?v={_CARD_JS_HASH}")
+    return _minify_html(html)

--- a/api/utils/page_rendering.py
+++ b/api/utils/page_rendering.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import hashlib
 import pathlib
 
+import falcon
 import minify_html
 from cachebox import LRUCache
 
@@ -39,6 +40,30 @@ _PRECONNECTS_HTML = (_FRAGMENTS_DIR / "preconnects.html").read_text()
 _FONTS_HTML = (_FRAGMENTS_DIR / "fonts.html").read_text()
 _CSS_HTML = (_FRAGMENTS_DIR / "css.html").read_text()
 _FOOTER_HTML = (_FRAGMENTS_DIR / "footer.html").read_text()
+
+
+def serve_static_file(*, filename: str, falcon_response: falcon.Response) -> None:
+    """Serve a static file to the Falcon response.
+
+    Args:
+    ----
+        filename (str): The file to serve.
+        falcon_response (falcon.Response): The Falcon response to write to.
+
+    """
+    full_filename = STATIC_DIR / filename
+    try:
+        with pathlib.Path(full_filename).open() as f:
+            falcon_response.text = f.read()
+    except FileNotFoundError:
+        falcon_response.status = falcon.HTTP_404
+        falcon_response.text = f"File not found: {filename}"
+    except PermissionError:
+        falcon_response.status = falcon.HTTP_403
+        falcon_response.text = f"Permission denied: {filename}"
+    except OSError as e:
+        falcon_response.status = falcon.HTTP_500
+        falcon_response.text = f"Error reading file {filename}: {e}"
 
 
 def _static_hash(filename: str) -> str | None:

--- a/api/utils/routing.py
+++ b/api/utils/routing.py
@@ -17,7 +17,11 @@ assigned in `__init__` can become a route.
 from __future__ import annotations
 
 import dataclasses
+import inspect
 from typing import TYPE_CHECKING, Any
+
+from api.utils.param_binding import bind_params
+from api.utils.type_conversions import _get_type_name
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
@@ -109,6 +113,134 @@ def route(
         return func
 
     return mark
+
+
+def max_positional_args(func: Any) -> float:  # noqa: ANN401
+    """Return how many positional args `func` accepts; inf if it takes *args.
+
+    Computed once per registered route at construction, not per request. `inspect.signature()`
+    follows a `bind_params` wrapper's `__wrapped__` link, so this sees the real handler's signature.
+
+    Args:
+        func: The handler, wrapped or not.
+
+    Returns:
+        The count, or inf for a handler taking *args.
+    """
+    try:
+        params = inspect.signature(func).parameters.values()
+    except (TypeError, ValueError):
+        return 0.0
+    if any(p.kind == inspect.Parameter.VAR_POSITIONAL for p in params):
+        return float("inf")
+    return float(sum(1 for p in params if p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)))
+
+
+def build_route_table(
+    resource: object,
+    *,
+    prefix: str = "",
+    advertise: bool | None = None,
+) -> dict[str, BoundRoute]:
+    """Bind every marked method on a resource into a path-to-route table.
+
+    The same routine builds the root resource's table and a mounted child's, so a child cannot end up
+    registered by a different set of rules than its parent.
+
+    Args:
+        resource: Instance whose class carries the markers. Handlers are bound to this instance.
+        prefix: Path prefix to register under, for a mounted child. Empty for the root resource.
+        advertise: Overrides what each route declared. A mount passes this once rather than trusting
+            every handler in the child to carry the flag — forgetting it in one place is then a
+            property of the mount, not a hole in one handler.
+
+    Returns:
+        Path to the route that answers it.
+
+    Raises:
+        RuntimeError: Two methods claim the same path.
+    """
+    table: dict[str, BoundRoute] = {}
+    for attr_name, declared in iter_marked_routes(type(resource)):
+        spec = declared
+        if advertise is not None and spec.advertise != advertise:
+            spec = dataclasses.replace(spec, advertise=advertise)
+        handler = getattr(resource, attr_name)
+        entry = BoundRoute(
+            action=bind_params(handler),
+            positional_capacity=max_positional_args(handler),
+            spec=spec,
+        )
+        for path in spec.paths:
+            full_path = f"{prefix}/{path}" if prefix else path
+            if full_path in table:
+                msg = f"Route path {full_path!r} is claimed by both {table[full_path].action.__name__} and {attr_name}"
+                raise RuntimeError(msg)
+            table[full_path] = entry
+    return table
+
+
+def build_routes_listing(route_table: dict[str, BoundRoute]) -> dict[str, dict[str, Any]]:
+    """Build the {route: {doc, args, kwargs}} listing served in 404 responses.
+
+    Only routes that declared themselves advertisable appear. A mounted child is registered with
+    advertise=False, so the listing cannot turn the mount into a directory of what is behind it —
+    which would undo the boundary while leaving every test passing.
+
+    Depends only on the table's contents, fixed once construction finishes, so it is built once
+    there rather than on every 404 (inspect.signature() per route isn't free).
+
+    Args:
+        route_table: Path to bound route.
+
+    Returns:
+        Route name to its doc, args and kwargs.
+    """
+    routes = {}
+    for endpoint_name, entry in route_table.items():
+        if not entry.spec.advertise:
+            continue
+        wrapped_func = entry.action
+        # Get the original function from the wrapper
+        original_func = wrapped_func.__wrapped__ if hasattr(wrapped_func, "__wrapped__") else wrapped_func
+
+        # Get function signature
+        sig = inspect.signature(original_func)
+
+        # Extract docstring
+        doc = original_func.__doc__ or ""
+
+        # Parse arguments
+        args = []
+        kwargs = {}
+
+        for param_name, param in sig.parameters.items():
+            if param_name.startswith("_"):
+                continue
+            if param_name in ("self", "falcon_response"):
+                continue
+
+            param_info = {
+                "name": param_name,
+                "type": _get_type_name(param.annotation),
+            }
+
+            if param.default != inspect.Parameter.empty:
+                # It's a keyword argument with default
+                kwargs[param_name] = {
+                    "type": _get_type_name(param.annotation),
+                    "default": param.default,
+                }
+            else:
+                # It's a positional argument
+                args.append(param_info)
+
+        routes[endpoint_name] = {
+            "doc": doc,
+            "args": args,
+            "kwargs": kwargs,
+        }
+    return routes
 
 
 def iter_marked_routes(cls: type) -> Iterator[tuple[str, RouteSpec]]:

--- a/api/utils/site_name.py
+++ b/api/utils/site_name.py
@@ -1,0 +1,106 @@
+"""Derive a human display name from the Host header a request arrived on.
+
+The site is deployed under more than one hostname, and each should title itself after the host the
+visitor used rather than a hardcoded name. `sylvan-librarian.com` becomes "Sylvan Librarian".
+
+The interesting part is hostnames with no separator. `tolarianacademy.com` has nothing to split on, so
+the name is segmented against the system dictionary — which is why the result is cached and why the
+lookup degrades to the raw hostname on systems with no word list rather than failing.
+
+Input is a request header, so it is treated as untrusted: length-capped, matched against an allowlist
+of hostname characters, and rejected outright for bare IPs and localhost, all of which fall back to
+FALLBACK_SITE_NAME.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import urllib.parse
+from functools import lru_cache
+
+FALLBACK_SITE_NAME = "MTG Search"
+
+
+# TLDs in this set are stripped from the hostname; others are concatenated into the word.
+# e.g. sylvan-librarian.com -> "Sylvan Librarian"; tolarian-acade.my -> "Tolarian Academy"
+_STRIP_TLDS = frozenset(["app", "biz", "co", "com", "dev", "edu", "gov", "info", "io", "me", "net", "org", "us"])
+
+
+# Allowlist: only valid hostname characters (letters, digits, hyphens, dots) after urlparse extracts the host.
+_SAFE_HOSTNAME_RE = re.compile(r"^[a-z0-9.\-]+$")
+
+_IP_RE = re.compile(r"^\d+\.\d+\.\d+\.\d+$")
+
+_MIN_WORD_LEN = 3
+
+
+# TODO: supplement with words from https://api.scryfall.com/catalog/word-bank so MtG-specific
+# terms (e.g. "sylvan", "planeswalker") are recognized even on systems without a full dictionary.
+def _load_word_set() -> frozenset[str]:
+    for path in ("/usr/share/dict/american-english", "/usr/share/dict/words"):
+        try:
+            with pathlib.Path(path).open() as f:
+                return frozenset(w.lower() for w in f.read().splitlines() if w.isalpha() and len(w) >= _MIN_WORD_LEN)
+        except OSError:
+            continue
+    return frozenset()
+
+
+_WORDS: frozenset[str] = _load_word_set()
+
+
+def _split_words(s: str, words: frozenset[str]) -> list[str] | None:
+    """Split s into dictionary words by searching split points from the middle outward.
+
+    Returns a list of words on success, or None if the string cannot be fully partitioned.
+    """
+    # Only attempt dictionary splitting for purely alphabetic strings.
+    if not s.isalpha():
+        return None
+
+    @lru_cache(maxsize=4096)
+    def _split(sub: str) -> tuple[str, ...] | None:
+        if sub in words:
+            return (sub,)
+        n = len(sub)
+        if n < _MIN_WORD_LEN:
+            return None
+        mid = n // 2
+        for k in sorted(range(1, n), key=lambda k: abs(k - mid)):
+            left, right = sub[:k], sub[k:]
+            if left in words:
+                rest = _split(right)
+                if rest is not None:
+                    return (left, *rest)
+            if right in words:
+                rest = _split(left)
+                if rest is not None:
+                    return (*rest, right)
+        return None
+
+    res = _split(s)
+    return list(res) if res is not None else None
+
+
+def hostname_to_site_name(raw_host: str) -> str:
+    """Derive a display name from a Host header value, falling back to FALLBACK_SITE_NAME."""
+    # urlparse requires a scheme; .hostname strips the port and lowercases.
+    hostname = urllib.parse.urlparse(f"http://{raw_host}").hostname or ""
+    return _hostname_to_site_name(hostname[:64])
+
+
+@lru_cache(maxsize=256)
+def _hostname_to_site_name(hostname: str) -> str:
+    if not hostname or hostname == "localhost" or _IP_RE.match(hostname) or not _SAFE_HOSTNAME_RE.match(hostname):
+        return FALLBACK_SITE_NAME
+    parts = hostname.split(".")[-2:]
+    tld = parts[-1].lower()
+    name = parts[0] if tld in _STRIP_TLDS else ".".join(parts)
+    name = name.replace(".", "").replace("-", " ").strip()
+    if " " not in name and _WORDS:
+        split = _split_words(name, _WORDS)
+        if split is not None:
+            name = " ".join(split)
+    name = name.title()
+    return name if any(c.isalnum() for c in name) else FALLBACK_SITE_NAME

--- a/api/utils/timer.py
+++ b/api/utils/timer.py
@@ -77,7 +77,3 @@ class Timer:
 
         _recurse_round(res)
         return res.get("_children", {})
-
-    def reset(self) -> None:
-        """Clear all recorded timings."""
-        self.timings_dict.clear()

--- a/client/query_sampler.py
+++ b/client/query_sampler.py
@@ -303,10 +303,6 @@ MAX_FAMILY_DRAWS = 8
 #: range query" is a thing targeted benchmarks ask for, and the one-family-per-field split — needed
 #: so `usd<5 cn>100` is reachable at all — would otherwise make it a literal at every call site.
 RANGE_FAMILIES = frozenset({"usd", "eur", "tix", "cn", "released"})
-#: The numeric families that are NOT range-indexed. Deliberately separate: they place thresholds the
-#: same way but reach different engine machinery, so a benchmark aimed at the range index must not
-#: draw them. `RANGE_FAMILIES | CARD_NUMERIC_FAMILIES == set(NUMERIC_COLUMNS)`.
-CARD_NUMERIC_FAMILIES = frozenset({"pow", "tou", "cmc", "loyalty"})
 
 
 @dataclasses.dataclass(frozen=True)

--- a/docs/issues/local-api-resource-routing-redesign.md
+++ b/docs/issues/local-api-resource-routing-redesign.md
@@ -17,8 +17,8 @@ reasoning the shipped work rests on — but read them as the state of the code *
 | --- | --- |
 | 1. Rewrite coercion | shipped — #787 |
 | 2. `@route` and explicit registration | shipped — #789, with #791 following on |
-| 3. Move the admin handlers to a child resource | not started |
-| 4. Delist | not started |
+| 3. Move the admin handlers to a child resource | shipped |
+| 4. Delist | partly — the child is unadvertised; the public listing is not yet opt-in |
 | 5. Auth at the mount | not started |
 
 Three things this doc commits to that the shipped code deliberately does **not** do:
@@ -27,8 +27,9 @@ Three things this doc commits to that the shipped code deliberately does **not**
   revised to record why the hand-rolled dispatch stayed.
 - **`DISALLOWED_QUERY_ARGS` still exists**, and handlers still declare `**_: object` — 27 of 28 do.
   Both retire with per-route unknown-parameter enforcement, which step 2 declared but did not enforce.
-- **Nothing reads `advertise` or `ignore_unknown_params` yet.** They are on every `RouteSpec`; all 30
-  routes are still published in the 404 listing. Steps 4 and the unknown-parameter work consume them.
+- **`advertise` is now read; `ignore_unknown_params` is not.** The mount passes `advertise=False`
+  once for the whole child, and the listing filters on it. Making the *public* listing opt-in — so a
+  forgotten flag under-advertises rather than over-advertises — is what remains of step 4.
 
 ## Current mechanics
 
@@ -194,7 +195,7 @@ that move code.
    and makes each route declare which HTTP methods it accepts. #791 followed on, registering the
    static assets at the URLs they are actually requested at now that paths are declared rather than
    derived from method names.
-3. **Move the admin handlers to a child resource.** *(next)* The closure analysis for this — which
+3. **Move the admin handlers to a child resource.** *(shipped)* The closure analysis for this — which
    methods and handles are shared, which move — lives in the out-of-tree doc. Mounting is a loop over
    a child's marked methods; resist extracting a `Router` abstraction until a second mount point
    exists.

--- a/scripts/bench_random.py
+++ b/scripts/bench_random.py
@@ -43,7 +43,7 @@ REPEATS = 3  # independent timed windows per cell (report min to reduce noise)
 
 print("Connecting to DB and loading engine store…", flush=True)
 api = APIResource(app_context=AppContext(last_import_time=multiprocessing.Value("d", time.time(), lock=True)))
-override_attr(api, "_import_recent", lambda: True)
+override_attr(api.admin, "_import_recent", lambda: True)
 override_attr(api.app_context, "setup_complete", lambda: True)
 api.app_context.reload_engine(force=True)
 total_printings = api.app_context.engine.size()

--- a/scripts/bench_random.py
+++ b/scripts/bench_random.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 sys.path.insert(0, "/app")
 
 from api.api_resource import APIResource
+from api.app_context import AppContext
 from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
 from api.parsing import parse_scryfall_query
 from api.tests.support import override_attr
@@ -41,11 +42,11 @@ REPEATS = 3  # independent timed windows per cell (report min to reduce noise)
 # ─── Setup ────────────────────────────────────────────────────────────────────
 
 print("Connecting to DB and loading engine store…", flush=True)
-api = APIResource(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
+api = APIResource(app_context=AppContext(last_import_time=multiprocessing.Value("d", time.time(), lock=True)))
 override_attr(api, "_import_recent", lambda: True)
-override_attr(api, "_setup_complete", lambda: True)
-api._reload_engine(force=True)
-total_printings = api._engine.size()
+override_attr(api.app_context, "setup_complete", lambda: True)
+api.app_context.reload_engine(force=True)
+total_printings = api.app_context.engine.size()
 print(f"Engine loaded: {total_printings:,} printings", flush=True)
 
 # Build the prebuilt list that the old implementation kept in memory.
@@ -53,7 +54,7 @@ print(f"Engine loaded: {total_printings:,} printings", flush=True)
 print("Building prebuilt card list (old approach)…", flush=True)
 tracemalloc.start()
 snapshot_before = tracemalloc.take_snapshot()
-_, prebuilt = api._engine.query(
+_, prebuilt = api.app_context.engine.query(
     filters=parse_scryfall_query(""),
     unique=str(UniqueOn.CARD),
     prefer=str(PreferOrder.DEFAULT),
@@ -89,9 +90,9 @@ def _time_fn(fn: Callable[[], object], warmup: int, window: float) -> float:
 def bench(n: int) -> tuple[float, float, float, float]:
     """Return (py_sample_us, preferred_us, reservoir_us, indexed_us) as min over REPEATS windows."""
     py_timings = [_time_fn(lambda: random.sample(prebuilt, n), WARMUP, WINDOW) for _ in range(REPEATS)]
-    pref_timings = [_time_fn(lambda: api._engine.sample_preferred(n), WARMUP, WINDOW) for _ in range(REPEATS)]
-    res_timings = [_time_fn(lambda: api._engine.sample_reservoir(n), WARMUP, WINDOW) for _ in range(REPEATS)]
-    idx_timings = [_time_fn(lambda: api._engine.sample_indexed(n), WARMUP, WINDOW) for _ in range(REPEATS)]
+    pref_timings = [_time_fn(lambda: api.app_context.engine.sample_preferred(n), WARMUP, WINDOW) for _ in range(REPEATS)]
+    res_timings = [_time_fn(lambda: api.app_context.engine.sample_reservoir(n), WARMUP, WINDOW) for _ in range(REPEATS)]
+    idx_timings = [_time_fn(lambda: api.app_context.engine.sample_indexed(n), WARMUP, WINDOW) for _ in range(REPEATS)]
     return min(py_timings), min(pref_timings), min(res_timings), min(idx_timings)
 
 

--- a/scripts/find_missing_cards.py
+++ b/scripts/find_missing_cards.py
@@ -153,7 +153,7 @@ def import_missing_card(card_name: str, api_base_url: str, session: requests.Ses
     """
     try:
         response = session.post(
-            f"{api_base_url}/import_card_by_name",
+            f"{api_base_url}/_admin/import_card_by_name",
             params={"card_name": card_name},
             timeout=30,
         )


### PR DESCRIPTION
## Summary

`AdminResource` (the data-management handlers — import, backfill, tagging — mounted behind a path prefix rather than sharing the public API's namespace) no longer holds a reference back to `APIResource`. In its place, `AppContext` is introduced as a neutral object both resources hold a reference to — connection pools, the query engine, and the cross-worker cache/import signals all live there instead of on whichever resource happened to construct them first. A second small bundle, `AdminContext`, holds the two primitives (`import_guard`, `schema_setup_event`) that serialize schema setup and are private to `AdminResource`.

Route registration is generalized to match: `api/utils/routing.py` gains `build_route_table`/`build_routes_listing`/`max_positional_args`, so the same registration logic mounts both the root resource's routes and the admin child's (under the `_admin/` prefix, `advertise=False`) rather than each resource building its table by hand.

Several other pieces of `api_resource.py` that had nothing to do with routing or resource wiring move out to their own modules: page assembly and critical-CSS injection (`api/utils/page_rendering.py`), Host-header → display-name mapping (`api/utils/site_name.py`), the runtime-toggleable cache decorator (`api/utils/caching.py`), and `set_statement_timeout` (`api/utils/db_utils.py`). `api_resource.py` shrinks accordingly — search logic, SQL generation, and the public routes are what's left.

`api/card_processing.py` gains `extract_frame_data_from_raw_card`, replacing both a dead standalone copy in `card_query_nodes.py` and an inline duplicate inside `preprocess_card`.

A handful of unrelated dead-code removals ride along: `extract_image_location_uuid`, `get_field_type`, `DB_NAME_TO_FIELD_TYPE`, `FORMAT_NAME_TO_CODE`, the unused `COMPARISON_OPERATORS` frozenset, `parse_q_list` (an unfinished TODO stub in the compression middleware), `Timer.reset`, an unreachable `return True` in `error_monitoring.py`, and an unused constant in `client/query_sampler.py`.

Also includes fixes from a follow-up review pass: a stale call site in `find_missing_cards.py` and `bench_random.py` pointed at routes/attributes that moved behind the admin mount, `import_card_by_name`'s existence check was missing its statement timeout, two docstrings described primitives inaccurately, two test files hand-rolled a mock `AppContext` instead of reusing the shared fixture, and two `last_import_time is None` branches were dead code given `AppContext`'s non-optional guarantee.

## What's mounted where

- `AdminResource`: `import_data`, `import_card_by_name`, `import_cards_by_search`, `import_all_is_tags`, `import_art_tags`, `import_oracle_tags`, `discover_is_tags_from_syntax`, `backfill_prefer_scores`, `backfill_cubecobra_scores`, `ingest_cubecobra`, `setup_schema`, `prefer_score_tuner` — all reachable only at `/_admin/<name>`, none advertised in the 404 listing.
- `APIResource`: `search`, `random_search`, `card`, `get_catalog`, `get_common_keywords`, static asset routes, and the two in-process startup calls (`setup_schema`, `import_data`) that run before the server starts accepting requests.

## Test plan

- [x] `python -m pytest api/` — full suite passes (aside from 2 pre-existing `test_engine_unit.py` failures unrelated to this branch, reproducing identically against `main`)
- [x] New coverage: `test_admin_mount.py` (route-table boundary — public surface, admin-only reachability, delisting, dispatch), `test_app_context.py`, `test_app_context_cross_process.py` (real fork-based tests that `cache_generation`/`last_import_time`/`engine_reload_guard` actually cross a process boundary), `test_site_name.py`, `test_page_rendering.py`
- [x] `ruff check` / `ruff format --check`
