### PR TITLE
Parsing: Count Nested Comparisons at Any Paren Depth (#903 Cause A)

### DIFF
--- a/api/parsing/pyparsing_based.py
+++ b/api/parsing/pyparsing_based.py
@@ -702,7 +702,9 @@ def _is_numeric_operand(t: str) -> bool:
 def _rhs_introduces_comparison(tokens: list[str], start_index: int) -> bool:
     """Return True if scanning forward from start_index hits a comparison operator before AND/OR/).
 
-    Used to disambiguate binary subtraction on the RHS of a comparison.
+    Used to disambiguate binary subtraction on the RHS of a comparison. A comparison operator
+    counts wherever it appears, including nested inside a parenthesized group — `cmc>1 -(t:elf)`
+    has its `:` one paren deep, and it still means the group is a filter, not an arithmetic term.
     """
     depth = 0
     for j in range(start_index, len(tokens)):
@@ -713,7 +715,7 @@ def _rhs_introduces_comparison(tokens: list[str], start_index: int) -> bool:
             if depth == 0:
                 return False
             depth -= 1
-        elif t in _COMPARISON_OPERATORS and depth == 0:
+        elif t in _COMPARISON_OPERATORS:
             return True
         elif t in {"AND", "OR"} and depth == 0:
             return False

--- a/api/parsing/tests/implicit_and_cases.py
+++ b/api/parsing/tests/implicit_and_cases.py
@@ -97,6 +97,20 @@ TESTCASES = [
     {"query": "(power + 1) - (cmc - 1) > 0", "expected": "(power+1)-(cmc-1)>0", "id": "arith_sub_paren_minus_paren_spaces"},
     # Arithmetic subtraction on the RHS of a comparison: must NOT get AND (regression guard)
     {"query": "power>cmc-1", "expected": "power>cmc-1", "id": "cmp_rhs_arith_sub"},
+    # Comparison LHS, minus, then a paren group whose comparison operator is nested one level
+    # deep (#903 cause A): the group is a filter to negate, not an arithmetic term, even though
+    # the ':'/'=' is invisible to a scan that only looks at depth 0.
+    {"query": "cmc>1 -(t:elf)", "expected": "cmc>1 AND -(t:elf)", "id": "cmp_then_group_with_nested_comparison"},
+    {
+        "query": "pow=3 -(name:force or type:elf)",
+        "expected": "pow=3 AND -(name:force OR type:elf)",
+        "id": "cmp_then_group_with_nested_comparison_or",
+    },
+    {
+        "query": "year:2019 -(oracle:exile or type:enchantment)",
+        "expected": "year:2019 AND -(oracle:exile OR type:enchantment)",
+        "id": "cmp_then_group_with_nested_comparison_year_lhs",
+    },
     {"query": "power > cmc - 1", "expected": "power>cmc-1", "id": "cmp_rhs_arith_sub_spaces"},
     {"query": "toughness>=power-cmc", "expected": "toughness>=power-cmc", "id": "cmp_rhs_arith_sub_attrs"},
     {"query": "toughness >= power - cmc", "expected": "toughness>=power-cmc", "id": "cmp_rhs_arith_sub_attrs_spaces"},

--- a/api/parsing/tests/test_parser_parity.py
+++ b/api/parsing/tests/test_parser_parity.py
@@ -91,27 +91,6 @@ def test_bare_mana_character_parity(query: str) -> None:
 # cannot land without deleting its entry here. Keep the minimal repro alongside the wild query —
 # it is what a fixer works from, and it fails for the same reason.
 KNOWN_DIVERGENCES: dict[str, tuple[str, list[str]]] = {
-    # pyparsing's preprocess_implicit_and misreads the '-' as subtraction and inserts no AND,
-    # because _rhs_introduces_comparison only counts comparison operators at depth 0 — the ones
-    # inside the group are invisible to it. Numeric LHS yields `int - boolean` (invalid SQL);
-    # a year LHS yields a parse error.
-    "a_minus_before_group_after_numeric": (
-        "#903 A: comparison nested in the group is invisible to _rhs_introduces_comparison",
-        [
-            "cmc>1 -(t:elf)",
-            "pow=3 -(name:force or type:elf)",
-            "usd>50 -(format:modern or format:commander)",
-            "year:2019 -(t:elf)",
-            "year:2019 -(oracle:exile or type:enchantment)",
-            "year:2022 -(id:rg or usd<0.25)",
-            "year:2022 -(id:ub or artist:avon)",
-            "year:2022 -(set:mid or color:ubr)",
-            "year:2022 -(tou=4 or set:mom)",
-            "year:2023 -(id:rg or name:dark)",
-            "year:2023 -(year:2020 or set:mom)",
-            "year:2024 -(name:co or set:khm)",
-        ],
-    ),
     # The implicit-AND tokenizer matches CaselessKeyword("AND"/"OR") before it knows it is in
     # value position, so 'o:or' preprocesses to 'o: OR' and the value is gone. Only on the slow
     # path — a query with none of ()"'/{+* takes the fast path and is unaffected.

--- a/docs/issues/00903-parser-parity-divergences.md
+++ b/docs/issues/00903-parser-parity-divergences.md
@@ -122,9 +122,15 @@ silent-zero-rows case. **B** is the narrowest.
 
 ## What shipped so far
 
-No fixes — only the pin. [`test_parser_parity.py`](../../api/parsing/tests/test_parser_parity.py)
-gains `test_known_parser_divergences`, parameterized over all 15 wild queries plus 4 minimal repros,
-each `xfail(strict=True)`. Fixing any cause turns its entries into `XPASS(strict)` failures, so a
-fix cannot land without deleting the entries it resolves — the list can only shrink.
+First, only the pin: [`test_parser_parity.py`](../../api/parsing/tests/test_parser_parity.py) gained
+`test_known_parser_divergences`, parameterized over all 15 wild queries plus 4 minimal repros, each
+`xfail(strict=True)`. Fixing any cause turns its entries into `XPASS(strict)` failures, so a fix
+cannot land without deleting the entries it resolves — the list can only shrink.
 
 The shared assertion moved into `assert_parsers_agree()` so both parity tests use one comparison.
+
+**A fixed**: `_rhs_introduces_comparison` now counts a comparison operator at any paren depth, not
+just depth 0 — a one-line change (dropping `and depth == 0` from the comparison branch). All 12
+cause-A entries removed from `KNOWN_DIVERGENCES`; regression cases added to
+[`implicit_and_cases.py`](../../api/parsing/tests/implicit_and_cases.py) covering the numeric-LHS,
+year-LHS, and single-vs-`OR`-group shapes. B and C remain open.


### PR DESCRIPTION
Fixes cause A of #903 — one of the three root causes behind the 15 wild-corpus queries where the hand-rolled and pyparsing parsers disagree, pinned as strict xfails in #904.

## What

`_rhs_introduces_comparison` in `api/parsing/pyparsing_based.py` decides whether a `-` after a comparison is arithmetic subtraction or filter negation, by scanning forward for a comparison operator. It only counted one at `depth == 0`, so a comparison nested one paren deep was invisible to it.

`cmc>1 -(t:elf)` has its `:` inside the parens, so the guard returned False, `preprocess_implicit_and` read the `-` as subtraction, and pyparsing emitted `cmc > (1 - <boolean>)` — PostgreSQL has no `integer - boolean`, so a runtime 500. With a `year:` LHS it's a parse error instead. The hand parser reads it correctly as `(cmc > 1) AND NOT (...)`.

The fix drops the `depth == 0` restriction on the comparison check (kept for `AND`/`OR`, which still only terminate the scan at the top level). `git log -S_rhs_introduces_comparison` shows the function hasn't changed since it was introduced, so the restriction wasn't load-bearing for anything else.

## Changes

- `_rhs_introduces_comparison`: comparison operators now count at any paren depth
- `test_parser_parity.py`: removed the 12 now-passing cause-A entries from `KNOWN_DIVERGENCES` (they'd otherwise XPASS and fail the strict-xfail suite)
- `implicit_and_cases.py`: added 3 regression cases covering the numeric-LHS, year-LHS, and single-vs-`OR`-group shapes
- `docs/issues/00903-parser-parity-divergences.md`: recorded cause A as fixed

Causes B (and/or in value position) and C (`!` as `=` alias) are unrelated and still open.

## Validation

- `api/parsing/tests/`: 2133 passed, 7 xfailed (was 19 xfailed) — no test that passed before now fails, and none of the surviving strict xfails XPASS
- Manually verified all 12 wild-corpus queries: hand-rolled and pyparsing now emit identical SQL
- `ruff check` and `ruff format --check` clean on the changed files