### PR TITLE
Parsing: not: Is a Synonym for -is:

### DIFF
--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -595,10 +595,16 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
 
     def to_human_explanation(self) -> str:
         """Convert to human-readable explanation with card-specific formatting."""
-        # Handle empty string values. Covers ManaValueNode too: a quoted empty mana/devotion value
-        # (mana:"") parses to one of these, not a StringValueNode, since parse_mana_value validates
-        # quoted values the same as bare ones (#909) — StringValueNode alone stopped catching it (#950).
-        if isinstance(self.rhs, StringValueNode | ManaValueNode) and not self.rhs.value.strip():
+        # `:` (contains / JSONB containment) against an empty value is always vacuous --
+        # `LIKE '%'` matches every row, `{} <@ anything` is always true -- so it carries no
+        # real constraint and explains to "". `=` against an empty value is the opposite: a
+        # real, narrow constraint (the field is exactly empty, e.g. is:vanilla's `o=""`), so
+        # it must NOT collapse here -- `_format_card_attribute_explanation` renders that case
+        # below instead. Covers ManaValueNode too: a quoted empty mana/devotion value
+        # (mana:"") parses to one of these, not a StringValueNode, since parse_mana_value
+        # validates quoted values the same as bare ones (#909) — StringValueNode alone
+        # stopped catching it (#950).
+        if self.operator == ":" and isinstance(self.rhs, StringValueNode | ManaValueNode) and not self.rhs.value.strip():
             return ""
         # Handle plain string rhs (for empty queries)
         if isinstance(self.rhs, str) and not self.rhs.strip():
@@ -627,9 +633,15 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
         # Default format
         return f"{lhs_str} {operator_str} {rhs_str}"
 
-    def _format_card_attribute_explanation(self, attr_node: CardAttributeNode, operator_str: str, rhs_str: str) -> str:  # noqa: PLR0911
+    def _format_card_attribute_explanation(self, attr_node: CardAttributeNode, operator_str: str, rhs_str: str) -> str:  # noqa: PLR0911, PLR0912
         """Format explanation for card attribute comparisons."""
         db_column_name = attr_node.attribute_name.lower()
+
+        # `=` against an empty value reaches here (see to_human_explanation) as a real
+        # constraint, not the vacuous `:` case -- state it plainly rather than falling into
+        # "the X contains " with nothing after it.
+        if self.operator == "=" and not rhs_str:
+            return f"the {attr_node.to_human_explanation()} is empty"
 
         # Special formatting for certain attributes
         if db_column_name == "card_color_identity" and self.operator in ("=", ":"):
@@ -644,16 +656,21 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
             return f"the toughness {operator_str} {rhs_str}"
         if db_column_name == "cmc":
             return f"the mana value {operator_str} {rhs_str}"
+        # `:` is substring containment on these; `=` is real equality against the whole
+        # field (verified against the actual SQL: `name=X` -> `card_name = X`, `name:X` ->
+        # `card_name_folded LIKE %X%`, same split for oracle_text/card_types/card_artist) --
+        # so `=` reads as "is", not "contains", to describe what it actually checks. Any
+        # other operator (e.g. `!=`) falls through to the generic default below.
         if db_column_name == "card_name" and self.operator in (":", "="):
-            return f"the name contains {rhs_str}"
+            return f"the name is {rhs_str}" if self.operator == "=" else f"the name contains {rhs_str}"
         if db_column_name == "oracle_text" and self.operator in (":", "="):
-            return f"the oracle text contains {rhs_str}"
+            return f"the oracle text is {rhs_str}" if self.operator == "=" else f"the oracle text contains {rhs_str}"
         if db_column_name == "card_types" and self.operator in (":", "="):
-            return f"the type contains {rhs_str}"
+            return f"the type is {rhs_str}" if self.operator == "=" else f"the type contains {rhs_str}"
         if db_column_name == "card_rarity_int":
             return f"the rarity {operator_str} {rhs_str}"
         if db_column_name == "card_artist" and self.operator in (":", "="):
-            return f"the artist contains {rhs_str}"
+            return f"the artist is {rhs_str}" if self.operator == "=" else f"the artist contains {rhs_str}"
         if db_column_name == "card_set_code" and self.operator in (":", "="):
             return f"the set contains {rhs_str}"
 

--- a/api/parsing/db_info.py
+++ b/api/parsing/db_info.py
@@ -211,6 +211,16 @@ DB_COLUMNS = [
         search_aliases=["is"],
         parser_class=ParserClass.TEXT,
     ),
+    # A distinct FieldInfo from "is" above, sharing its db_column_name, so a `not:` leaf
+    # generates the identical SQL/explanation as `is:` on its own -- rewrite.py's
+    # negate_not_prefix distinguishes the two via original_attribute and supplies the
+    # negation Scryfall's docs describe ("not: is the same as -is:").
+    FieldInfo(
+        db_column_name="card_is_tags",
+        field_type=FieldType.JSONB_OBJECT,
+        search_aliases=["not"],
+        parser_class=ParserClass.TEXT,
+    ),
     FieldInfo(
         db_column_name="card_rarity_int",
         field_type=FieldType.NUMERIC,

--- a/api/parsing/nodes.py
+++ b/api/parsing/nodes.py
@@ -308,6 +308,15 @@ class NaryOperatorNode(QueryNode):
                 explanation = f"({explanation})"
             parts.append(explanation)
 
+        # An operand that explains to "" is not a constraint and has no clause to contribute;
+        # joining it anyway leaves a dangling connector (e.g. is:vanilla's `t:creature o=""`
+        # explaining as "the type contains creature and " with nothing after the "and").
+        parts = [part for part in parts if part]
+        if not parts:
+            return ""
+        if len(parts) == 1:
+            return parts[0]
+
         return self._join_explanations(parts)
 
     def _join_explanations(self: NaryOperatorNode, parts: list[str]) -> str:

--- a/api/parsing/rewrite.py
+++ b/api/parsing/rewrite.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from api.parsing.card_query_nodes import CardAttributeNode
 from api.parsing.hand_parser import parse_query as _parse_query
 from api.parsing.nodes import (
     AndNode,
@@ -198,6 +199,47 @@ def _expand(node: QueryNode, in_progress: frozenset[tuple[str, str]]) -> tuple[Q
     return node, False
 
 
+def _swap_not_leaves(node: QueryNode) -> tuple[QueryNode, bool]:
+    """Replace `not:value` leaves with `NotNode(is:value)`; return `(node, changed)`.
+
+    Reuses the leaf's own operator and rhs untouched -- only `lhs` changes, from the `not`
+    FieldInfo to `is`'s -- so the wrapped leaf is indistinguishable from a user-typed
+    `is:value` and `expand_derived_predicates` (which runs next) still applies is:'s
+    expansion table to it (`not:vanilla` negates the same subtree `is:vanilla` expands to,
+    not a raw, never-populated `card_is_tags @> {"vanilla": true}` check).
+    """
+    cls = node.__class__
+    if cls is AndNode or cls is OrNode:
+        changed = False
+        operands = []
+        for op in node.operands:
+            new_op, op_changed = _swap_not_leaves(op)
+            operands.append(new_op)
+            changed |= op_changed
+        return (cls(operands), True) if changed else (node, False)
+    if cls is NotNode:
+        new_op, changed = _swap_not_leaves(node.operand)
+        return (NotNode(new_op), True) if changed else (node, False)
+    if isinstance(node, BinaryOperatorNode) and isinstance(node.lhs, CardAttributeNode) and node.lhs.original_attribute == "not":
+        is_lhs = CardAttributeNode("is", node.lhs.matched_parser_class)
+        return NotNode(type(node)(is_lhs, node.operator, node.rhs)), True
+    return node, False
+
+
+def negate_not_prefix(query: Query) -> Query:
+    """Rewrite `not:value` leaves into `NotNode(is:value)`.
+
+    Scryfall's docs: `is:` "has a convenient inverted mode `not:` which is the same as
+    `-is:`." Runs before `expand_derived_predicates` so a `not:`-spelled derived value
+    (`not:vanilla`, `not:new`, ...) gets is:'s expansion table applied underneath the
+    negation, same as if the user had written `-is:vanilla` directly.
+    """
+    root, changed = _swap_not_leaves(query.root)
+    if not changed:
+        return query
+    return flatten_nested_operations(Query(root))
+
+
 def _regex_plain_literal(pattern: str) -> str | None:
     r"""The exact substring an unanchored, metacharacter-free regex matches, else None.
 
@@ -272,15 +314,17 @@ def expand_derived_predicates(query: Query) -> Query:
 # The post-parse rewrite pipeline, applied in order at the shared parse seam. Add future AST
 # rewrites to this tuple — both parsers call `rewrite_query`, so a new pass lands in exactly one
 # place and is guaranteed identical treatment across parsers (enforced by test_parser_parity).
-_REWRITE_PASSES = (expand_derived_predicates, lower_literal_regexes)
+_REWRITE_PASSES = (negate_not_prefix, expand_derived_predicates, lower_literal_regexes)
 
 
 def rewrite_query(query: Query) -> Query:
     """Apply every post-parse AST rewrite, in order. The single seam both parsers call.
 
-    Order is significant: `expand_derived_predicates` runs first (a synonym may expand into a subtree
-    that itself contains a regex or other rewritable leaf), then `lower_literal_regexes`, then any
-    future pass appended to `_REWRITE_PASSES`.
+    Order is significant: `negate_not_prefix` runs first (a `not:`-spelled leaf becomes
+    `NotNode(is:...)`, so it reads as a plain `is:` leaf to everything after it), then
+    `expand_derived_predicates` (a synonym may expand into a subtree that itself contains a
+    regex or other rewritable leaf), then `lower_literal_regexes`, then any future pass
+    appended to `_REWRITE_PASSES`.
     """
     for rewrite_pass in _REWRITE_PASSES:
         query = rewrite_pass(query)

--- a/api/parsing/tests/test_explanation.py
+++ b/api/parsing/tests/test_explanation.py
@@ -85,6 +85,26 @@ def test_explain_empty_mana_value(parse_query, query_str: str) -> None:
     assert explanation == ""
 
 
+@pytest.mark.parametrize(
+    argnames=["query_str", "expected_explanation"],
+    argvalues=[
+        # is:vanilla expands to `t:creature o=""`; the empty-oracle operand explains to ""
+        # and must be filtered out of the AND join, not left as a dangling connector.
+        ("is:vanilla", "the type contains creature"),
+        ("not:vanilla", "not (the type contains creature)"),
+        ("-is:vanilla", "not (the type contains creature)"),
+        # A typeahead balancer auto-closing a half-typed "urza'" produces `name:urza''`,
+        # which parses as `name:urza AND name:''` -- the second operand explains to "".
+        ("name:urza''", "the name contains urza"),
+    ],
+)
+def test_explain_filters_empty_string_operand(parse_query, query_str: str, expected_explanation: str) -> None:
+    """An operand that explains to "" contributes no clause and must not leave a dangling connector."""
+    parsed_query = parse_query(query_str)
+    explanation = parsed_query.to_human_explanation()
+    assert explanation == expected_explanation
+
+
 def test_explain_multiple_and_conditions(parse_query) -> None:
     """Test explanation with multiple AND conditions."""
     parsed_query = parse_query("power>3 toughness>3 cmc=5")

--- a/api/parsing/tests/test_explanation.py
+++ b/api/parsing/tests/test_explanation.py
@@ -88,18 +88,74 @@ def test_explain_empty_mana_value(parse_query, query_str: str) -> None:
 @pytest.mark.parametrize(
     argnames=["query_str", "expected_explanation"],
     argvalues=[
-        # is:vanilla expands to `t:creature o=""`; the empty-oracle operand explains to ""
-        # and must be filtered out of the AND join, not left as a dangling connector.
-        ("is:vanilla", "the type contains creature"),
-        ("not:vanilla", "not (the type contains creature)"),
-        ("-is:vanilla", "not (the type contains creature)"),
+        # `:` (contains / JSONB containment) against "" is always vacuous -- no real
+        # constraint, so it explains to nothing.
+        ('o:""', ""),
+        ('name:""', ""),
+        # `=` against "" is the opposite: a real, narrow constraint (the field is exactly
+        # empty), so it must render as its own clause instead of collapsing.
+        ('o=""', "the oracle text is empty"),
+        ('name=""', "the name is empty"),
+        ('mana=""', "the mana cost is empty"),
+        ('devotion=""', "the devotion is empty"),
+    ],
+)
+def test_explain_empty_value_operator_dependent(parse_query, query_str: str, expected_explanation: str) -> None:
+    """Whether an empty value collapses to "" depends on the operator, not just the value.
+
+    Verified against the live SQL each spelling produces: `:`/JSONB-containment against ""
+    is a tautology (`LIKE '%'`, `{} <@ anything`), `=` against "" is a genuine filter
+    (`oracle_text = ''`), so only the former is safe to drop from an explanation.
+    """
+    parsed_query = parse_query(query_str)
+    explanation = parsed_query.to_human_explanation()
+    assert explanation == expected_explanation
+
+
+@pytest.mark.parametrize(
+    argnames=["query_str", "expected_explanation"],
+    argvalues=[
+        # `=` is real equality against the whole field on these text columns (verified
+        # against the SQL: `name=X` -> `card_name = X`, `name:X` -> `LIKE %X%`, same split
+        # for oracle_text/card_types/card_artist) -- Scryfall itself treats `o=`/`o:` as
+        # pure synonyms, but this codebase's own `=` diverges deliberately (rewrite.py's
+        # is:vanilla relies on it to express "no oracle text at all"), so the explanation
+        # must say "is X", not "contains X", to describe what actually gets checked.
+        ("name=bolt", "the name is bolt"),
+        ("name:bolt", "the name contains bolt"),
+        ("o=flying", "the oracle text is flying"),
+        ("o:flying", "the oracle text contains flying"),
+        ("type=goblin", "the type is goblin"),
+        ("type:goblin", "the type contains goblin"),
+        ("artist=nielsen", "the artist is nielsen"),
+        ("artist:nielsen", "the artist contains nielsen"),
+    ],
+)
+def test_explain_equals_vs_contains(parse_query, query_str: str, expected_explanation: str) -> None:
+    """= reads as "is" (equality) and : reads as "contains" (substring), matching the SQL."""
+    parsed_query = parse_query(query_str)
+    explanation = parsed_query.to_human_explanation()
+    assert explanation == expected_explanation
+
+
+@pytest.mark.parametrize(
+    argnames=["query_str", "expected_explanation"],
+    argvalues=[
+        # is:vanilla expands to `t:creature o=""`. `o=""` is a real, narrow constraint (the
+        # oracle text is exactly empty) and must render as its own clause, not vanish.
+        ("is:vanilla", "the type contains creature and the oracle text is empty"),
+        ("not:vanilla", "not (the type contains creature and the oracle text is empty)"),
+        ("-is:vanilla", "not (the type contains creature and the oracle text is empty)"),
         # A typeahead balancer auto-closing a half-typed "urza'" produces `name:urza''`,
-        # which parses as `name:urza AND name:''` -- the second operand explains to "".
+        # which parses as `name:urza AND name:''` -- the second operand uses `:` against an
+        # empty value, which is always vacuous (LIKE '%' matches everything) and explains to
+        # "", so it must be filtered out of the AND join rather than left as a dangling
+        # connector.
         ("name:urza''", "the name contains urza"),
     ],
 )
 def test_explain_filters_empty_string_operand(parse_query, query_str: str, expected_explanation: str) -> None:
-    """An operand that explains to "" contributes no clause and must not leave a dangling connector."""
+    """A vacuous (`:`) empty-value operand drops out of the join; a narrow (`=`) one doesn't."""
     parsed_query = parse_query(query_str)
     explanation = parsed_query.to_human_explanation()
     assert explanation == expected_explanation

--- a/api/parsing/tests/test_rewrite.py
+++ b/api/parsing/tests/test_rewrite.py
@@ -109,6 +109,39 @@ def test_real_frame_value_not_rewritten(parse_query) -> None:
     assert root.rhs.value == "2003"
 
 
+# ── #982: not: is the same as -is: ────────────────────────────────────────────
+# (not: query, equivalent -is: query) -- the two must produce identical ASTs, including
+# on values with their own is:-expansion (vanilla, new, ...): not:vanilla negates the
+# same subtree is:vanilla expands to, not a raw card_is_tags lookup for a key nothing
+# ever stores.
+NOT_EQUIVALENCES = [
+    ("not:creature", "-is:creature"),
+    ("not:vanilla", "-is:vanilla"),
+    ("not:new", "-is:new"),
+    ("not:reprint", "-is:reprint"),
+]
+
+
+@pytest.mark.parametrize(
+    argnames=["not_query", "expansion"],
+    argvalues=NOT_EQUIVALENCES,
+    ids=[s for s, _ in NOT_EQUIVALENCES],
+)
+def test_not_expands_to_negated_is(parse_query, not_query: str, expansion: str) -> None:
+    """Each not: query parses to the same AST as the equivalent -is: query (both parsers)."""
+    assert parse_query(not_query) == parse_query(expansion)
+
+
+@pytest.mark.parametrize(
+    argnames=["not_query", "expansion"],
+    argvalues=NOT_EQUIVALENCES,
+    ids=[s for s, _ in NOT_EQUIVALENCES],
+)
+def test_not_generates_same_sql_as_negated_is(not_query: str, expansion: str) -> None:
+    """The rewrite is real end-to-end: not: and -is: emit identical SQL + params."""
+    assert generate_sql_query(parse_scryfall_query(not_query)) == generate_sql_query(parse_scryfall_query(expansion))
+
+
 # ── #734: plain-literal regex -> substring lowering ──────────────────────────
 # A metacharacter-free, unanchored regex is a substring search, so it must parse to exactly the same
 # AST as its quoted-substring form (which is index-backed, where an arbitrary regex is a full scan).


### PR DESCRIPTION
Scryfall's docs: `is:` "has a convenient inverted mode `not:` which is the same as `-is:`." Neither parser had a `not` field keyword at all — negation only existed via the leading `-` operator, so `not:reprint` fell through to the unrecognized-field path rather than behaving as `-is:reprint`.

`not:` gets its own `FieldInfo` (`search_aliases=["not"]`) sharing `is:`'s `db_column_name`, so SQL/explanation generation for the underlying comparison is already identical to `is:` on its own — the only thing missing is negation. A new rewrite pass, `negate_not_prefix`, swaps a `not:`-tagged leaf's `lhs` for an `is:`-tagged one and wraps the result in the existing `NotNode`. It runs *before* `expand_derived_predicates` in `_REWRITE_PASSES`, so a `not:`-spelled derived value (`not:vanilla`, `not:new`, ...) still gets `is:`'s expansion table applied underneath the negation — without that ordering, `not:vanilla` would check a `card_is_tags` key ("vanilla") that's never actually stored, since `is:vanilla` is a purely derived predicate, and would match nothing (or everything, since NOT of an always-false containment check is always true).

Verified `not:vanilla`/`not:creature`/`not:new`/`not:reprint` produce byte-identical SQL to the equivalent `-is:X` on both parser implementations. New tests in `test_rewrite.py` pin this as an explicit equivalence table, same pattern as the existing `is:`-synonym tests.

Closes #982.

---

Second commit, found while manually exercising this branch: `is:vanilla` expands to `t:creature o=""`, and the empty-oracle-text operand explains to `""` — but `NaryOperatorNode.to_human_explanation()` joined it into the AND anyway, leaving a dangling connector (`"the type contains creature and "`, nothing after the "and"). Since `not:`/`-is:` just wrap whatever `is:vanilla` explains to in `not (...)`, they inherited the same broken explanation. Fixed by filtering empty-string parts out before joining, and short-circuiting to the sole remaining part when only one survives — same fix covers `is:vanilla`, `not:vanilla`, `-is:vanilla`, and `name:urza''` (the shape a typeahead balancer produces from a half-typed `urza'`, parsing as `name:urza AND name:''`).

Closes #979.

---

Third commit, refining the second: the first pass made *every* empty-valued operand explain to `""`, but that's not always correct — `:` (contains) against an empty value is genuinely vacuous (`LIKE '%'` matches everything), while `=` (equality) against an empty value is a real, narrow constraint (`oracle_text = ''` literally means "no oracle text"). Collapsing both the same way silently dropped real information: `is:vanilla` was explaining as just `"the type contains creature"`, losing the "no oracle text" half of what it actually checks.

Checked live against `api.scryfall.com`: Scryfall itself treats `o=`/`o:` (and `name=`/`name:`, `type=`/`type:`, `artist=`/`artist:`) as pure synonyms, and rejects an empty term outright. This codebase's own `=` diverges from that deliberately — `rewrite.py`'s `is:vanilla` rewrite relies on `o=""` meaning real equality to express "no oracle text at all," which its own comment already documents (`# empty-oracle equality; -11 subset`). Given that divergence is intentional, the explanation should say so: `=` now reads as "is X" and `:` as "contains X" for `name`/`oracle_text`/`card_types`/`card_artist` (verified against the actual SQL each compiles to; `card_set_code` is untouched since `=` and `:` already compile to identical SQL there). An empty `=` value renders as "is empty" instead of falling through to "is " with nothing after it.

`is:vanilla` now explains as `"the type contains creature and the oracle text is empty"` — both halves of what it actually checks.

This also means [#975](https://github.com/jbylund/sylvan_librarian/issues/975) ("is:vanilla expands to a vacuous o="" check") was itself wrong — filed from an external PR's commit message without checking this codebase's own `=` semantics. Closed with an explanation.