### PR TITLE
Parsing: Accept '!' as an '=' Alias on Color/Mana/Numeric/Rarity/Year/Date (#903 Cause C)

### DIFF
--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -49,6 +49,13 @@ _DUAL_NUM_TEXT: frozenset[str] = frozenset(
 
 _NUMERIC_ALIASES: frozenset[str] = frozenset(alias for alias, pc in _ALIAS_TO_PC.items() if pc == ParserClass.NUMERIC)
 
+# On Scryfall '!' is an alias for '=' on these classes only (verified live, #903 cause C) — on
+# TEXT/LEGALITY it isn't an operator at all, and a trailing bang there falls through to the
+# existing exact-name-prefix reading of the next factor instead.
+_BANG_ALIAS_CLASSES: frozenset[ParserClass] = frozenset(
+    {ParserClass.COLOR, ParserClass.MANA, ParserClass.RARITY, ParserClass.YEAR, ParserClass.DATE}
+)
+
 _VALID_COLOR_NAMES: frozenset[str] = frozenset(COLOR_NAME_TO_CODE)
 _COLOR_LETTERS: frozenset[str] = frozenset("wubrgcWUBRGC")
 _MIN_MTG_YEAR: int = 1992
@@ -490,8 +497,9 @@ class Parser:
 
         # ── NUMERIC attribute ──
         if pc == ParserClass.NUMERIC:
-            if next_tok.type == TT.OP:
-                op = self.consume().value
+            if next_tok.type in (TT.OP, TT.BANG):
+                op = "=" if next_tok.type == TT.BANG else next_tok.value
+                self.consume()
                 return CardBinaryOperatorNode(CardAttributeNode(wl, ParserClass.NUMERIC), op, self.parse_num_expr_value())
             if next_tok.type in _ARITH_OPS and not next_tok.space_before:
                 lhs = self._arith_tail(CardAttributeNode(wl, ParserClass.NUMERIC))
@@ -510,8 +518,10 @@ class Parser:
             return lhs
 
         # ── known non-NUMERIC attribute ──
-        if pc is not None and next_tok.type == TT.OP:
-            op = self.consume().value
+        bang_alias = pc is not None and next_tok.type == TT.BANG and pc in _BANG_ALIAS_CLASSES
+        if pc is not None and (next_tok.type == TT.OP or bang_alias):
+            op = "=" if bang_alias else next_tok.value
+            self.consume()
             return CardBinaryOperatorNode(CardAttributeNode(wl, pc), op, self.parse_value_for_class(pc, wl))
         if pc is not None:
             # alias recognised but no operator → might still be a hyphenated bare word (e.g. "a-b-c")

--- a/api/parsing/pyparsing_based.py
+++ b/api/parsing/pyparsing_based.py
@@ -55,6 +55,10 @@ ParserElement.enable_packrat(cache_size_limit=2**13)  # 8192 cache entries
 # Constants
 NEGATION_TOKEN_COUNT = 2
 DEFAULT_OPERATORS = one_of(": > < >= <= = !=")
+# On Scryfall '!' is an alias for '=' on COLOR/MANA/NUMERIC/RARITY/YEAR/DATE only (verified live,
+# #903 cause C) — not on TEXT/LEGALITY, so those conditions keep using DEFAULT_OPERATORS. '!='
+# still wins over bare '!' here: DEFAULT_OPERATORS is tried first and already matches it whole.
+EQ_ALIAS_OPERATORS = DEFAULT_OPERATORS | Literal("!").set_parse_action(lambda: "=")
 
 _NUMERIC_LITERAL_RE = re.compile(r"^\d+(\.\d+)?$")
 _COMPARISON_OPERATORS = frozenset({">", "<", ">=", "<=", "=", "!=", ":"})
@@ -366,27 +370,27 @@ def create_all_condition_parsers(basic_parsers: dict, mana_parsers: dict, color_
 
     numeric_comparison_lhs = arithmetic_expr | paren_expr_term | numeric_attr_word | literal_number
     numeric_comparison_rhs = arithmetic_expr | signed_arithmetic_expr | paren_expr_term | numeric_attr_word | signed_literal_number
-    unified_numeric_comparison = numeric_comparison_lhs + DEFAULT_OPERATORS + numeric_comparison_rhs
+    unified_numeric_comparison = numeric_comparison_lhs + EQ_ALIAS_OPERATORS + numeric_comparison_rhs
     unified_numeric_comparison.set_parse_action(make_binary_operator_node)
 
     # No string_value_word fallback: a mana/devotion condition's rhs is always a validated
     # ManaValueNode, one of these two, never an unchecked StringValueNode (#954) — mirroring
     # hand_parser.parse_mana_value, which has no plain-string case for this attribute class either.
     mana_value_or_string = mana_value | mana_quoted_value
-    mana_condition = create_condition_parser(mana_attr_word, mana_value_or_string)
+    mana_condition = create_condition_parser(mana_attr_word, mana_value_or_string, operators=EQ_ALIAS_OPERATORS)
 
-    color_condition = create_condition_parser(color_attr_word, color_value | quoted_string)
+    color_condition = create_condition_parser(color_attr_word, color_value | quoted_string, operators=EQ_ALIAS_OPERATORS)
 
     regex_pattern = basic_parsers["regex_pattern"]
-    rarity_condition = create_condition_parser(rarity_attr_word, quoted_string | string_value_word)
+    rarity_condition = create_condition_parser(rarity_attr_word, quoted_string | string_value_word, operators=EQ_ALIAS_OPERATORS)
     legality_condition = create_condition_parser(legality_attr_word, quoted_string | string_value_word)
     text_condition = create_condition_parser(text_attr_word, regex_pattern | quoted_string | string_value_word)
 
     date_value = Regex(r"\d{4}(?:-\d{2}-\d{2})?")
-    date_condition = create_condition_parser(date_attr_word, date_value)
+    date_condition = create_condition_parser(date_attr_word, date_value, operators=EQ_ALIAS_OPERATORS)
 
     year_value = Regex(r"\d{4}")
-    year_condition = create_condition_parser(year_attr_word, year_value)
+    year_condition = create_condition_parser(year_attr_word, year_value, operators=EQ_ALIAS_OPERATORS)
 
     attr_attr_condition = (
         (numeric_attr_word + DEFAULT_OPERATORS + numeric_attr_word)

--- a/api/parsing/tests/test_exact_name_search.py
+++ b/api/parsing/tests/test_exact_name_search.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from api.parsing import parse_scryfall_query
 from api.parsing.card_query_nodes import ExactNameNode
 from api.parsing.nodes import AndNode, NotNode, QueryContext
 
@@ -99,6 +100,30 @@ def test_exact_name_sql_generation(parse_query, query: str, expected_sql: str, e
     observed_sql = parsed.to_sql(context)
     assert observed_sql == expected_sql, f"SQL mismatch: {observed_sql!r}"
     assert context == expected_parameters, f"Params mismatch: {context!r}"
+
+
+@pytest.mark.parametrize(
+    argnames="query",
+    argvalues=[
+        "t!creature",
+        "o!flying",
+        "s!khm",
+        "f!modern",
+    ],
+)
+def test_bang_not_an_operator_on_text_and_legality_fields(query: str) -> None:
+    """On Scryfall '!' is an '=' alias only on COLOR/MANA/NUMERIC/RARITY/YEAR/DATE fields (#903 C).
+
+    On TEXT/LEGALITY fields it isn't an operator at all, so the hand parser must keep its
+    pre-existing fallback: the field alias as an implicit-name term, the rest as an exact-name
+    term, joined by AND. (pyparsing errors on this shape today regardless of field class — a
+    separate, undiscovered divergence, not one of the wild-corpus queries #903 tracks.)
+    """
+    result = parse_scryfall_query(query)
+    assert isinstance(result.root, AndNode), f"Expected AndNode, got {type(result.root)}"
+    assert len(result.root.operands) == 2
+    exact_name_nodes = [op for op in result.root.operands if isinstance(op, ExactNameNode)]
+    assert len(exact_name_nodes) == 1, "Expected exactly one ExactNameNode in AND"
 
 
 def test_exact_name_node_equality() -> None:

--- a/api/parsing/tests/test_parser_parity.py
+++ b/api/parsing/tests/test_parser_parity.py
@@ -84,6 +84,52 @@ def test_bare_mana_character_parity(query: str) -> None:
     assert_parsers_agree(query)
 
 
+@pytest.mark.parametrize(
+    argnames=["query"],
+    argvalues=[
+        ("c!w",),
+        ("c!ubg cmc>=6 f:standard",),
+        ("en-kor c!w",),
+        ("o:destroy o:creature o:with o:flying c!g",),
+        ("cmc!3",),
+        ("r!rare",),
+        ("mana!2G",),
+        ("year!2020",),
+        ("date!2020-01-01",),
+    ],
+    ids=[
+        "wild_color_bang",
+        "wild_color_bang_with_cmc_and_legality",
+        "wild_color_bang_after_hyphenated_word",
+        "wild_color_bang_after_oracle_terms",
+        "numeric_bang",
+        "rarity_bang",
+        "mana_bang",
+        "year_bang",
+        "date_bang",
+    ],
+)
+def test_bang_equals_alias_parity(query: str) -> None:
+    """'!' is Scryfall's '=' alias on COLOR/MANA/NUMERIC/RARITY/YEAR/DATE fields (#903 C)."""
+    assert_parsers_agree(query)
+
+
+@pytest.mark.parametrize(
+    argnames=["bang_query", "eq_query"],
+    argvalues=[
+        ("c!ubg", "c=ubg"),
+        ("cmc!3", "cmc=3"),
+        ("r!rare", "r=rare"),
+        ("mana!2G", "mana=2G"),
+        ("year!2020", "year=2020"),
+        ("date!2020-01-01", "date=2020-01-01"),
+    ],
+)
+def test_bang_equals_alias_matches_eq_spelling(bang_query: str, eq_query: str) -> None:
+    """The '!' spelling must produce identical SQL to the '=' spelling it aliases (#903 C)."""
+    assert generate_sql_query(parse_scryfall_query(bang_query)) == generate_sql_query(parse_scryfall_query(eq_query))
+
+
 # Real queries from benchmarks/wild-queries/wild-corpus.jsonl on which the two parsers disagree
 # today, grouped by the root cause in #903. Sweeping that 14k-query corpus found exactly these.
 #
@@ -100,19 +146,6 @@ KNOWN_DIVERGENCES: dict[str, tuple[str, list[str]]] = {
             "o:and power+toughness>10",
             "(o:or o:more) t:land",
             "(oracle:two oracle:or oracle:more oracle:opponents) type:land",
-        ],
-    ),
-    # On Scryfall '!' is an alias for '=' on color/mana/numeric/rarity/year/date fields, and not an
-    # operator at all on text fields. Neither parser implements the alias: pyparsing rejects the
-    # shape, and the hand parser applies the text-field fallback everywhere, so 'c!w' becomes
-    # name LIKE %c% AND name = "w" and quietly matches nothing.
-    "c_bang_equals_alias": (
-        "#903 C: '!' as an '=' alias unimplemented — pyparsing rejects, hand parser mis-parses",
-        [
-            "c!w",
-            "c!ubg cmc>=6 f:standard",
-            "en-kor c!w",
-            "o:destroy o:creature o:with o:flying c!g",
         ],
     ),
 }

--- a/docs/issues/00903-parser-parity-divergences.md
+++ b/docs/issues/00903-parser-parity-divergences.md
@@ -133,4 +133,20 @@ The shared assertion moved into `assert_parsers_agree()` so both parity tests us
 just depth 0 — a one-line change (dropping `and depth == 0` from the comparison branch). All 12
 cause-A entries removed from `KNOWN_DIVERGENCES`; regression cases added to
 [`implicit_and_cases.py`](../../api/parsing/tests/implicit_and_cases.py) covering the numeric-LHS,
-year-LHS, and single-vs-`OR`-group shapes. B and C remain open.
+year-LHS, and single-vs-`OR`-group shapes.
+
+**C fixed**: `!` now aliases `=` on COLOR/MANA/NUMERIC/RARITY/YEAR/DATE in both parsers — the hand
+parser accepts a `BANG` token wherever it accepted `OP` for those classes (`parse_word_primary` in
+`hand_parser.py`); pyparsing gained an `EQ_ALIAS_OPERATORS = DEFAULT_OPERATORS | Literal("!").set_parse_action(lambda: "=")`
+used only by the five eligible `condition`s (`mana_condition`, `color_condition`,
+`rarity_condition`, `date_condition`, `year_condition`) plus `unified_numeric_comparison`;
+`legality_condition`/`text_condition` are untouched, so `!=` still wins over bare `!` by
+longest-match and TEXT/LEGALITY still fall through to the pre-existing exact-name fallback. All 4
+cause-C entries removed from `KNOWN_DIVERGENCES`.
+
+Residual, out of scope for this fix: pyparsing hard-rejects `field!value` on TEXT/LEGALITY fields
+(e.g. `t!creature`) regardless of class, where the hand parser has always had the fallback
+reading — this divergence was never in the wild-corpus sweep (no such query appeared), so it isn't
+one of the tracked 15 and is left for a future pass.
+
+B remains open.


### PR DESCRIPTION
Fixes cause C of #903 — one of the three root causes behind the wild-corpus queries where the hand-rolled and pyparsing parsers disagree, pinned as strict xfails in #904.

## What

On Scryfall `!` is simply an alias for `=` on COLOR, MANA, NUMERIC, RARITY, YEAR, and DATE fields — `c!ubg` ≡ `c=ubg`, `cmc!3` ≡ `cmc=3`, `r!rare` ≡ `r=rare`, etc (verified live against api.scryfall.com, matching `total_cards` for every pairing in the issue doc's table). It is **not** an operator at all on TEXT/LEGALITY fields — Scryfall gives 0 results for `t!creature`, `o!flying`, `s!khm`, `f!modern`, because `!` there falls back to being read as part of an exact-name term.

Neither parser implemented the alias. pyparsing rejected the shape outright (`ParseException`). The hand parser applied the TEXT-field fallback to *every* class, so `c!w` silently became `name:c AND !w` (matching cards named "c", not colorless-then-white) instead of `color=w`.

## Changes

- **`hand_parser.py`**: `parse_word_primary` now accepts a `BANG` token wherever it accepted an `OP` token, for NUMERIC and for a new `_BANG_ALIAS_CLASSES` set (COLOR/MANA/RARITY/YEAR/DATE) — treating it as `=`. TEXT/LEGALITY are untouched and keep falling through to the existing exact-name fallback.
- **`pyparsing_based.py`**: new `EQ_ALIAS_OPERATORS = DEFAULT_OPERATORS | Literal("!").set_parse_action(lambda: "=")`, used only by `mana_condition`, `color_condition`, `rarity_condition`, `date_condition`, `year_condition`, and `unified_numeric_comparison`. `legality_condition`/`text_condition` keep plain `DEFAULT_OPERATORS`. `!=` still wins over bare `!` on both sides by longest-match (verified: `c!=w`/`cmc!=3` unaffected).
- **`test_parser_parity.py`**: removed the 4 now-passing `c_bang_equals_alias` entries from `KNOWN_DIVERGENCES` (they'd otherwise XPASS and fail the strict-xfail suite). Added `test_bang_equals_alias_parity` (the 4 wild queries + one repro per remaining eligible class) and `test_bang_equals_alias_matches_eq_spelling` (asserts the `!` and `=` spellings produce byte-identical SQL, not just parser agreement with each other).
- **`test_exact_name_search.py`**: added a hand-parser-only regression test confirming the TEXT/LEGALITY fallback (`t!creature`, `o!flying`, `s!khm`, `f!modern`) is unchanged.
- **`docs/issues/00903-parser-parity-divergences.md`**: recorded cause C as fixed, and noted a residual: pyparsing hard-rejects `field!value` on TEXT/LEGALITY regardless of class, which is pre-existing and unrelated to this change (confirmed by reproducing it on `main` before this branch) — it was never in the wild-corpus sweep, so it isn't one of the tracked 15 and is left for a future pass.

Cause B (and/or in value position) is the only one left open.

## Validation

- `api/parsing/tests/`: 2152 passed, 3 xfailed (was 7 xfailed before this change, 19 before #968) — no test that passed before now fails, and none of the surviving strict xfails XPASS
- `api/`: full non-Docker suite (2207 tests) passes
- Manually verified all 12 eligible-class bang queries produce byte-identical SQL to their `=` spelling, in both parsers
- Manually confirmed the TEXT/LEGALITY pyparsing rejection is pre-existing on `main`, not introduced here
- `ruff check` and `ruff format --check` clean on the changed files