### PR TITLE
Parsing: has: Is a Synonym for is:

### DIFF
--- a/api/parsing/db_info.py
+++ b/api/parsing/db_info.py
@@ -208,7 +208,7 @@ DB_COLUMNS = [
     FieldInfo(
         db_column_name="card_is_tags",
         field_type=FieldType.JSONB_OBJECT,
-        search_aliases=["is"],
+        search_aliases=["is", "has"],
         parser_class=ParserClass.TEXT,
     ),
     # A distinct FieldInfo from "is" above, sharing its db_column_name, so a `not:` leaf

--- a/api/parsing/tests/test_sql_gen.py
+++ b/api/parsing/tests/test_sql_gen.py
@@ -678,6 +678,24 @@ def test_is_tag_sql_translation(parse_query, input_query: str, expected_sql: str
 
 
 @pytest.mark.parametrize(
+    argnames="tag_value",
+    argvalues=["creature", "modal-dfc", "spell"],
+)
+def test_has_is_alias(parse_query, tag_value: str) -> None:
+    """Test that has: is a full synonym for is:.
+
+    Scryfall treats has: as a full synonym for is:, for every tag value -- not just the
+    handful of "does this card have X" examples its docs happen to show (has:indicator,
+    has:watermark). Confirmed live against api.scryfall.com: is:X and has:X return identical
+    card counts for every value tried.
+    """
+    is_context = QueryContext()
+    has_context = QueryContext()
+    assert parse_query(f"is:{tag_value}").to_sql(is_context) == parse_query(f"has:{tag_value}").to_sql(has_context)
+    assert is_context == has_context
+
+
+@pytest.mark.parametrize(
     argnames=("input_query", "expected_sql", "expected_parameters"),
     argvalues=[
         # Case-insensitive oracle tag search


### PR DESCRIPTION
`has:` didn't exist in this parser's vocabulary at all. Scryfall's docs only show it for a couple of "does this card have X" queries (`has:indicator`, `has:watermark`), which reads like a narrow keyword — it isn't. Checked live against `api.scryfall.com`: `is:X` and `has:X` return identical card counts for every value tried, including ones with no "possession" framing at all (`foil`, `vanilla`, `spell`, `commander`, `promo`, `dfc`, `reprint`, `bear`, `indicator`, `full`, `hires`). `has:` is a full, general synonym for `is:`.

Neither parser has an `is:`-specific code path — both `hand_parser.py` and `pyparsing_based.py` derive every field keyword generically from `FieldInfo.search_aliases` in `db_info.py`. So the fix is the alias list itself: `search_aliases=["is"]` → `search_aliases=["is", "has"]`. Both parsers pick it up automatically.

Added a parametrized test asserting `has:X` and `is:X` produce identical SQL/parameters, for both parser implementations, alongside the existing `is:` tag SQL translation tests.

Closes #977.