### PR TITLE
Parsing: commander:/colour:/colours: as Colour-Identity/Colour Aliases

### DIFF
--- a/api/parsing/db_info.py
+++ b/api/parsing/db_info.py
@@ -70,13 +70,15 @@ DB_COLUMNS = [
     FieldInfo(
         db_column_name="card_colors",
         field_type=FieldType.JSONB_OBJECT,
-        search_aliases=["color", "colors", "c"],
+        search_aliases=["color", "colors", "colour", "colours", "c"],
         parser_class=ParserClass.COLOR,
     ),
     FieldInfo(
         db_column_name="card_color_identity",
         field_type=FieldType.JSONB_OBJECT,
-        search_aliases=["color_identity", "coloridentity", "id", "identity", "ci"],
+        # `commander:` is how players search a commander's colour identity -- a deck built
+        # around it must stay within it, so a commander query is a color-identity query.
+        search_aliases=["color_identity", "coloridentity", "id", "identity", "ci", "commander"],
         parser_class=ParserClass.COLOR,
     ),
     FieldInfo(

--- a/api/parsing/tests/test_sql_gen.py
+++ b/api/parsing/tests/test_sql_gen.py
@@ -1519,3 +1519,29 @@ testcases_proper_subset_masks = {
 )
 def test_proper_subset_masks(query_mask: int, expected: list[int]) -> None:
     assert _proper_subset_masks(query_mask) == expected
+
+
+# ── #976: commander:/colour:/colours: as aliases, not a literal name search ──────────────
+# (alias query, canonical query) -- alias spelling must generate byte-identical SQL to the
+# canonical one, not fall through to a literal name search on card_name.
+COMMANDER_COLOUR_ALIAS_EQUIVALENCES = [
+    ("commander:wub", "id:wub"),
+    ("commander<=wub", "id<=wub"),
+    ("colour:blue", "color:blue"),
+    ("colours:wu", "colors:wu"),
+]
+
+
+@pytest.mark.parametrize(
+    argnames=["alias_query", "canonical_query"],
+    argvalues=COMMANDER_COLOUR_ALIAS_EQUIVALENCES,
+    ids=[q for q, _ in COMMANDER_COLOUR_ALIAS_EQUIVALENCES],
+)
+def test_commander_colour_alias_generates_same_sql(parse_query, alias_query: str, canonical_query: str) -> None:
+    """commander:/colour:/colours: generate identical SQL to id:/color:/colors:, for both parsers."""
+    alias_context = QueryContext()
+    canonical_context = QueryContext()
+    alias_sql = parse_query(alias_query).to_sql(alias_context)
+    canonical_sql = parse_query(canonical_query).to_sql(canonical_context)
+    assert alias_sql == canonical_sql
+    assert alias_context == canonical_context


### PR DESCRIPTION
`commander:`, `colour:`, and `colours:` weren't recognized field keywords, so they fell through to a literal name search instead of doing what the user meant.

`commander:` is how players search a commander's colour identity — a deck built around it must stay within it. Verified live: `commander:esper`, `id<=esper`, and `id:esper` all return 19449 on `api.scryfall.com`, confirming `commander:` is the same subset-comparison as `id:`, not a new operator. `colour:`/`colours:` are just the British spelling of `color:`/`colors:`.

Neither parser has field-specific code for these — both derive field keywords generically from `FieldInfo.search_aliases` in `db_info.py`. Adding the three spellings there is the entire fix: `"commander"` alongside `id`/`identity`/`ci` on the color-identity `FieldInfo`, `"colour"`/`"colours"` alongside `color`/`colors` on the color `FieldInfo`. Both parsers pick it up automatically, and whichever operator the user types (`:`, `<=`, `=`) keeps its existing subset/equality semantics since it resolves to the identical column.

Verified `commander:wub`/`commander<=wub`/`colour:blue`/`colours:wu` produce byte-identical SQL to `id:wub`/`id<=wub`/`color:blue`/`colors:wu` on both parser implementations.

Closes #976.