### PR TITLE
Fix Review Findings From PR #963

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Browser → GET /search?q=<query>
 
 - **`api/parsing/`** — Core query parser (~2,500 lines). `parsing_f.py` drives the pyparsing grammar; `nodes.py` defines AST node types; `card_query_nodes.py` has card-specific nodes; `db_info.py` maps query fields to DB columns.
 - **`api/api_resource.py`** — Dispatch (Falcon sink), search logic, SQL generation from AST, and the public routes.
-- **`api/admin_resource.py`** — Data-management handlers (import, backfill, tagging), mounted by `APIResource` under a path prefix rather than sharing the public namespace. Holds a reference to its parent for the handful of methods and handles they share.
+- **`api/admin_resource.py`** — Data-management handlers (import, backfill, tagging), mounted by `APIResource` under a path prefix rather than sharing the public namespace. Holds no reference to its parent; state the two resources share (connection pools, the query engine, cross-worker cache/import signals) lives on the `AppContext` both take a reference to at construction (`api/app_context.py`).
 - **`api/utils/routing.py`** — The `@route` marker, route-table construction, and the 404 listing. A handler is reachable only if marked; the listing skips anything registered `advertise=False`, which is what makes the mount a boundary rather than a URL prefix.
 - **`api/utils/param_binding.py`** — Resolves each handler's annotations once at registration and binds request parameters against a fixed plan.
 - **`api/utils/page_rendering.py`**, **`api/utils/css_utils.py`**, **`api/utils/site_name.py`**, **`api/utils/caching.py`** — Page assembly, critical-CSS extraction, Host-header display names, and the settings-aware cache decorator.

--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -16,9 +16,10 @@ reference to at construction (see `api/app_context.py`). Neither resource owns t
 peers that reach into a neutral shared object instead of into each other.
 
 `import_guard`/`schema_setup_event` are not part of `AppContext`: they're cross-worker-shared, but
-only *within* `AdminResource`'s own copies across processes (serialising concurrent import
-attempts) — nothing on the search side ever touches either one. They get their own small bundle,
-`AdminContext`, defined here since nothing outside this module needs it.
+only *within* `AdminResource`'s own copies across processes. `import_guard` serialises concurrent
+*schema setup* only — the import flow itself serialises on `AppContext.last_import_time`'s own lock
+instead (see `import_data`) — and nothing on the search side ever touches either primitive. They get
+their own small bundle, `AdminContext`, defined here since nothing outside this module needs it.
 """
 
 from __future__ import annotations
@@ -189,7 +190,9 @@ class AdminContext:
         """Build the primitives, or accept ones a caller already built.
 
         Args:
-            import_guard: Cross-process lock serialising imports.
+            import_guard: Cross-process lock serialising concurrent schema setup (see
+                `setup_schema`) -- not the import flow itself, which serialises on
+                `AppContext.last_import_time`'s own lock instead (see `import_data`).
             schema_setup_event: Set once the schema has been created.
         """
         self.import_guard = import_guard
@@ -210,8 +213,8 @@ class AdminResource:
         Args:
             app_context: State and resources shared with the resource this is mounted on --
                 connection pools, the query engine, the cross-worker cache/import signals.
-            admin_context: Import-serialisation primitives private to this resource. Built fresh if
-                not given, matching every other handle here.
+            admin_context: Schema-setup-serialisation primitives private to this resource. Built
+                fresh if not given, matching every other handle here.
         """
         self.app_context = app_context
         self.admin_context = admin_context or AdminContext()

--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -19,7 +19,8 @@ peers that reach into a neutral shared object instead of into each other.
 only *within* `AdminResource`'s own copies across processes. `import_guard` serialises concurrent
 *schema setup* only — the import flow itself serialises on `AppContext.last_import_time`'s own lock
 instead (see `import_data`) — and nothing on the search side ever touches either primitive. They get
-their own small bundle, `AdminContext`, defined here since nothing outside this module needs it.
+their own small bundle, `AdminContext`, defined here. `APIResource` and `api_worker` import the type
+to construct and forward it, but nothing outside this module reads or writes its fields.
 """
 
 from __future__ import annotations
@@ -179,7 +180,11 @@ CARD_IS_TAGS = LAND_IS_TAGS + [  # noqa: RUF005
 
 
 class AdminContext:
-    """Cross-worker primitives private to AdminResource: not shared with any other resource."""
+    """Cross-worker primitives private to AdminResource's own use.
+
+    The type itself is imported by `APIResource` and `api_worker` to construct and forward an
+    instance, but nothing outside `AdminResource` reads or writes the primitives it holds.
+    """
 
     def __init__(
         self,

--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -291,9 +291,7 @@ class AdminResource:
             logger.info("Schema setup complete in pid %d", os.getpid())
 
     def _import_recent(self) -> bool:
-        """Return True if a bulk import completed in the last 5 minutes (or setup is complete when no shared timestamp)."""
-        if self.app_context.last_import_time is None:
-            return self.app_context.setup_complete()
+        """Return True if a bulk import completed in the last 5 minutes."""
         # Unlocked read: c_double is atomic on typical platforms; avoids lock contention on fast path
         t = self.app_context.last_import_time.get_obj().value
         if not t:
@@ -318,8 +316,7 @@ class AdminResource:
         after_transfer = time.monotonic()
 
         if result["status"] == "success":
-            if self.app_context.last_import_time is not None:
-                self.app_context.last_import_time.value = time.time()
+            self.app_context.last_import_time.value = time.time()
             total_time = after_transfer - before
             cards_sent = result.get("cards_sent", result["cards_loaded"])
             rate = cards_sent / total_time if total_time > 0 else 0

--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -945,6 +945,7 @@ class AdminResource:
 
         # Check if card already exists in database for backward compatibility
         with self.app_context.writer_pool.connection() as conn, conn.cursor() as cursor:
+            db_utils.set_statement_timeout(cursor, 10_000)
             cursor.execute(
                 "SELECT card_name FROM magic.cards WHERE card_name = %(card_name)s",
                 {"card_name": card_name},

--- a/api/tests/test_admin_mount.py
+++ b/api/tests/test_admin_mount.py
@@ -6,8 +6,6 @@ admin handlers reachable, or advertises them, would otherwise pass every other t
 
 from __future__ import annotations
 
-import multiprocessing
-import time
 from unittest.mock import MagicMock
 
 import falcon
@@ -16,7 +14,7 @@ import pytest
 
 from api.admin_resource import ADMIN_MOUNT_PREFIX, AdminResource
 from api.api_resource import APIResource
-from api.app_context import AppContext
+from api.tests.support import mock_app_context
 
 # The complete public surface, as a literal. A route appearing or disappearing here is a deliberate
 # act, and this is the guard that makes it one — the failure this whole change exists to prevent was
@@ -66,12 +64,7 @@ def resource_fixture() -> APIResource:
     are distinct objects, matching that AdminResource reads/writes via its own pool rather than
     the one search-shaped resources use.
     """
-    app_context = AppContext(
-        reader_pool=MagicMock(),
-        writer_pool=MagicMock(),
-        engine=MagicMock(),
-        last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-    )
+    app_context = mock_app_context(reader_pool=MagicMock(), writer_pool=MagicMock())
     return APIResource(app_context=app_context)
 
 

--- a/api/tests/test_app_context_cross_process.py
+++ b/api/tests/test_app_context_cross_process.py
@@ -18,9 +18,8 @@ from __future__ import annotations
 
 import multiprocessing
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
 
-from api.app_context import AppContext
+from api.tests.support import mock_app_context
 
 if TYPE_CHECKING:
     from multiprocessing.sharedctypes import Synchronized
@@ -30,22 +29,16 @@ if TYPE_CHECKING:
 _JOIN_TIMEOUT = 5
 
 
-def _mock_app_context(**overrides: object) -> AppContext:
-    kwargs: dict[str, object] = {"reader_pool": MagicMock(), "writer_pool": MagicMock(), "engine": MagicMock()}
-    kwargs.update(overrides)
-    return AppContext(**kwargs)
-
-
 def _child_bumps_cache_generation(cache_generation: Synchronized) -> None:
-    _mock_app_context(cache_generation=cache_generation).bump_cache_generation()
+    mock_app_context(cache_generation=cache_generation).bump_cache_generation()
 
 
 def _child_writes_last_import_time(last_import_time: Synchronized, value: float) -> None:
-    _mock_app_context(last_import_time=last_import_time).last_import_time.value = value
+    mock_app_context(last_import_time=last_import_time).last_import_time.value = value
 
 
 def _child_holds_the_guard(guard: LockType, acquired: EventType, release: EventType) -> None:
-    ctx = _mock_app_context(engine_reload_guard=guard)
+    ctx = mock_app_context(engine_reload_guard=guard)
     ctx.engine_reload_guard.acquire()
     acquired.set()
     release.wait(timeout=_JOIN_TIMEOUT)
@@ -65,7 +58,7 @@ class TestSharedSignalsCrossProcesses:
         assert process.exitcode == 0
         # A *different* AppContext instance, in this (parent) process, built from the same shared
         # Value -- not the one the child mutated -- must see the child's write.
-        parent_ctx = _mock_app_context(cache_generation=cache_generation)
+        parent_ctx = mock_app_context(cache_generation=cache_generation)
         assert parent_ctx.cache_generation.value == 1
 
     def test_last_import_time_write_is_visible_across_processes(self) -> None:
@@ -76,7 +69,7 @@ class TestSharedSignalsCrossProcesses:
         process.join(timeout=_JOIN_TIMEOUT)
 
         assert process.exitcode == 0
-        parent_ctx = _mock_app_context(last_import_time=last_import_time)
+        parent_ctx = mock_app_context(last_import_time=last_import_time)
         assert parent_ctx.last_import_time.value == 12345.0
 
     def test_engine_reload_guard_serialises_across_processes(self) -> None:
@@ -89,7 +82,7 @@ class TestSharedSignalsCrossProcesses:
         try:
             assert acquired.wait(timeout=_JOIN_TIMEOUT), "child never signalled that it holds the guard"
 
-            parent_ctx = _mock_app_context(engine_reload_guard=guard)
+            parent_ctx = mock_app_context(engine_reload_guard=guard)
             # The child holds the lock from a different process: a non-blocking acquire here must fail.
             assert parent_ctx.engine_reload_guard.acquire(block=False) is False
 

--- a/scripts/bench_random.py
+++ b/scripts/bench_random.py
@@ -43,7 +43,7 @@ REPEATS = 3  # independent timed windows per cell (report min to reduce noise)
 
 print("Connecting to DB and loading engine store…", flush=True)
 api = APIResource(app_context=AppContext(last_import_time=multiprocessing.Value("d", time.time(), lock=True)))
-override_attr(api, "_import_recent", lambda: True)
+override_attr(api.admin, "_import_recent", lambda: True)
 override_attr(api.app_context, "setup_complete", lambda: True)
 api.app_context.reload_engine(force=True)
 total_printings = api.app_context.engine.size()

--- a/scripts/find_missing_cards.py
+++ b/scripts/find_missing_cards.py
@@ -153,7 +153,7 @@ def import_missing_card(card_name: str, api_base_url: str, session: requests.Ses
     """
     try:
         response = session.post(
-            f"{api_base_url}/import_card_by_name",
+            f"{api_base_url}/_admin/import_card_by_name",
             params={"card_name": card_name},
             timeout=30,
         )


### PR DESCRIPTION
## Summary

Fixes for a subset of the findings from reviewing #963's diff, stacked on top of that branch so they can be reviewed independently before merging into it.

- Fix `find_missing_cards.py`'s import endpoint to the admin-mounted path
- Re-add the statement timeout on `import_card_by_name`'s existence check
- Fix `bench_random.py`'s `_import_recent` override target
- Update CLAUDE.md's `AdminResource` description for the AppContext split
- Fix `import_guard`'s docstrings to describe what it actually serialises
- Reuse `support.mock_app_context` instead of duplicating it in two tests
- Fix `AdminContext`'s docstring about who needs the type
- Remove dead `last_import_time` None-checks in `AdminResource`

## Test plan

- [x] `python -m pytest api/tests/test_admin_mount.py api/tests/test_app_context_cross_process.py` — 30 passed
- [x] `python -m pytest api/tests/test_import_card_by_name.py api/tests/test_import_cards_by_search.py api/tests/test_upsert_cards.py api/tests/test_admin_mount.py` — 62 passed
- [x] `python -m pytest api/` — 2861 passed (2 pre-existing failures in `test_engine_unit.py`, unrelated to this branch and reproduce identically against `origin/main`)
- [x] `ruff check` on all touched files