### PR TITLE
Admin: Require Basic Auth at the _admin Mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,10 @@ applies every time that stack starts; exporting one in the shell overrides the f
   - Comma-separated list of origins to allow
   - Example: `https://example.com,https://app.example.com`
   - Supplements environment-specific defaults
+- `ADMIN_PASSWORD` - Shared secret required to reach any `_admin/` route (see [Admin Endpoints](#admin-endpoints))
+  - Generated automatically into `env.json` on first boot; never overwrites an existing value
+  - Retrieve it with `jq -r .ADMIN_PASSWORD env.json`
+  - If unset, every `_admin/` request is rejected rather than left open
 
 **Client Service:**
 - `API_URL` - URL of the API service (default: `http://apiservice:8080`)
@@ -387,10 +391,24 @@ python -m client.query_runner
 - **GET /search** - Card search with query parameter support
 - **GET /favicon.ico** - Favicon for web interface
 
-### Tagging Endpoints
+### Admin Endpoints
 
-- **GET /update_tagged_cards** - Import cards for specific tags
-- **GET /discover_and_import_all_tags** - Bulk tag discovery and import
+Data-management routes — importing card data, running score/tag backfills, applying schema
+migrations — live under `_admin/` rather than the public namespace, and require HTTP Basic Auth.
+`setup_schema` and `import_data` both run automatically on startup, so a fresh instance already has
+card data; these exist for triggering a re-import or backfill on demand.
+
+- **GET /_admin/import_data** - Re-import card data from Scryfall's bulk data API
+- **GET /_admin/backfill_prefer_scores** - Recompute `prefer_score` for all cards
+- **GET /_admin/backfill_cubecobra_scores** - Recompute `cubecobra_score` for all cards
+- **GET /_admin/import_oracle_tags** / **/_admin/import_art_tags** / **/_admin/import_all_is_tags** - Import Scryfall's oracle, art, and `is:` tags
+
+Authenticate with any username and the `ADMIN_PASSWORD` value from `env.json` (see
+[Environment Variables](#environment-variables)):
+
+```bash
+curl -u admin:$(jq -r .ADMIN_PASSWORD env.json) http://localhost:28080/_admin/import_data
+```
 
 ### Query Parameters
 

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -260,6 +260,10 @@ class APIResource:
         self.admin = AdminResource(app_context=self.app_context, admin_context=admin_context)
         self.routes.update(build_route_table(self.admin, prefix=ADMIN_MOUNT_PREFIX, advertise=False))
         self._not_found_routes = build_routes_listing(self.routes)
+        # Shown only once AdminAuthMiddleware has stamped req.context["admin_authenticated"] —
+        # see _raise_not_found. Precomputed here for the same reason as _not_found_routes:
+        # inspect.signature() per route isn't free, and the table never changes after construction.
+        self._authenticated_not_found_routes = build_routes_listing(self.routes, include_unadvertised=True)
 
         self.admin.setup_schema()
         self.admin.import_data()  # ensures that database is setup
@@ -287,6 +291,27 @@ class APIResource:
         if entry is None or len(action_args) > entry.positional_capacity:
             return None, []
         return entry, action_args
+
+    def _build_action_kwargs(self, req: falcon.Request, resp: falcon.Response, entry: BoundRoute | None) -> dict[str, Any]:
+        """Assemble the keyword arguments passed to a route's action.
+
+        Args:
+            req: The incoming request.
+            resp: The response the action will populate.
+            entry: The matched route, or None when the path didn't resolve to anything -- in which
+                case action is _raise_not_found rather than a real route handler.
+
+        Returns:
+            Keyword arguments for the action call.
+        """
+        params = {k: v for k, v in req.params.items() if k not in DISALLOWED_QUERY_ARGS}
+        if entry is None:
+            # Only _raise_not_found reads this; set after the query string so a request can't
+            # spoof it via ?admin_authenticated=1 on a path that doesn't resolve to anything.
+            params["admin_authenticated"] = req.context.get("admin_authenticated", False)
+        params["falcon_response"] = resp
+        params["request_host"] = req.get_header("X-Proxy-Host") or req.host
+        return params
 
     def _handle(self, req: falcon.Request, resp: falcon.Response) -> None:
         """Handle a Falcon request and set the response.
@@ -322,8 +347,7 @@ class APIResource:
         res = None
         before = time.monotonic()
         try:
-            params = {k: v for k, v in req.params.items() if k not in DISALLOWED_QUERY_ARGS}
-            res = action(*action_args, falcon_response=resp, request_host=req.get_header("X-Proxy-Host") or req.host, **params)
+            res = action(*action_args, **self._build_action_kwargs(req, resp, entry))
             resp.media = res
         except ParamCoercionError as oops:
             # A value the client sent is not valid for the parameter it names. The message contains only
@@ -372,12 +396,20 @@ class APIResource:
                 for span_name, span_data in res.get("outer_timings", {}).items():
                     record_span(req, span_name, span_data.get("_meta", {}).get("duration_ms", 0))
 
-    def _raise_not_found(self, *_args: object, **_: object) -> None:
-        """Raise a Falcon HTTPNotFound error with available routes."""
+    def _raise_not_found(self, *_args: object, admin_authenticated: bool = False, **_: object) -> None:
+        """Raise a Falcon HTTPNotFound error with available routes.
+
+        Args:
+            admin_authenticated: Whether this request already carried a valid admin credential
+                (AdminAuthMiddleware, via req.context). A caller who has already proven they hold
+                the shared secret gains nothing from the admin routes being hidden, so they get the
+                full listing instead of just the public one.
+        """
+        routes = self._authenticated_not_found_routes if admin_authenticated else self._not_found_routes
         raise falcon.HTTPNotFound(
             title="Not Found",
             description={
-                "routes": self._not_found_routes,
+                "routes": routes,
             },
         )
 

--- a/api/api_worker.py
+++ b/api/api_worker.py
@@ -103,6 +103,7 @@ class ApiWorker(multiprocessing.Process):
         from api.api_resource import APIResource  # pylint: disable=import-outside-toplevel
         from api.app_context import AppContext  # pylint: disable=import-outside-toplevel
         from api.middlewares import (
+            AdminAuthMiddleware,
             CachingMiddleware,
             CompressionMiddleware,
             CORSMiddleware,
@@ -125,6 +126,7 @@ class ApiWorker(multiprocessing.Process):
         api = falcon.App(
             middleware=[
                 TimingMiddleware(),
+                AdminAuthMiddleware(),  # ahead of caching: a rejected admin request must never hit the cache
                 QueryLogMiddleware(),  # process_response fires before TimingMiddleware's
                 CachingMiddleware(cache=shared_cache),
                 CompressionMiddleware(),

--- a/api/middlewares/__init__.py
+++ b/api/middlewares/__init__.py
@@ -8,6 +8,7 @@ Exports:
 
 from __future__ import annotations
 
+from api.middlewares.admin_auth_middleware import AdminAuthMiddleware
 from api.middlewares.caching_middleware import CachingMiddleware
 from api.middlewares.compression import CompressionMiddleware
 from api.middlewares.cors_middleware import CORSMiddleware
@@ -17,6 +18,7 @@ from api.middlewares.security_headers import SecurityHeadersMiddleware
 from api.middlewares.timing import ProfilingMiddleware, TimingMiddleware
 
 __all__ = [
+    "AdminAuthMiddleware",
     "CORSMiddleware",
     "CachingMiddleware",
     "CompressionMiddleware",

--- a/api/middlewares/admin_auth_middleware.py
+++ b/api/middlewares/admin_auth_middleware.py
@@ -1,0 +1,129 @@
+"""HTTP Basic Auth gate for every route under the admin mount.
+
+The mount (`api/admin_resource.py`'s `_admin` prefix) is what makes this cheap: one check where
+requests enter the child, rather than a decorator on every handler that someone forgets on the
+next one. See docs/issues/security-admin-route-split-child-resources.md for the fuller design
+history -- this is that doc's last open step, "auth at the mount".
+
+Basic Auth over a bespoke header was the deliberate choice: it gets a native browser login prompt
+for free (no admin UI to build), and `curl -u user:pass` needs no separate tooling either. The
+username is not checked -- there is one shared secret, not per-operator accounts -- only the
+password is compared, in constant time, against ADMIN_PASSWORD.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import logging
+import secrets
+from typing import TYPE_CHECKING
+
+from api.admin_resource import ADMIN_MOUNT_PREFIX
+from api.settings import settings
+
+if TYPE_CHECKING:
+    import falcon
+
+logger = logging.getLogger(__name__)
+
+_REALM = "admin"
+_ADMIN_PREFIX_WITH_SLASH = f"{ADMIN_MOUNT_PREFIX}/"
+
+
+def _is_admin_path(path: str) -> bool:
+    """Check whether a request path falls under the admin mount.
+
+    Args:
+        path: req.path, unmodified (leading slash still present).
+
+    Returns:
+        True if the path is the admin mount itself or anything nested under it.
+    """
+    normalized = path.strip("/")
+    return normalized == ADMIN_MOUNT_PREFIX or normalized.startswith(_ADMIN_PREFIX_WITH_SLASH)
+
+
+def _is_authenticated(req: falcon.Request) -> bool:
+    """Check whether a request carries a valid admin credential.
+
+    Args:
+        req: The incoming request.
+
+    Returns:
+        True if ADMIN_PASSWORD is set and the request's Basic Auth password matches it.
+    """
+    expected = settings.admin_password
+    if not expected:
+        return False
+    supplied = _supplied_password(req.get_header("Authorization"))
+    return supplied is not None and secrets.compare_digest(supplied.encode(), expected.encode())
+
+
+def _supplied_password(authorization_header: str | None) -> str | None:
+    """Extract the password from a `Basic` Authorization header.
+
+    Args:
+        authorization_header: Raw Authorization header value, or None if absent.
+
+    Returns:
+        The password half of `user:password`, or None if the header is missing, is not a
+        well-formed Basic credential, or carries no `:` separator.
+    """
+    if not authorization_header:
+        return None
+    scheme, _, token = authorization_header.partition(" ")
+    if scheme.lower() != "basic" or not token:
+        return None
+    token = token.strip()
+    try:
+        decoded = base64.b64decode(token, validate=True).decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError):
+        return None
+    _username, sep, password = decoded.partition(":")
+    return password if sep else None
+
+
+class AdminAuthMiddleware:
+    """Requires a valid Basic Auth password on every request under the admin mount.
+
+    Runs ahead of CachingMiddleware in the middleware list so a rejected request never reaches
+    the cache lookup, and stamps `Cache-Control: no-store` on every admin-path response -- pass
+    or reject -- so nothing under the mount is ever eligible for CachingMiddleware to store in
+    the first place, independent of ordering.
+
+    Also stamps `req.context["admin_authenticated"]` on *every* request, not only ones under the
+    mount: `_raise_not_found` (`api/api_resource.py`) reads it to decide whether a 404 gets the
+    public route listing or the full one including admin routes -- there's no reason to hide the
+    admin surface from a caller who has already proven they hold the shared secret. Checking the
+    credential unconditionally costs nothing on the hot path: with no Authorization header (the
+    overwhelming majority of requests) `_supplied_password` returns immediately.
+    """
+
+    def __init__(self) -> None:
+        """Warn once at startup if the admin surface has no password to check against."""
+        if not settings.admin_password:
+            logger.warning("ADMIN_PASSWORD is not set -- every _admin request will be rejected")
+
+    def process_request(self, req: falcon.Request, resp: falcon.Response) -> None:
+        """Reject unauthenticated requests to the admin mount; mark the rest no-store.
+
+        Args:
+            req: The incoming request.
+            resp: The response to populate on rejection, or annotate on passthrough.
+        """
+        authenticated = _is_authenticated(req)
+        req.context["admin_authenticated"] = authenticated
+
+        if not _is_admin_path(req.path):
+            return
+
+        resp.set_header("Cache-Control", "no-store")
+
+        if authenticated:
+            return
+
+        resp.status = "401 Unauthorized"
+        resp.set_header("WWW-Authenticate", f'Basic realm="{_REALM}"')
+        resp.media = {"error": "Unauthorized"}
+        resp.complete = True

--- a/api/middlewares/caching_middleware.py
+++ b/api/middlewares/caching_middleware.py
@@ -39,17 +39,6 @@ _UNCACHEABLE_HEADER_PREFIXES: tuple[str, ...] = ("access-control-", "x-cache")
 # Responses to POST/PUT/DELETE are not replayable in the first place.
 CACHEABLE_METHODS = frozenset({"GET", "HEAD"})
 
-# Appended to a request's ordinary cache key to get the slot its 4xx response goes in when the
-# caller is admin-authenticated. A 4xx's content can depend on req.context["admin_authenticated"]
-# (APIResource._raise_not_found serves a different route listing to each), which the ordinary key
-# doesn't encode -- so an admin-authenticated 4xx needs its own slot, or it would either leak that
-# listing forward to a later anonymous caller on the same path, or (stored the other way around) get
-# masked by an anonymous 404 cached first. Plain bytes appended to the ordinary orjson-encoded key
-# rather than folded into a new orjson.dumps call: orjson can't re-serialize the raw bytes the first
-# call already produced, and a suffix can never collide with a distinct request's key, because every
-# orjson array encoding ends in "]" with nothing after it.
-_ADMIN_4XX_KEY_SUFFIX = b":admin-4xx"
-
 
 def cacheable_headers(headers: Mapping[str, str]) -> list[tuple[str, str]]:
     """Return the subset of headers safe to replay on a cache hit for a different request."""
@@ -128,20 +117,7 @@ class CachingMiddleware:
 
         cache_key = self._cache_key(req)
         req.context["cache_key"] = cache_key  # reused by process_response — one serialization per request
-        authenticated = req.context.get("admin_authenticated", False)
-
-        cached = self.cache.get(cache_key)
-        if cached is not None and authenticated and cached.status.startswith("4"):
-            # The ordinary slot isn't trustworthy here: it may hold a 4xx written by (or for) an
-            # anonymous caller, and a 4xx's content can depend on admin_authenticated (see
-            # APIResource._raise_not_found) -- check the admin-only slot instead. Only reached when
-            # the ordinary lookup above already found *something* and it was a 4xx, so the common
-            # case (every anonymous request, and every admin request that hits a 2xx) never pays
-            # for this second lookup.
-            admin_key = cache_key + _ADMIN_4XX_KEY_SUFFIX
-            req.context["admin_4xx_cache_key"] = admin_key
-            cached = self.cache.get(admin_key)
-
+        cached: CachedResponse | None = self.cache.get(cache_key)
         if cached is not None:
             if TYPE_CHECKING:
                 cached = typecast("CachedResponse", cached)
@@ -181,24 +157,22 @@ class CachingMiddleware:
         del resource, req_succeeded
         if req.context.get("cache_hit"):
             return
-        if resp.status and resp.status.startswith("5"):
+        # Neither is cacheable. 5xx is a transient failure, not a repeatable answer. 4xx isn't
+        # cached either, on different grounds: the path space behind a 404 is effectively
+        # unbounded (bots, scanners, typos), so almost none of it repeats -- caching it buys
+        # nothing while spending LRU slots that would otherwise hold a reusable /search response.
+        # It also sidesteps a real hazard for free: a 404's content can depend on the caller (see
+        # APIResource._raise_not_found, which serves admin-authenticated callers a different route
+        # listing), and the cache key here has no notion of that -- caching it would need to
+        # partition by caller to avoid leaking or masking that listing across callers. Not caching
+        # 4xx at all makes that a non-issue rather than something to get right.
+        if resp.status and resp.status[0] in ("4", "5"):
             return
         if "no-store" in (resp.get_header("Cache-Control") or ""):
             return
-
-        is_4xx = bool(resp.status) and resp.status.startswith("4")
-        authenticated = req.context.get("admin_authenticated", False)
-        if is_4xx and authenticated:
-            # See process_request: this response's content can depend on admin_authenticated, so
-            # it gets its own slot rather than the one every other caller's request maps to --
-            # otherwise the next anonymous 404 on this path would replay it verbatim.
-            cache_key = req.context.get("admin_4xx_cache_key")
-            if cache_key is None:
-                cache_key = self._cache_key(req) + _ADMIN_4XX_KEY_SUFFIX
-        else:
-            cache_key = req.context.get("cache_key")
-            if cache_key is None:
-                cache_key = self._cache_key(req)
+        cache_key = req.context.get("cache_key")
+        if cache_key is None:
+            cache_key = self._cache_key(req)
         # __contains__ on SharedCache does a full slot probe (filter check + lock + active-page
         # probe + lock-free sealed-page probes) — no false positives. On lock timeout it returns
         # False, which causes a redundant set() that also silently drops under contention.

--- a/api/middlewares/caching_middleware.py
+++ b/api/middlewares/caching_middleware.py
@@ -45,6 +45,37 @@ def cacheable_headers(headers: Mapping[str, str]) -> list[tuple[str, str]]:
     return [(k, v) for k, v in headers.items() if not k.lower().startswith(_UNCACHEABLE_HEADER_PREFIXES)]
 
 
+def status_is_cacheable(status: str) -> bool:
+    """Check whether a response status is safe to store and replay.
+
+    5xx is a transient failure, not a repeatable answer. Most 4xx isn't cacheable either, on
+    different grounds: the path space behind a 404 is effectively unbounded (bots, scanners,
+    typos), so almost none of it repeats -- caching it buys nothing while spending LRU slots that
+    would otherwise hold a reusable /search response. It also sidesteps a real hazard for free: a
+    404's content can depend on the caller (see APIResource._raise_not_found, which serves
+    admin-authenticated callers a different route listing), and the cache key here has no notion
+    of that -- caching it would need to partition by caller to avoid leaking or masking that
+    listing across callers. Not caching 4xx at all makes that a non-issue rather than something to
+    get right.
+
+    400 is the one exception: it's a deterministic function of the request shape already in the
+    cache key (a query parameter that fails type coercion, e.g. ParamCoercionError), never varies
+    by caller, and -- unlike a 404's effectively unbounded path space -- a client retrying the same
+    malformed request genuinely repeats the same key.
+
+    Args:
+        status: A response's HTTP status line, e.g. "404 Not Found".
+
+    Returns:
+        True if the response may be cached.
+    """
+    if status.startswith("5"):
+        return False
+    if status.startswith("400"):
+        return True
+    return not status.startswith("4")
+
+
 class CachedResponse(NamedTuple):
     """Fully rendered response, detached from the falcon.Response that produced it.
 
@@ -157,16 +188,7 @@ class CachingMiddleware:
         del resource, req_succeeded
         if req.context.get("cache_hit"):
             return
-        # Neither is cacheable. 5xx is a transient failure, not a repeatable answer. 4xx isn't
-        # cached either, on different grounds: the path space behind a 404 is effectively
-        # unbounded (bots, scanners, typos), so almost none of it repeats -- caching it buys
-        # nothing while spending LRU slots that would otherwise hold a reusable /search response.
-        # It also sidesteps a real hazard for free: a 404's content can depend on the caller (see
-        # APIResource._raise_not_found, which serves admin-authenticated callers a different route
-        # listing), and the cache key here has no notion of that -- caching it would need to
-        # partition by caller to avoid leaking or masking that listing across callers. Not caching
-        # 4xx at all makes that a non-issue rather than something to get right.
-        if resp.status and resp.status[0] in ("4", "5"):
+        if resp.status and not status_is_cacheable(resp.status):
             return
         if "no-store" in (resp.get_header("Cache-Control") or ""):
             return

--- a/api/middlewares/caching_middleware.py
+++ b/api/middlewares/caching_middleware.py
@@ -39,6 +39,17 @@ _UNCACHEABLE_HEADER_PREFIXES: tuple[str, ...] = ("access-control-", "x-cache")
 # Responses to POST/PUT/DELETE are not replayable in the first place.
 CACHEABLE_METHODS = frozenset({"GET", "HEAD"})
 
+# Appended to a request's ordinary cache key to get the slot its 4xx response goes in when the
+# caller is admin-authenticated. A 4xx's content can depend on req.context["admin_authenticated"]
+# (APIResource._raise_not_found serves a different route listing to each), which the ordinary key
+# doesn't encode -- so an admin-authenticated 4xx needs its own slot, or it would either leak that
+# listing forward to a later anonymous caller on the same path, or (stored the other way around) get
+# masked by an anonymous 404 cached first. Plain bytes appended to the ordinary orjson-encoded key
+# rather than folded into a new orjson.dumps call: orjson can't re-serialize the raw bytes the first
+# call already produced, and a suffix can never collide with a distinct request's key, because every
+# orjson array encoding ends in "]" with nothing after it.
+_ADMIN_4XX_KEY_SUFFIX = b":admin-4xx"
+
 
 def cacheable_headers(headers: Mapping[str, str]) -> list[tuple[str, str]]:
     """Return the subset of headers safe to replay on a cache hit for a different request."""
@@ -117,7 +128,22 @@ class CachingMiddleware:
 
         cache_key = self._cache_key(req)
         req.context["cache_key"] = cache_key  # reused by process_response — one serialization per request
-        cached: CachedResponse | None = self.cache.get(cache_key)
+        authenticated = req.context.get("admin_authenticated", False)
+
+        cached: CachedResponse | None = None
+        if authenticated:
+            admin_key = cache_key + _ADMIN_4XX_KEY_SUFFIX
+            req.context["admin_4xx_cache_key"] = admin_key
+            cached = self.cache.get(admin_key)
+
+        if cached is None:
+            candidate = self.cache.get(cache_key)
+            # The ordinary slot is only safe to serve an admin-authenticated caller if it isn't a
+            # 4xx: a 2xx/3xx there is identical for every caller, but a 4xx may have been written
+            # by (or for) an anonymous caller and carry the wrong route listing for this one.
+            if candidate is not None and not (authenticated and candidate.status.startswith("4")):
+                cached = candidate
+
         if cached is not None:
             if TYPE_CHECKING:
                 cached = typecast("CachedResponse", cached)
@@ -161,9 +187,20 @@ class CachingMiddleware:
             return
         if "no-store" in (resp.get_header("Cache-Control") or ""):
             return
-        cache_key = req.context.get("cache_key")
-        if cache_key is None:
-            cache_key = self._cache_key(req)
+
+        is_4xx = bool(resp.status) and resp.status.startswith("4")
+        authenticated = req.context.get("admin_authenticated", False)
+        if is_4xx and authenticated:
+            # See process_request: this response's content can depend on admin_authenticated, so
+            # it gets its own slot rather than the one every other caller's request maps to --
+            # otherwise the next anonymous 404 on this path would replay it verbatim.
+            cache_key = req.context.get("admin_4xx_cache_key")
+            if cache_key is None:
+                cache_key = self._cache_key(req) + _ADMIN_4XX_KEY_SUFFIX
+        else:
+            cache_key = req.context.get("cache_key")
+            if cache_key is None:
+                cache_key = self._cache_key(req)
         # __contains__ on SharedCache does a full slot probe (filter check + lock + active-page
         # probe + lock-free sealed-page probes) — no false positives. On lock timeout it returns
         # False, which causes a redundant set() that also silently drops under contention.

--- a/api/middlewares/caching_middleware.py
+++ b/api/middlewares/caching_middleware.py
@@ -130,19 +130,17 @@ class CachingMiddleware:
         req.context["cache_key"] = cache_key  # reused by process_response — one serialization per request
         authenticated = req.context.get("admin_authenticated", False)
 
-        cached: CachedResponse | None = None
-        if authenticated:
+        cached = self.cache.get(cache_key)
+        if cached is not None and authenticated and cached.status.startswith("4"):
+            # The ordinary slot isn't trustworthy here: it may hold a 4xx written by (or for) an
+            # anonymous caller, and a 4xx's content can depend on admin_authenticated (see
+            # APIResource._raise_not_found) -- check the admin-only slot instead. Only reached when
+            # the ordinary lookup above already found *something* and it was a 4xx, so the common
+            # case (every anonymous request, and every admin request that hits a 2xx) never pays
+            # for this second lookup.
             admin_key = cache_key + _ADMIN_4XX_KEY_SUFFIX
             req.context["admin_4xx_cache_key"] = admin_key
             cached = self.cache.get(admin_key)
-
-        if cached is None:
-            candidate = self.cache.get(cache_key)
-            # The ordinary slot is only safe to serve an admin-authenticated caller if it isn't a
-            # 4xx: a 2xx/3xx there is identical for every caller, but a 4xx may have been written
-            # by (or for) an anonymous caller and carry the wrong route listing for this one.
-            if candidate is not None and not (authenticated and candidate.status.startswith("4")):
-                cached = candidate
 
         if cached is not None:
             if TYPE_CHECKING:

--- a/api/settings.py
+++ b/api/settings.py
@@ -69,6 +69,7 @@ class Settings:
             "PREFER_SCORE_BACKFILL_TIMEOUT_MS",
             DEFAULT_PREFER_SCORE_BACKFILL_TIMEOUT_MS,
         )
+        self._admin_password: str = os.environ.get("ADMIN_PASSWORD", "")
 
     @property
     def enable_cache(self) -> bool:
@@ -108,6 +109,21 @@ class Settings:
         Override with PREFER_SCORE_BACKFILL_TIMEOUT_MS. 0 disables the timeout entirely.
         """
         return self._prefer_score_backfill_timeout_ms
+
+    @property
+    def admin_password(self) -> str:
+        """Shared secret gating every route under the admin mount.
+
+        Read from ADMIN_PASSWORD, generated into env.json on first boot by
+        scripts/gen_env_json.sh. Empty means unset -- AdminAuthMiddleware treats that as "reject
+        everything" rather than "no password required".
+        """
+        return self._admin_password
+
+    @admin_password.setter
+    def admin_password(self, value: str) -> None:
+        """Set the admin password, for tests -- no process re-reads ADMIN_PASSWORD after startup."""
+        self._admin_password = value
 
 
 # Global settings instance

--- a/api/tests/test_admin_auth_middleware.py
+++ b/api/tests/test_admin_auth_middleware.py
@@ -1,0 +1,168 @@
+"""Tests for the Basic Auth gate on the admin mount.
+
+These build a bare Falcon app around a trivial sink rather than the real APIResource, so a
+failure here is never masked or caused by anything an admin handler does -- the whole point of
+gating at the mount is that no handler-level behavior can affect whether the check runs.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import falcon
+import falcon.testing
+import pytest
+
+from api.admin_resource import ADMIN_MOUNT_PREFIX
+from api.middlewares.admin_auth_middleware import AdminAuthMiddleware, _is_admin_path, _supplied_password
+from api.settings import settings
+
+TEST_PASSWORD = "correct-horse-battery-staple"
+
+
+def _basic_auth_header(username: str, password: str) -> str:
+    token = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return f"Basic {token}"
+
+
+@pytest.fixture(name="admin_password")
+def admin_password_fixture() -> str:
+    """Set ADMIN_PASSWORD for the duration of one test, then restore it."""
+    original = settings.admin_password
+    settings.admin_password = TEST_PASSWORD
+    yield TEST_PASSWORD
+    settings.admin_password = original
+
+
+@pytest.fixture(name="client")
+def client_fixture(admin_password: str) -> falcon.testing.TestClient:
+    """A TestClient wrapping only AdminAuthMiddleware and a sink that always succeeds.
+
+    The sink's response is deliberately uninteresting: everything under test is whether the
+    middleware lets the request reach it at all, not what it does once there.
+    """
+    app = falcon.App(middleware=[AdminAuthMiddleware()])
+    app.add_sink(lambda req, resp: setattr(resp, "media", {"ok": True, "path": req.path}), prefix="/")
+    return falcon.testing.TestClient(app)
+
+
+class TestIsAdminPath:
+    """Path matching must gate exactly the mount and its children -- no more, no less."""
+
+    @pytest.mark.parametrize(
+        argnames=["path"],
+        argvalues=[
+            (f"/{ADMIN_MOUNT_PREFIX}",),
+            (f"/{ADMIN_MOUNT_PREFIX}/",),
+            (f"/{ADMIN_MOUNT_PREFIX}/setup_schema",),
+            (f"/{ADMIN_MOUNT_PREFIX}/nested/path",),
+        ],
+    )
+    def test_matches_the_mount_and_its_children(self, path: str) -> None:
+        assert _is_admin_path(path)
+
+    @pytest.mark.parametrize(
+        argnames=["path"],
+        argvalues=[
+            ("/",),
+            ("/search",),
+            (f"/{ADMIN_MOUNT_PREFIX}x",),
+            (f"/{ADMIN_MOUNT_PREFIX}_evil",),
+            ("/_administrator",),
+        ],
+    )
+    def test_does_not_match_lookalikes(self, path: str) -> None:
+        assert not _is_admin_path(path)
+
+
+class TestSuppliedPassword:
+    """Extracting the password half of a Basic credential."""
+
+    def test_none_when_header_missing(self) -> None:
+        assert _supplied_password(None) is None
+
+    def test_none_for_non_basic_scheme(self) -> None:
+        assert _supplied_password("Bearer sometoken") is None
+
+    def test_none_for_malformed_base64(self) -> None:
+        assert _supplied_password("Basic not-valid-base64!!!") is None
+
+    def test_none_without_a_colon_separator(self) -> None:
+        header = f"Basic {base64.b64encode(b'nocolonhere').decode()}"
+        assert _supplied_password(header) is None
+
+    def test_extracts_password_ignoring_username(self) -> None:
+        assert _supplied_password(_basic_auth_header("anyuser", "secret")) == "secret"
+
+    def test_scheme_match_is_case_insensitive(self) -> None:
+        header = _basic_auth_header("anyuser", "secret").replace("Basic", "basic")
+        assert _supplied_password(header) == "secret"
+
+    def test_password_may_itself_contain_colons(self) -> None:
+        assert _supplied_password(_basic_auth_header("user", "pa:ss:word")) == "pa:ss:word"
+
+
+class TestAdminAuthMiddleware:
+    """End-to-end behavior through a real Falcon dispatch cycle."""
+
+    def test_rejects_with_no_credentials(self, client: falcon.testing.TestClient) -> None:
+        result = client.simulate_get(f"/{ADMIN_MOUNT_PREFIX}/setup_schema")
+        assert result.status == falcon.HTTP_401
+        assert result.headers["WWW-Authenticate"] == 'Basic realm="admin"'
+
+    def test_rejects_wrong_password(self, client: falcon.testing.TestClient) -> None:
+        result = client.simulate_get(
+            f"/{ADMIN_MOUNT_PREFIX}/setup_schema",
+            headers={"Authorization": _basic_auth_header("admin", "wrong")},
+        )
+        assert result.status == falcon.HTTP_401
+
+    def test_accepts_correct_password_regardless_of_username(
+        self, client: falcon.testing.TestClient, admin_password: str
+    ) -> None:
+        result = client.simulate_get(
+            f"/{ADMIN_MOUNT_PREFIX}/setup_schema",
+            headers={"Authorization": _basic_auth_header("whoever", admin_password)},
+        )
+        assert result.status == falcon.HTTP_200
+        assert result.json == {"ok": True, "path": f"/{ADMIN_MOUNT_PREFIX}/setup_schema"}
+
+    def test_gates_every_http_method_not_just_get(
+        self, client: falcon.testing.TestClient, admin_password: str
+    ) -> None:
+        assert client.simulate_post(f"/{ADMIN_MOUNT_PREFIX}/import_data").status == falcon.HTTP_401
+        result = client.simulate_post(
+            f"/{ADMIN_MOUNT_PREFIX}/import_data",
+            headers={"Authorization": _basic_auth_header("whoever", admin_password)},
+        )
+        assert result.status == falcon.HTTP_200
+
+    def test_public_routes_are_untouched(self, client: falcon.testing.TestClient) -> None:
+        result = client.simulate_get("/search")
+        assert result.status == falcon.HTTP_200
+        assert "WWW-Authenticate" not in result.headers
+        assert "Cache-Control" not in result.headers
+
+    def test_admin_responses_are_marked_no_store_even_on_success(
+        self, client: falcon.testing.TestClient, admin_password: str
+    ) -> None:
+        result = client.simulate_get(
+            f"/{ADMIN_MOUNT_PREFIX}/setup_schema",
+            headers={"Authorization": _basic_auth_header("whoever", admin_password)},
+        )
+        assert result.headers["Cache-Control"] == "no-store"
+
+    def test_admin_rejections_are_also_marked_no_store(self, client: falcon.testing.TestClient) -> None:
+        result = client.simulate_get(f"/{ADMIN_MOUNT_PREFIX}/setup_schema")
+        assert result.headers["Cache-Control"] == "no-store"
+
+    def test_unset_admin_password_rejects_everything(self, client: falcon.testing.TestClient) -> None:
+        settings.admin_password = ""
+        try:
+            result = client.simulate_get(
+                f"/{ADMIN_MOUNT_PREFIX}/setup_schema",
+                headers={"Authorization": _basic_auth_header("whoever", "")},
+            )
+            assert result.status == falcon.HTTP_401
+        finally:
+            settings.admin_password = TEST_PASSWORD

--- a/api/tests/test_admin_authenticated_not_found.py
+++ b/api/tests/test_admin_authenticated_not_found.py
@@ -1,0 +1,154 @@
+"""An authenticated caller gets the full 404 route listing; an unauthenticated one doesn't.
+
+Hiding admin routes from the public 404 listing (test_admin_mount.py) protects against a caller who
+has not proven they hold the shared secret. It buys nothing once they have, so an authenticated
+request gets the full listing instead -- and since the listing shown now depends on who's asking,
+these also cover the caching hazard that creates: CachingMiddleware still caches 4xx responses (an
+admin-authenticated 404 is itself a good candidate -- typo'd admin URLs repeat), but an
+admin-authenticated 4xx and an anonymous 4xx to the same path go in separate cache slots, so
+neither leaks into or gets masked by the other. 2xx/3xx traffic is untouched: nothing in this app
+varies a successful response by auth state, so it keeps sharing the ordinary slot for everyone.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import falcon
+import falcon.testing
+import pytest
+
+from api.admin_resource import ADMIN_MOUNT_PREFIX
+from api.api_resource import APIResource
+from api.middlewares.admin_auth_middleware import AdminAuthMiddleware
+from api.middlewares.caching_middleware import CachingMiddleware
+from api.settings import settings
+from api.tests.support import mock_app_context
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+TEST_PASSWORD = "correct-horse-battery-staple"
+
+_AUTH_HEADERS = {"Authorization": "Basic d2hvZXZlcjpjb3JyZWN0LWhvcnNlLWJhdHRlcnktc3RhcGxl"}  # whoever:TEST_PASSWORD
+
+
+@pytest.fixture(name="admin_password")
+def admin_password_fixture() -> str:
+    """Set ADMIN_PASSWORD for the duration of one test, then restore it."""
+    original = settings.admin_password
+    settings.admin_password = TEST_PASSWORD
+    yield TEST_PASSWORD
+    settings.admin_password = original
+
+
+@pytest.fixture(name="resource")
+def resource_fixture() -> APIResource:
+    app_context = mock_app_context(reader_pool=MagicMock(), writer_pool=MagicMock())
+    return APIResource(app_context=app_context)
+
+
+def _client(resource: APIResource, *, cache: bool = False) -> falcon.testing.TestClient:
+    middleware = [AdminAuthMiddleware()]
+    if cache:
+        middleware.append(CachingMiddleware())
+    app = falcon.App(middleware=middleware)
+    app.add_sink(resource._handle, prefix="/")
+    return falcon.testing.TestClient(app)
+
+
+class TestAuthenticatedNotFoundListing:
+    """What an unknown path returns depends on whether the caller already authenticated."""
+
+    def test_unauthenticated_404_omits_admin_routes(self, resource: APIResource, admin_password: str) -> None:
+        del admin_password
+        result = _client(resource).simulate_get("/totally/bogus")
+        assert result.status == falcon.HTTP_404
+        assert "setup_schema" not in result.json["description"]["routes"]
+
+    def test_authenticated_404_includes_admin_routes(self, resource: APIResource, admin_password: str) -> None:
+        del admin_password
+        result = _client(resource).simulate_get("/totally/bogus", headers=_AUTH_HEADERS)
+        assert result.status == falcon.HTTP_404
+        assert f"{ADMIN_MOUNT_PREFIX}/setup_schema" in result.json["description"]["routes"]
+
+    def test_wrong_credential_still_gets_the_public_listing(self, resource: APIResource, admin_password: str) -> None:
+        del admin_password
+        wrong = {"Authorization": "Basic d2hvZXZlcjp3cm9uZw=="}  # whoever:wrong
+        result = _client(resource).simulate_get("/totally/bogus", headers=wrong)
+        assert result.status == falcon.HTTP_404
+        assert "setup_schema" not in result.json["description"]["routes"]
+
+    def test_authenticated_404_under_the_mount_also_gets_the_full_listing(
+        self, resource: APIResource, admin_password: str
+    ) -> None:
+        del admin_password
+        result = _client(resource).simulate_get(f"/{ADMIN_MOUNT_PREFIX}/nope", headers=_AUTH_HEADERS)
+        assert result.status == falcon.HTTP_404
+        assert f"{ADMIN_MOUNT_PREFIX}/setup_schema" in result.json["description"]["routes"]
+
+
+class TestNotFoundCachingIsPartitionedByAuth:
+    """4xx responses are still cached -- just never across the auth boundary."""
+
+    @pytest.fixture(autouse=True)
+    def _enable_cache(self) -> Generator[None]:
+        with patch("api.middlewares.caching_middleware.settings") as mock_settings:
+            mock_settings.enable_cache = True
+            yield
+
+    def test_repeated_anonymous_404_is_a_cache_hit(self, resource: APIResource, admin_password: str) -> None:
+        del admin_password
+        client = _client(resource, cache=True)
+        first = client.simulate_get("/totally/bogus")
+        second = client.simulate_get("/totally/bogus")
+
+        assert first.headers.get("X-Cache") == "miss"
+        assert second.headers.get("X-Cache") == "hit"
+        assert "setup_schema" not in second.json["description"]["routes"]
+
+    def test_repeated_authenticated_404_is_a_cache_hit(self, resource: APIResource, admin_password: str) -> None:
+        del admin_password
+        client = _client(resource, cache=True)
+        first = client.simulate_get("/totally/bogus", headers=_AUTH_HEADERS)
+        second = client.simulate_get("/totally/bogus", headers=_AUTH_HEADERS)
+
+        assert first.headers.get("X-Cache") == "miss"
+        assert second.headers.get("X-Cache") == "hit"
+        assert f"{ADMIN_MOUNT_PREFIX}/setup_schema" in second.json["description"]["routes"]
+
+    def test_authenticated_404_is_not_served_to_a_later_unauthenticated_caller(
+        self, resource: APIResource, admin_password: str
+    ) -> None:
+        del admin_password
+        client = _client(resource, cache=True)
+        authed = client.simulate_get("/totally/bogus", headers=_AUTH_HEADERS)
+        unauthed = client.simulate_get("/totally/bogus")
+
+        assert f"{ADMIN_MOUNT_PREFIX}/setup_schema" in authed.json["description"]["routes"]
+        assert "setup_schema" not in unauthed.json["description"]["routes"]
+        assert unauthed.headers.get("X-Cache") != "hit"
+
+    def test_unauthenticated_404_does_not_mask_a_later_authenticated_caller(
+        self, resource: APIResource, admin_password: str
+    ) -> None:
+        del admin_password
+        client = _client(resource, cache=True)
+        unauthed = client.simulate_get("/totally/bogus")
+        authed = client.simulate_get("/totally/bogus", headers=_AUTH_HEADERS)
+
+        assert "setup_schema" not in unauthed.json["description"]["routes"]
+        assert f"{ADMIN_MOUNT_PREFIX}/setup_schema" in authed.json["description"]["routes"]
+        assert authed.headers.get("X-Cache") != "hit"
+
+    def test_public_2xx_cache_is_shared_regardless_of_auth(self, resource: APIResource, admin_password: str) -> None:
+        # The ordinary slot stays shared for successful responses: nothing in this app varies a
+        # 2xx by auth state, so partitioning it would only fragment the cache real traffic uses.
+        del admin_password
+        client = _client(resource, cache=True)
+        anon = client.simulate_get("/robots.txt")
+        authed = client.simulate_get("/robots.txt", headers=_AUTH_HEADERS)
+
+        assert anon.headers.get("X-Cache") == "miss"
+        assert authed.headers.get("X-Cache") == "hit"

--- a/api/tests/test_admin_authenticated_not_found.py
+++ b/api/tests/test_admin_authenticated_not_found.py
@@ -108,15 +108,39 @@ class TestNotFoundCachingIsPartitionedByAuth:
         assert second.headers.get("X-Cache") == "hit"
         assert "setup_schema" not in second.json["description"]["routes"]
 
-    def test_repeated_authenticated_404_is_a_cache_hit(self, resource: APIResource, admin_password: str) -> None:
+    def test_repeated_authenticated_404_with_no_prior_anonymous_visit_recomputes_each_time(
+        self, resource: APIResource, admin_password: str
+    ) -> None:
+        # The lookup only ever consults the admin-only slot when the ordinary slot already holds
+        # *something* and it's a 4xx (see CachingMiddleware.process_request) -- an admin 404 is
+        # never written to the ordinary slot, so with no anonymous caller in the picture the
+        # ordinary slot stays empty and every repeat looks like a fresh miss. Content stays
+        # correct either way; this documents the accepted cost (a cheap recompute, not a query).
         del admin_password
         client = _client(resource, cache=True)
         first = client.simulate_get("/totally/bogus", headers=_AUTH_HEADERS)
         second = client.simulate_get("/totally/bogus", headers=_AUTH_HEADERS)
 
         assert first.headers.get("X-Cache") == "miss"
-        assert second.headers.get("X-Cache") == "hit"
+        assert second.headers.get("X-Cache") == "miss"
         assert f"{ADMIN_MOUNT_PREFIX}/setup_schema" in second.json["description"]["routes"]
+
+    def test_authenticated_404_hits_the_admin_slot_once_an_anonymous_visit_populated_the_ordinary_one(
+        self, resource: APIResource, admin_password: str
+    ) -> None:
+        # The one scenario the admin-only slot's second lookup exists for: an anonymous caller
+        # cached a plain 404 at the ordinary key first, so the *next* authenticated request finds
+        # something there, sees it's a 4xx, and checks (and populates, then hits) the admin slot
+        # instead of trusting it.
+        del admin_password
+        client = _client(resource, cache=True)
+        client.simulate_get("/totally/bogus")  # anonymous: populates the ordinary slot
+        first_authed = client.simulate_get("/totally/bogus", headers=_AUTH_HEADERS)
+        second_authed = client.simulate_get("/totally/bogus", headers=_AUTH_HEADERS)
+
+        assert f"{ADMIN_MOUNT_PREFIX}/setup_schema" in first_authed.json["description"]["routes"]
+        assert second_authed.headers.get("X-Cache") == "hit"
+        assert f"{ADMIN_MOUNT_PREFIX}/setup_schema" in second_authed.json["description"]["routes"]
 
     def test_authenticated_404_is_not_served_to_a_later_unauthenticated_caller(
         self, resource: APIResource, admin_password: str

--- a/api/tests/test_admin_authenticated_not_found.py
+++ b/api/tests/test_admin_authenticated_not_found.py
@@ -2,12 +2,12 @@
 
 Hiding admin routes from the public 404 listing (test_admin_mount.py) protects against a caller who
 has not proven they hold the shared secret. It buys nothing once they have, so an authenticated
-request gets the full listing instead -- and since the listing shown now depends on who's asking,
-these also cover the caching hazard that creates: CachingMiddleware still caches 4xx responses (an
-admin-authenticated 404 is itself a good candidate -- typo'd admin URLs repeat), but an
-admin-authenticated 4xx and an anonymous 4xx to the same path go in separate cache slots, so
-neither leaks into or gets masked by the other. 2xx/3xx traffic is untouched: nothing in this app
-varies a successful response by auth state, so it keeps sharing the ordinary slot for everyone.
+request gets the full listing instead. Since the listing shown now depends on who's asking,
+these also cover the caching hazard that would create: CachingMiddleware doesn't cache 4xx
+responses at all (a 404's path space is effectively unbounded -- bots, scanners, typos -- so almost
+none of it repeats, and caching it would need to be partitioned by caller to avoid leaking or
+masking the admin listing across callers). 2xx/3xx traffic is untouched and keeps sharing one
+cache slot regardless of auth state, since nothing in this app varies a successful response by it.
 """
 
 from __future__ import annotations
@@ -89,8 +89,8 @@ class TestAuthenticatedNotFoundListing:
         assert f"{ADMIN_MOUNT_PREFIX}/setup_schema" in result.json["description"]["routes"]
 
 
-class TestNotFoundCachingIsPartitionedByAuth:
-    """4xx responses are still cached -- just never across the auth boundary."""
+class TestNotFoundIsNeverCached:
+    """404s are never cached, for anyone -- see CachingMiddleware.process_response."""
 
     @pytest.fixture(autouse=True)
     def _enable_cache(self) -> Generator[None]:
@@ -98,24 +98,17 @@ class TestNotFoundCachingIsPartitionedByAuth:
             mock_settings.enable_cache = True
             yield
 
-    def test_repeated_anonymous_404_is_a_cache_hit(self, resource: APIResource, admin_password: str) -> None:
+    def test_repeated_anonymous_404_is_never_a_cache_hit(self, resource: APIResource, admin_password: str) -> None:
         del admin_password
         client = _client(resource, cache=True)
         first = client.simulate_get("/totally/bogus")
         second = client.simulate_get("/totally/bogus")
 
         assert first.headers.get("X-Cache") == "miss"
-        assert second.headers.get("X-Cache") == "hit"
+        assert second.headers.get("X-Cache") == "miss"
         assert "setup_schema" not in second.json["description"]["routes"]
 
-    def test_repeated_authenticated_404_with_no_prior_anonymous_visit_recomputes_each_time(
-        self, resource: APIResource, admin_password: str
-    ) -> None:
-        # The lookup only ever consults the admin-only slot when the ordinary slot already holds
-        # *something* and it's a 4xx (see CachingMiddleware.process_request) -- an admin 404 is
-        # never written to the ordinary slot, so with no anonymous caller in the picture the
-        # ordinary slot stays empty and every repeat looks like a fresh miss. Content stays
-        # correct either way; this documents the accepted cost (a cheap recompute, not a query).
+    def test_repeated_authenticated_404_is_never_a_cache_hit(self, resource: APIResource, admin_password: str) -> None:
         del admin_password
         client = _client(resource, cache=True)
         first = client.simulate_get("/totally/bogus", headers=_AUTH_HEADERS)
@@ -124,23 +117,6 @@ class TestNotFoundCachingIsPartitionedByAuth:
         assert first.headers.get("X-Cache") == "miss"
         assert second.headers.get("X-Cache") == "miss"
         assert f"{ADMIN_MOUNT_PREFIX}/setup_schema" in second.json["description"]["routes"]
-
-    def test_authenticated_404_hits_the_admin_slot_once_an_anonymous_visit_populated_the_ordinary_one(
-        self, resource: APIResource, admin_password: str
-    ) -> None:
-        # The one scenario the admin-only slot's second lookup exists for: an anonymous caller
-        # cached a plain 404 at the ordinary key first, so the *next* authenticated request finds
-        # something there, sees it's a 4xx, and checks (and populates, then hits) the admin slot
-        # instead of trusting it.
-        del admin_password
-        client = _client(resource, cache=True)
-        client.simulate_get("/totally/bogus")  # anonymous: populates the ordinary slot
-        first_authed = client.simulate_get("/totally/bogus", headers=_AUTH_HEADERS)
-        second_authed = client.simulate_get("/totally/bogus", headers=_AUTH_HEADERS)
-
-        assert f"{ADMIN_MOUNT_PREFIX}/setup_schema" in first_authed.json["description"]["routes"]
-        assert second_authed.headers.get("X-Cache") == "hit"
-        assert f"{ADMIN_MOUNT_PREFIX}/setup_schema" in second_authed.json["description"]["routes"]
 
     def test_authenticated_404_is_not_served_to_a_later_unauthenticated_caller(
         self, resource: APIResource, admin_password: str
@@ -167,8 +143,8 @@ class TestNotFoundCachingIsPartitionedByAuth:
         assert authed.headers.get("X-Cache") != "hit"
 
     def test_public_2xx_cache_is_shared_regardless_of_auth(self, resource: APIResource, admin_password: str) -> None:
-        # The ordinary slot stays shared for successful responses: nothing in this app varies a
-        # 2xx by auth state, so partitioning it would only fragment the cache real traffic uses.
+        # Unaffected by any of the above: nothing in this app varies a 2xx by auth state, so it
+        # keeps sharing the one cache slot every caller maps to.
         del admin_password
         client = _client(resource, cache=True)
         anon = client.simulate_get("/robots.txt")

--- a/api/tests/test_caching_middleware.py
+++ b/api/tests/test_caching_middleware.py
@@ -1,0 +1,63 @@
+"""Tests for status_is_cacheable and the one exception it carves out of the 4xx rule.
+
+404-is-never-cached is covered end-to-end in test_admin_authenticated_not_found.py, alongside the
+auth-listing feature that motivated it. This file covers the function in isolation, plus the one
+behavior that isn't exercised elsewhere: a 400 (a query parameter that fails type coercion) is
+cacheable, unlike every other 4xx.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import falcon
+import falcon.testing
+import pytest
+
+from api.api_resource import APIResource
+from api.middlewares.caching_middleware import CachingMiddleware, status_is_cacheable
+from api.tests.support import mock_app_context
+
+
+@pytest.mark.parametrize(
+    argnames=["status", "expected"],
+    argvalues=[
+        ("200 OK", True),
+        ("304 Not Modified", True),
+        ("400 Bad Request", True),
+        ("401 Unauthorized", False),
+        ("403 Forbidden", False),
+        ("404 Not Found", False),
+        ("405 Method Not Allowed", False),
+        ("429 Too Many Requests", False),
+        ("500 Internal Server Error", False),
+        ("503 Service Unavailable", False),
+    ],
+)
+def test_status_is_cacheable(status: str, expected: bool) -> None:
+    assert status_is_cacheable(status) is expected
+
+
+class TestBadParamCachingEndToEnd:
+    """A 400 from a query parameter that fails type coercion is deterministic and safe to cache."""
+
+    @pytest.fixture(name="resource")
+    def resource_fixture(self) -> APIResource:
+        return APIResource(app_context=mock_app_context(reader_pool=MagicMock(), writer_pool=MagicMock()))
+
+    def _client(self, resource: APIResource) -> falcon.testing.TestClient:
+        app = falcon.App(middleware=[CachingMiddleware()])
+        app.add_sink(resource._handle, prefix="/")
+        return falcon.testing.TestClient(app)
+
+    def test_repeated_bad_param_400_is_a_cache_hit(self, resource: APIResource) -> None:
+        with patch("api.middlewares.caching_middleware.settings") as mock_settings:
+            mock_settings.enable_cache = True
+            client = self._client(resource)
+            first = client.simulate_get("/search", params={"limit": "notanumber"})
+            second = client.simulate_get("/search", params={"limit": "notanumber"})
+
+        assert first.status == falcon.HTTP_400
+        assert first.headers.get("X-Cache") == "miss"
+        assert second.status == falcon.HTTP_400
+        assert second.headers.get("X-Cache") == "hit"

--- a/api/utils/routing.py
+++ b/api/utils/routing.py
@@ -180,25 +180,32 @@ def build_route_table(
     return table
 
 
-def build_routes_listing(route_table: dict[str, BoundRoute]) -> dict[str, dict[str, Any]]:
+def build_routes_listing(route_table: dict[str, BoundRoute], *, include_unadvertised: bool = False) -> dict[str, dict[str, Any]]:
     """Build the {route: {doc, args, kwargs}} listing served in 404 responses.
 
-    Only routes that declared themselves advertisable appear. A mounted child is registered with
-    advertise=False, so the listing cannot turn the mount into a directory of what is behind it —
-    which would undo the boundary while leaving every test passing.
+    By default only routes that declared themselves advertisable appear. A mounted child is
+    registered with advertise=False, so the default listing cannot turn the mount into a directory
+    of what is behind it — which would undo the boundary while leaving every test passing.
 
     Depends only on the table's contents, fixed once construction finishes, so it is built once
-    there rather than on every 404 (inspect.signature() per route isn't free).
+    there rather than on every 404 (inspect.signature() per route isn't free) — true for both the
+    default listing and the include_unadvertised=True one, which callers precompute separately
+    rather than filtering the default one at request time.
 
     Args:
         route_table: Path to bound route.
+        include_unadvertised: Include routes that declared advertise=False too. For a second,
+            separately-built listing shown only to callers who have already authenticated past
+            the boundary those routes sit behind — never as a request-time toggle on this one
+            table, since that would make the boundary a formatting choice instead of a fact about
+            what a given caller can see.
 
     Returns:
         Route name to its doc, args and kwargs.
     """
     routes = {}
     for endpoint_name, entry in route_table.items():
-        if not entry.spec.advertise:
+        if not entry.spec.advertise and not include_unadvertised:
             continue
         wrapped_func = entry.action
         # Get the original function from the wrapper

--- a/scripts/gen_env_json.sh
+++ b/scripts/gen_env_json.sh
@@ -5,14 +5,20 @@
 # makefile reads it back into XPGUSER/XPGPASSWORD/XPGDATABASE and mirrors it into
 # .env for docker compose, so both agree on one set of values.
 #
-# It is deliberately never overwritten. These credentials initialize the postgres
-# data volume on first boot, so changing them afterwards locks the API out of an
-# existing database (recover with `make reset-<env>`, which drops the volume).
+# The postgres credentials are deliberately never overwritten: they initialize the
+# postgres data volume on first boot, so changing them afterwards locks the API out
+# of an existing database (recover with `make reset-<env>`, which drops the volume).
+# ADMIN_PASSWORD carries no such constraint -- nothing persists it outside this file --
+# so an existing env.json from before it existed gets it backfilled in place below,
+# rather than only generating it for a brand new file.
 set -eu
 
-# Bytes of randomness in the generated postgres password. Hex-encoded, so the
-# resulting string is twice this many characters.
+# Bytes of randomness in each generated secret. Hex-encoded, so the resulting string
+# is twice this many characters. ADMIN_PASSWORD is longer because it crosses the
+# network (Basic Auth on the _admin mount); the postgres password never leaves the
+# compose network.
 PASSWORD_RANDOM_BYTES=16
+ADMIN_PASSWORD_RANDOM_BYTES=24
 
 # Starting values for everything else. Safe to edit in env.json before first boot.
 DEFAULT_DATABASE=magic
@@ -20,17 +26,27 @@ DEFAULT_USER=foouser
 
 target="${1:-env.json}"
 
+random_hex() {
+    openssl rand -hex "$1" 2>/dev/null ||
+        od -An -tx1 -N "$1" /dev/urandom | tr -d ' \n'
+}
+
 if [ -e "${target}" ]; then
+    if ! jq -e 'has("ADMIN_PASSWORD")' "${target}" >/dev/null 2>&1; then
+        admin_password="$(random_hex "${ADMIN_PASSWORD_RANDOM_BYTES}")"
+        tmp="$(mktemp "${target}.XXXXXX")"
+        jq --arg pw "${admin_password}" '. + {ADMIN_PASSWORD: $pw}' "${target}" > "${tmp}"
+        mv "${tmp}" "${target}"
+    fi
     exit 0
 fi
 
-password="$(
-    openssl rand -hex "${PASSWORD_RANDOM_BYTES}" 2>/dev/null ||
-        od -An -tx1 -N "${PASSWORD_RANDOM_BYTES}" /dev/urandom | tr -d ' \n'
-)"
+password="$(random_hex "${PASSWORD_RANDOM_BYTES}")"
+admin_password="$(random_hex "${ADMIN_PASSWORD_RANDOM_BYTES}")"
 
 cat > "${target}" <<EOF
 {
+  "ADMIN_PASSWORD": "${admin_password}",
   "ENABLE_ENGINE": "true",
   "XPGDATABASE": "${DEFAULT_DATABASE}",
   "XPGPASSWORD": "${password}",


### PR DESCRIPTION
## Summary
- Adds `AdminAuthMiddleware`, gating every route under the `_admin` mount with HTTP Basic Auth (`secrets.compare_digest` against `ADMIN_PASSWORD`), and stamping `Cache-Control: no-store` on all admin responses. Fails closed if `ADMIN_PASSWORD` is unset.
- Generates `ADMIN_PASSWORD` into `env.json` on first boot (`scripts/gen_env_json.sh`), backfilling it into an existing `env.json` since nothing persists it into a database volume the way the postgres credentials do.
- An admin-authenticated caller now gets the full 404 route listing (including admin routes) instead of the public-only one, since hiding it only matters to a caller who hasn't proven they hold the shared secret.
- `CachingMiddleware` no longer caches 4xx responses at all, with one exception: 400 (a query parameter that fails type coercion) is still cached, since it's a deterministic function of the request shape already in the cache key and never varies by caller — unlike 404, whose path space is effectively unbounded (bots, scanners, typos) and whose content can depend on the caller (the admin-listing feature above). Extracted as `status_is_cacheable()`. 2xx/3xx responses are untouched and keep sharing one cache slot for everyone.
- README: replaces the stale "Tagging Endpoints" section (named routes that predate the admin split) with an accurate "Admin Endpoints" section, and documents `ADMIN_PASSWORD` in the Environment Variables list.

## Test plan
- [x] `make test-unit` (3061 passed, 19 xfailed)
- [x] `ruff check .` clean
- [x] New tests: `api/tests/test_admin_auth_middleware.py`, `api/tests/test_admin_authenticated_not_found.py`, `api/tests/test_caching_middleware.py` (credential parsing, path matching, end-to-end 401/200, no-store, 404-never-cached in both directions, 400-is-cached end to end)