### PR TITLE
Parsing: Match 'and'/'or' in Value Position as a Value, Not a Keyword (#903 Cause B)

### DIFF
--- a/api/parsing/pyparsing_based.py
+++ b/api/parsing/pyparsing_based.py
@@ -645,9 +645,15 @@ def _get_implicit_and_tokenizer() -> ParserElement:
     # swallows "2>1 name:" as a pattern in "power/2>1 name:/a/" (#908).
     regex_after_op = comparison_tok + regex_raw
 
+    # A bare word in value position is a value even when it spells 'and'/'or' (#903 cause B) — so
+    # match it as a unit with the preceding operator, before and_tok/or_tok get a chance to see it
+    # as a standalone keyword. Mirrors regex_after_op's same trick for the same reason.
+    word_after_op = comparison_tok + string_value_tok
+
     one_token = (
         quoted_raw
         | regex_after_op
+        | word_after_op
         | lparen_tok
         | rparen_tok
         | and_tok

--- a/api/parsing/tests/test_parser_parity.py
+++ b/api/parsing/tests/test_parser_parity.py
@@ -130,35 +130,24 @@ def test_bang_equals_alias_matches_eq_spelling(bang_query: str, eq_query: str) -
     assert generate_sql_query(parse_scryfall_query(bang_query)) == generate_sql_query(parse_scryfall_query(eq_query))
 
 
-# Real queries from benchmarks/wild-queries/wild-corpus.jsonl on which the two parsers disagree
-# today, grouped by the root cause in #903. Sweeping that 14k-query corpus found exactly these.
-#
-# Each is xfail(strict=True): fixing one turns it into an XPASS and fails the suite, so the fix
-# cannot land without deleting its entry here. Keep the minimal repro alongside the wild query —
-# it is what a fixer works from, and it fails for the same reason.
-KNOWN_DIVERGENCES: dict[str, tuple[str, list[str]]] = {
-    # The implicit-AND tokenizer matches CaselessKeyword("AND"/"OR") before it knows it is in
-    # value position, so 'o:or' preprocesses to 'o: OR' and the value is gone. Only on the slow
-    # path — a query with none of ()"'/{+* takes the fast path and is unaffected.
-    "b_reserved_word_as_value": (
-        "#903 B: and/or in value position consumed as a boolean operator by the tokenizer",
-        [
-            "o:and power+toughness>10",
-            "(o:or o:more) t:land",
-            "(oracle:two oracle:or oracle:more oracle:opponents) type:land",
-        ],
-    ),
-}
-
-
 @pytest.mark.parametrize(
     argnames=["query"],
     argvalues=[
-        pytest.param(query, marks=pytest.mark.xfail(strict=True, reason=reason), id=f"{cause}-{index}")
-        for cause, (reason, queries) in KNOWN_DIVERGENCES.items()
-        for index, query in enumerate(queries)
+        ("o:and power+toughness>10",),
+        ("(o:or o:more) t:land",),
+        ("(oracle:two oracle:or oracle:more oracle:opponents) type:land",),
+    ],
+    ids=[
+        "reserved_word_value_with_arithmetic_comparison",
+        "reserved_word_value_in_group",
+        "reserved_word_values_repeated_in_group",
     ],
 )
-def test_known_parser_divergences(query: str) -> None:
-    """Queries the parsers disagree on today (#903) — remove an entry when its cause is fixed."""
+def test_reserved_word_as_value_parity(query: str) -> None:
+    """'and'/'or' in value position is a value, not a boolean operator (#903 B).
+
+    All 3 take the slow preprocess_implicit_and path (each has a '(' or '+'), where the
+    implicit-AND tokenizer used to match CaselessKeyword("AND"/"OR") before knowing it was in
+    value position, so e.g. 'o:or' silently lost its value and became 'o: OR'.
+    """
     assert_parsers_agree(query)

--- a/docs/issues/00903-parser-parity-divergences.md
+++ b/docs/issues/00903-parser-parity-divergences.md
@@ -149,4 +149,15 @@ Residual, out of scope for this fix: pyparsing hard-rejects `field!value` on TEX
 reading — this divergence was never in the wild-corpus sweep (no such query appeared), so it isn't
 one of the tracked 15 and is left for a future pass.
 
-B remains open.
+**B fixed**: added `word_after_op = comparison_tok + string_value_tok` to
+`_get_implicit_and_tokenizer`'s `one_token` alternation, ahead of `and_tok`/`or_tok`/`comparison_tok`
+— mirroring `regex_after_op`'s existing trick of matching a value together with the operator that
+precedes it, so a bare word right after `:`/`=`/etc. is captured as one unit before the AND/OR
+keyword check ever gets a look at it. All 3 cause-B entries removed.
+
+All 15 wild-corpus queries (19 including minimal repros) now agree between the two parsers.
+`test_known_parser_divergences` and `KNOWN_DIVERGENCES` were removed from
+[`test_parser_parity.py`](../../api/parsing/tests/test_parser_parity.py) — nothing left to pin —
+and replaced with `test_reserved_word_as_value_parity` covering the 3 cause-B queries directly. A
+future wild-corpus sweep (see "How they were found" above) is the way to check for new divergences,
+should parser changes introduce any.


### PR DESCRIPTION
Fixes cause B of #903 — the last of the three root causes behind the wild-corpus queries where the hand-rolled and pyparsing parsers disagreed, pinned as strict xfails in #904.

## What

`_get_implicit_and_tokenizer`'s `one_token` alternation tries `and_tok`/`or_tok` (`CaselessKeyword("AND"/"OR")`) before it has any notion of value position, so a value that happens to spell "and" or "or" gets consumed as a boolean operator instead:

```
o:and power+toughness>10   ->  o: AND power+toughness>10   (value silently dropped)
(o:or o:more) t:land       ->  (o: OR o:more) AND t:land    (value silently dropped)
```

Only on the slow tokenizing path — `preprocess_implicit_and` short-circuits queries with none of `()"'/{+*` onto a fast whitespace-split path that's unaffected, which is why `o:and power>10` was fine while `o:and power+toughness>10` wasn't. It sometimes "recovered" a coincidentally-right answer too (`(oracle:two oracle:or) type:land` preprocessed to a dangling `oracle:` matching the following `OR` token as the literal string `"OR"`), which is worse than failing outright.

## Fix

Added one production, `word_after_op = comparison_tok + string_value_tok`, placed ahead of `and_tok`/`or_tok`/`comparison_tok` in the alternation. It matches a bare word together with the operator that precedes it — mirroring `regex_after_op`'s existing trick just above it in the same function, which solves the identical class of problem for `/regex/` values (#908). Once the operator+word are captured as one unit, `and_tok`/`or_tok` never get a chance to see the word as a standalone keyword.

The hand parser already got this right for free (it parses values in context rather than pre-tokenizing), so only `pyparsing_based.py` needed a change.

## Changes

- `pyparsing_based.py`: added `word_after_op`, wired into `one_token` (6 lines)
- `test_parser_parity.py`: this was the last entry in `KNOWN_DIVERGENCES` — removed it and `test_known_parser_divergences` entirely (nothing left to pin), replaced with `test_reserved_word_as_value_parity` covering the 3 wild queries directly
- `docs/issues/00903-parser-parity-divergences.md`: recorded cause B as fixed — all three causes are now resolved

## Validation

- `api/parsing/tests/`: 2155 passed, **0 xfailed** (was 3 xfailed before this change, 19 before #968/#971) — every wild-corpus divergence and minimal repro now agrees between the two parsers
- `api/`: full non-Docker suite (2210 tests) passes
- Manually verified all 3 wild queries plus a same-shape non-reserved-word sanity check produce identical SQL between both parsers
- `ruff check` and `ruff format --check` clean on the changed files

With this merged, #903 has no open causes left — worth closing the issue.