### PR TITLE
Docs: Add CHANGELOG.md for the First Tagged Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project are documented here. Versions follow
+[CalVer](https://calver.org/) (`YYYY.MM.DD.PATCH`) rather than semantic versioning — see
+[#778](https://github.com/jbylund/sylvan_librarian/issues/778) for why.
+
+## [Unreleased]
+
+Initial release.
+
+### Security
+
+- Admin/data-management routes now require authentication (`/_admin`, HTTP Basic Auth) — set
+  `ADMIN_PASSWORD` in `env.json` ([#961](https://github.com/jbylund/sylvan_librarian/pull/961),
+  [#962](https://github.com/jbylund/sylvan_librarian/pull/962),
+  [#963](https://github.com/jbylund/sylvan_librarian/pull/963),
+  [#966](https://github.com/jbylund/sylvan_librarian/pull/966))
+- API port bound to loopback by default
+  ([#781](https://github.com/jbylund/sylvan_librarian/pull/781))
+- Error responses no longer leak internal detail
+  ([#782](https://github.com/jbylund/sylvan_librarian/pull/782))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # Changelog
 
 All notable changes to this project are documented here. Versions follow
-[CalVer](https://calver.org/) (`YYYY.MM.DD.PATCH`) rather than semantic versioning — see
-[#778](https://github.com/jbylund/sylvan_librarian/issues/778) for why.
+[CalVer](https://calver.org/) (`YYYY.MM.DD.PATCH`) rather than semantic versioning.
 
-## [Unreleased]
+## [2026.08.21.0]
 
 Initial release.
 


### PR DESCRIPTION
## Summary
Adds `CHANGELOG.md`, the last piece of Phase 1 in #778 before cutting the first tagged release.
Entry is under `[Unreleased]` rather than a dated version — the heading gets renamed to the concrete `YYYY.MM.DD.PATCH` in a follow-up commit at the moment the tag is actually cut, so the version doesn't lie about its date if this PR sits in review.
Security section links out to PR numbers rather than the in-progress `docs/issues/security-*` doc, since that doc is still gitignored and not a valid link target from a public file.

## Test plan
- [x] Confirm the linked PR numbers resolve and match the described changes