### PR TITLE
Parsing: Guild, Shard, and Wedge Colour Names in c: Queries

### DIFF
--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -7,12 +7,11 @@ import unicodedata
 
 from titlecase import titlecase
 
+from api.parsing.colors import COLOR_ALIAS_TO_CODES, COLOR_CODE_TO_NAME
 from api.parsing.db_info import (
     ALIAS_TO_FIELD_INFOS,
     CARD_SUPERTYPES,
     CARD_TYPES,
-    COLOR_CODE_TO_NAME,
-    COLOR_NAME_TO_CODE,
     FORMAT_CODE_TO_NAME,
     FieldType,
     ParserClass,
@@ -204,7 +203,9 @@ def get_colors_comparison_object(val: str, attr: str = "card_colors") -> dict[st
     """Convert color string to comparison object for database queries.
 
     Args:
-        val: Color string (either color codes like 'WUBRG' or color name like 'red').
+        val: Color string (either color codes like 'WUBRG' or a color name like 'red' or
+            'azorius' — every name in COLOR_ALIAS_TO_CODES, which is the vocabulary Scryfall
+            itself accepts).
         attr: The DB column this value is being compared against. Colorless means two
             different things depending on the field: for card_colors/card_color_identity
             it's the *absence* of any color (Scryfall stores both as `[]`, verified
@@ -220,23 +221,20 @@ def get_colors_comparison_object(val: str, attr: str = "card_colors") -> dict[st
         ValueError: If the color string is invalid.
     """
     colorless_is_value = attr == "produced_mana"
-    # If all chars are color codes
+    # A color NAME spells a set of letters ('azorius' -> 'wu', 'brown' -> 'c', 'colorless' -> 'c');
+    # a letter string already is one. Expanding the name FIRST leaves a single code path, so
+    # `c:azorius` and `c:wu` serialize to the identical rhs and cannot drift apart, and the
+    # colorless-is-a-value distinction below is stated once instead of once per spelling.
+    codes = COLOR_ALIAS_TO_CODES.get(val, val)
     color_code_set = set(COLOR_CODE_TO_NAME)
-    if val and set(val) <= color_code_set:
+    if codes and set(codes) <= color_code_set:
         if colorless_is_value:
-            return {c.upper(): True for c in val}
+            return {c.upper(): True for c in codes}
         # Colorless-only queries use an empty dict, matching how colorless cards
         # are stored (card_color_identity = {}) rather than {"C": True}.
-        return {c.upper(): True for c in val if c != "c"}
-    # If it's a color name (e.g. 'red', 'blue', etc.)
-    try:
-        letter_code = COLOR_NAME_TO_CODE[val]
-        if letter_code == "c":
-            return {"C": True} if colorless_is_value else {}
-        return {letter_code.upper(): True}
-    except KeyError as e:
-        msg = f"Invalid color string: {val}"
-        raise ValueError(msg) from e
+        return {c.upper(): True for c in codes if c != "c"}
+    msg = f"Invalid color string: {val}"
+    raise ValueError(msg)
 
 
 def get_frame_data_comparison_object(val: str) -> dict[str, bool]:

--- a/api/parsing/colors.py
+++ b/api/parsing/colors.py
@@ -52,6 +52,14 @@ COLOR_ALIAS_TO_CODES = {
     "golgari": "bg",
     "boros": "rw",
     "simic": "gu",
+    # the five Strixhaven colleges -- verified live the same way, corpus-wide: c:lorehold =
+    # c:rw = 682, c:prismari = c:ur = 668, c:quandrix = c:gu = 638, c:silverquill = c:wb = 614,
+    # c:witherbloom = c:bg = 606.
+    "lorehold": "rw",
+    "prismari": "ur",
+    "quandrix": "gu",
+    "silverquill": "wb",
+    "witherbloom": "bg",
     # the five Alara shards
     "bant": "gwu",
     "esper": "wub",

--- a/api/parsing/colors.py
+++ b/api/parsing/colors.py
@@ -1,0 +1,81 @@
+"""Colour vocabulary: the letter codes and every name Scryfall's search accepts for them."""
+
+COLOR_CODE_TO_NAME = {
+    "b": "black",
+    "c": "colorless",
+    "g": "green",
+    "r": "red",
+    "u": "blue",
+    "w": "white",
+}
+
+# Every colour NAME Scryfall's search accepts, as the letter set that name spells.
+#
+# The guild / shard / wedge vocabulary is what players actually type -- `c:azorius` is a normal
+# thing to write and this parser answered it with a parse error -- so the whole table was measured
+# rather than guessed, one request each against api.scryfall.com (`c:<value> e:khm`, 2026-08-16),
+# and every accepted name then checked against its letter spelling over the WHOLE corpus. Kaldheim
+# holds exactly one card of three colours or more, so a set-scoped check would have agreed with
+# almost any mapping; the corpus-wide pairs are the ones that pin it: `c:bant` = `c:gwu` = 153,
+# `c:esper` = `c:wub` = 146, `c:yore-tiller` = `c:wubr` = 62, `c:witch-maw` = `c:gwub` = 63,
+# `c:rainbow` = `c:wubrg` = 60, `c:brown` = `c:c` = 4,300, and so on for all 24 pairs.
+#
+# It is a BOUNDARY rather than a superset. `yore`, `glint`, `dune`, `ink` and `witch` on their own
+# come back "Unknown color ..." -- the un-hyphenated four-colour nicknames are NOT in Scryfall's
+# table, only the hyphenated forms and the five one-word synonyms are -- and so do `five`, `mono`,
+# `guild`, `shard`, `wedge`, `nephilim` and `chromatic`.
+#
+# `all` spells `wubrgc` where `rainbow` spells `wubrg`, and the difference is measured rather than
+# cosmetic: for card_colors and card_color_identity the `c` drops out, so `c:all` = `c:wubrg` = 60,
+# while for produced_mana it does not, so `produces:all` matches nothing (no card produces all six)
+# where `produces:rainbow` = `produces:wubrg` = 13. One table serves all three columns because
+# `get_colors_comparison_object` already draws exactly that line. It also fully replaces the old
+# name -> single-letter-code table (`white` -> `w`, etc.), so there is only one lookup path.
+COLOR_ALIAS_TO_CODES = {
+    # the five colours, colourless, and the British and slang spellings of the latter
+    "white": "w",
+    "blue": "u",
+    "black": "b",
+    "red": "r",
+    "green": "g",
+    "colorless": "c",
+    "colourless": "c",
+    "brown": "c",
+    # the ten Ravnica guilds
+    "azorius": "wu",
+    "dimir": "ub",
+    "rakdos": "br",
+    "gruul": "rg",
+    "selesnya": "gw",
+    "orzhov": "wb",
+    "izzet": "ur",
+    "golgari": "bg",
+    "boros": "rw",
+    "simic": "gu",
+    # the five Alara shards
+    "bant": "gwu",
+    "esper": "wub",
+    "grixis": "ubr",
+    "jund": "brg",
+    "naya": "rgw",
+    # the five Khans wedges
+    "abzan": "wbg",
+    "jeskai": "urw",
+    "sultai": "bgu",
+    "mardu": "rwb",
+    "temur": "gur",
+    # the five four-colour names, hyphenated (the Nephilim) and as one word
+    "yore-tiller": "wubr",
+    "glint-eye": "ubrg",
+    "dune-brood": "brgw",
+    "ink-treader": "rgwu",
+    "witch-maw": "gwub",
+    "artifice": "wubr",
+    "chaos": "ubrg",
+    "aggression": "brgw",
+    "altruism": "rgwu",
+    "growth": "gwub",
+    # all five colours, and all six values
+    "rainbow": "wubrg",
+    "all": "wubrgc",
+}

--- a/api/parsing/db_info.py
+++ b/api/parsing/db_info.py
@@ -331,17 +331,6 @@ CARD_TYPES = {
     "Tribal",
 }
 
-COLOR_CODE_TO_NAME = {
-    "b": "black",
-    "c": "colorless",
-    "g": "green",
-    "r": "red",
-    "u": "blue",
-    "w": "white",
-}
-
-COLOR_NAME_TO_CODE = {v: k for k, v in COLOR_CODE_TO_NAME.items()}
-
 FORMAT_CODE_TO_NAME = {
     "m": "modern",
     "s": "standard",

--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -736,27 +736,25 @@ class Parser:
             self.consume()
             return StringValueNode(str(tok.value))
         if tok.type == TT.WORD:
+            self.consume()
             val = str(tok.value)
             # The four-colour names are HYPHENATED (`yore-tiller`, `witch-maw`), and `-` is not a
-            # word-continuation character, so the lexer hands this WORD MINUS WORD. Glue the three
-            # back together — but only when the result is a name, so an ordinary `c:w-1` still
-            # ends the value at the `w` and lets arithmetic have the rest. Same adjacency rule
-            # parse_date_value uses for YYYY-MM-DD: no space on either side of the hyphen.
-            if (
-                self.peek(1).type == TT.MINUS
+            # word-continuation character, so the lexer hands this WORD MINUS WORD. Same greedy
+            # hyphen-continuation rule parse_text_value uses (no space on either side) -- glue
+            # first, validate once at the end, rather than checking membership before consuming.
+            # WORD-only (not NUMBER, unlike parse_text_value's continuation): a color value is
+            # never numeric, so `c:w-1` still stops at `w` and leaves `-1` for whatever comes next.
+            while (
+                self.peek().type == TT.MINUS
+                and not self.peek().space_before
+                and self.peek(1).type == TT.WORD
                 and not self.peek(1).space_before
-                and self.peek(2).type == TT.WORD
-                and not self.peek(2).space_before
-                and f"{val}-{self.peek(2).value}".lower() in _VALID_COLOR_NAMES
             ):
                 self.consume()
-                self.consume()
-                tail = self.consume()
-                return StringValueNode(f"{val}-{tail.value}")
+                val += "-" + str(self.consume().value)
             if val.lower() not in _VALID_COLOR_NAMES and not all(c in _COLOR_LETTERS for c in val):
                 msg = f"Invalid color value {val!r} at position {tok.pos}"
                 raise ParseError(msg)
-            self.consume()
             return StringValueNode(val)
         msg = f"Expected color value, got {tok.value!r} at position {tok.pos}"
         raise ParseError(msg)

--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -12,7 +12,8 @@ from dataclasses import dataclass
 from enum import Enum, auto
 
 from api.parsing.card_query_nodes import CardAttributeNode, CardBinaryOperatorNode, ExactNameNode
-from api.parsing.db_info import ALIAS_TO_FIELD_INFOS, COLOR_NAME_TO_CODE, ParserClass
+from api.parsing.colors import COLOR_ALIAS_TO_CODES
+from api.parsing.db_info import ALIAS_TO_FIELD_INFOS, ParserClass
 from api.parsing.mana_symbols import first_invalid_mana_symbol
 from api.parsing.nodes import (
     AndNode,
@@ -56,7 +57,7 @@ _BANG_ALIAS_CLASSES: frozenset[ParserClass] = frozenset(
     {ParserClass.COLOR, ParserClass.MANA, ParserClass.RARITY, ParserClass.YEAR, ParserClass.DATE}
 )
 
-_VALID_COLOR_NAMES: frozenset[str] = frozenset(COLOR_NAME_TO_CODE)
+_VALID_COLOR_NAMES: frozenset[str] = frozenset(COLOR_ALIAS_TO_CODES)
 _COLOR_LETTERS: frozenset[str] = frozenset("wubrgcWUBRGC")
 _MIN_MTG_YEAR: int = 1992
 _MAX_YEAR: int = 2040
@@ -736,6 +737,22 @@ class Parser:
             return StringValueNode(str(tok.value))
         if tok.type == TT.WORD:
             val = str(tok.value)
+            # The four-colour names are HYPHENATED (`yore-tiller`, `witch-maw`), and `-` is not a
+            # word-continuation character, so the lexer hands this WORD MINUS WORD. Glue the three
+            # back together — but only when the result is a name, so an ordinary `c:w-1` still
+            # ends the value at the `w` and lets arithmetic have the rest. Same adjacency rule
+            # parse_date_value uses for YYYY-MM-DD: no space on either side of the hyphen.
+            if (
+                self.peek(1).type == TT.MINUS
+                and not self.peek(1).space_before
+                and self.peek(2).type == TT.WORD
+                and not self.peek(2).space_before
+                and f"{val}-{self.peek(2).value}".lower() in _VALID_COLOR_NAMES
+            ):
+                self.consume()
+                self.consume()
+                tail = self.consume()
+                return StringValueNode(f"{val}-{tail.value}")
             if val.lower() not in _VALID_COLOR_NAMES and not all(c in _COLOR_LETTERS for c in val):
                 msg = f"Invalid color value {val!r} at position {tok.pos}"
                 raise ParseError(msg)

--- a/api/parsing/pyparsing_based.py
+++ b/api/parsing/pyparsing_based.py
@@ -23,8 +23,8 @@ from pyparsing import (
 )
 
 from api.parsing.card_query_nodes import CardAttributeNode, ExactNameNode, to_card_query_ast
+from api.parsing.colors import COLOR_ALIAS_TO_CODES
 from api.parsing.db_info import (
-    COLOR_NAME_TO_CODE,
     NUMERIC_CARD_ATTRIBUTES,
     PARSER_CLASS_TO_FIELD_INFOS,
     ParserClass,
@@ -315,7 +315,10 @@ def create_color_parsers() -> dict[str, ParserElement]:
     Returns:
         Dictionary containing color parser elements
     """
-    color_word = make_regex_pattern(COLOR_NAME_TO_CODE)
+    # The same vocabulary the hand parser's _VALID_COLOR_NAMES draws from — one table, so a name
+    # added for one parser cannot be missing from the other (test_parser_parity asserts they agree
+    # on validity, and a colour name accepted by only one of them is exactly that failure).
+    color_word = make_regex_pattern(COLOR_ALIAS_TO_CODES)
     color_letter_pattern = Regex(r"[wubrgcWUBRGC]+")
     color_value = color_word | color_letter_pattern
 

--- a/api/parsing/tests/test_color_names.py
+++ b/api/parsing/tests/test_color_names.py
@@ -11,6 +11,10 @@ with almost any mapping: `c:bant` = `c:gwu` = 153, `c:yore-tiller` = `c:wubr` = 
 The list is a boundary rather than a superset: `yore`, `glint`, `dune`, `ink` and `witch` on
 their own are rejected by Scryfall, so the un-hyphenated four-colour nicknames are not in its
 table, and neither are `five`, `mono`, `guild`, `shard` or `wedge`.
+
+The five Strixhaven colleges (Lorehold, Prismari, Quandrix, Silverquill, Witherbloom) were added
+later, verified the same way: `c:witherbloom` = `c:bg` = 606 corpus-wide, and so on for all five.
+`college`, `colleges`, and `strixhaven` are rejected by Scryfall, same boundary-not-superset rule.
 """
 
 import pytest
@@ -31,6 +35,12 @@ COLOR_NAME_CASES = [
     ("c:golgari", "c:bg"),
     ("c:boros", "c:rw"),
     ("c:simic", "c:gu"),
+    # the five Strixhaven colleges
+    ("c:lorehold", "c:rw"),
+    ("c:prismari", "c:ur"),
+    ("c:quandrix", "c:gu"),
+    ("c:silverquill", "c:wb"),
+    ("c:witherbloom", "c:bg"),
     ("c:bant", "c:gwu"),
     ("c:esper", "c:wub"),
     ("c:grixis", "c:ubr"),
@@ -106,6 +116,9 @@ def test_color_names_are_case_insensitive(query: str) -> None:
         "c:nephilim",
         "c:azorius-senate",
         "c:boros-legion",
+        "c:college",
+        "c:colleges",
+        "c:strixhaven",
     ],
 )
 def test_rejected_color_names_still_fail(invalid_query: str) -> None:

--- a/api/parsing/tests/test_color_names.py
+++ b/api/parsing/tests/test_color_names.py
@@ -1,0 +1,119 @@
+"""Scryfall's colour-NAME vocabulary: the guilds, shards, wedges and four-colour names.
+
+`c:azorius` is a normal thing for a player to type, and this parser answered it with a parse
+error — only `white`/`blue`/`black`/`red`/`green`/`colorless` and bare letter strings were
+accepted. Scryfall accepts 44 names, measured one request each against api.scryfall.com
+(`c:<value> e:khm`, 2026-08-16) and each then checked against its letter spelling over the whole
+corpus, because Kaldheim holds exactly one card of three colours or more and would have agreed
+with almost any mapping: `c:bant` = `c:gwu` = 153, `c:yore-tiller` = `c:wubr` = 62,
+`c:rainbow` = `c:wubrg` = 60, `c:brown` = `c:c` = 4,300.
+
+The list is a boundary rather than a superset: `yore`, `glint`, `dune`, `ink` and `witch` on
+their own are rejected by Scryfall, so the un-hyphenated four-colour nicknames are not in its
+table, and neither are `five`, `mono`, `guild`, `shard` or `wedge`.
+"""
+
+import pytest
+
+from api.parsing import generate_sql_query, parse_scryfall_query
+from api.parsing.colors import COLOR_ALIAS_TO_CODES
+from api.parsing.pyparsing_based import parse_search_query
+
+# (name query, the letter query it must mean). Every pair verified live before landing.
+COLOR_NAME_CASES = [
+    ("c:azorius", "c:wu"),
+    ("c:dimir", "c:ub"),
+    ("c:rakdos", "c:br"),
+    ("c:gruul", "c:rg"),
+    ("c:selesnya", "c:gw"),
+    ("c:orzhov", "c:wb"),
+    ("c:izzet", "c:ur"),
+    ("c:golgari", "c:bg"),
+    ("c:boros", "c:rw"),
+    ("c:simic", "c:gu"),
+    ("c:bant", "c:gwu"),
+    ("c:esper", "c:wub"),
+    ("c:grixis", "c:ubr"),
+    ("c:jund", "c:brg"),
+    ("c:naya", "c:rgw"),
+    ("c:abzan", "c:wbg"),
+    ("c:jeskai", "c:urw"),
+    ("c:sultai", "c:bgu"),
+    ("c:mardu", "c:rwb"),
+    ("c:temur", "c:gur"),
+    ("c:yore-tiller", "c:wubr"),
+    ("c:glint-eye", "c:ubrg"),
+    ("c:dune-brood", "c:brgw"),
+    ("c:ink-treader", "c:rgwu"),
+    ("c:witch-maw", "c:gwub"),
+    ("c:artifice", "c:wubr"),
+    ("c:chaos", "c:ubrg"),
+    ("c:aggression", "c:brgw"),
+    ("c:altruism", "c:rgwu"),
+    ("c:growth", "c:gwub"),
+    ("c:rainbow", "c:wubrg"),
+    ("c:colourless", "c:c"),
+    ("c:brown", "c:c"),
+    # `all` spells wubrgc, which is wubrg once the c drops out of a card_colors comparison …
+    ("c:all", "c:wubrg"),
+    # … and stays six values on produced_mana, where colorless is a genuine producible thing.
+    ("produces:all", "produces:wubrgc"),
+    ("produces:rainbow", "produces:wubrg"),
+    # The identity spellings take the same vocabulary (Scryfall: id:bant e:khm == id:gwu e:khm).
+    ("id:bant", "id:gwu"),
+    ("identity:esper", "identity:wub"),
+    ("ci<=abzan", "ci<=wbg"),
+    ("c>=azorius", "c>=wu"),
+    ("c!=jund", "c!=brg"),
+    ("-c:temur", "-c:gur"),
+]
+
+
+@pytest.mark.parametrize(
+    argnames=("query", "canonical_query"),
+    argvalues=COLOR_NAME_CASES,
+    ids=[q for q, _ in COLOR_NAME_CASES],
+)
+def test_color_name_matches_letters(query: str, canonical_query: str) -> None:
+    """A colour name produces exactly the SQL its letter spelling does, in both parsers."""
+    assert generate_sql_query(parse_scryfall_query(query)) == generate_sql_query(parse_scryfall_query(canonical_query))
+    assert generate_sql_query(parse_search_query(query)) == generate_sql_query(parse_search_query(canonical_query))
+
+
+@pytest.mark.parametrize(
+    argnames="query",
+    argvalues=["c:AZORIUS", "c:Azorius", "c:BaNt", "id:YORE-TILLER"],
+)
+def test_color_names_are_case_insensitive(query: str) -> None:
+    """Scryfall answers `c:AZORIUS e:khm` with the same 6 cards as `c:azorius e:khm`."""
+    assert generate_sql_query(parse_scryfall_query(query)) == generate_sql_query(parse_scryfall_query(query.lower()))
+
+
+# Values Scryfall REJECTS, which this parser must keep rejecting: adding a name Scryfall does not
+# have would answer a WIDER result than Scryfall, silently.
+@pytest.mark.parametrize(
+    argnames="invalid_query",
+    argvalues=[
+        "c:yore",
+        "c:glint",
+        "c:dune",
+        "c:ink",
+        "c:witch",
+        "c:five",
+        "c:guild",
+        "c:shard",
+        "c:wedge",
+        "c:nephilim",
+        "c:azorius-senate",
+        "c:boros-legion",
+    ],
+)
+def test_rejected_color_names_still_fail(invalid_query: str) -> None:
+    """A name outside Scryfall's table is still a parse error rather than a silent widening."""
+    with pytest.raises(ValueError, match="Failed to parse query"):
+        parse_scryfall_query(invalid_query)
+
+
+def test_every_alias_spells_only_color_codes() -> None:
+    """Every entry in the table expands to letters `get_colors_comparison_object` can read."""
+    assert all(set(codes) <= set("wubrgc") for codes in COLOR_ALIAS_TO_CODES.values())


### PR DESCRIPTION
Scryfall accepts colour names beyond the six base words and bare letter strings — the ten Ravnica guilds, the five Strixhaven colleges, the five Alara shards, the five Khans wedges, the five four-colour names (hyphenated as the Nephilim and as one word), `rainbow`/`all`/`brown`, and the British spellings. `c:azorius` was a parse error here; it answers 6 cards on Scryfall.

`COLOR_ALIAS_TO_CODES` maps each name to the letter set it spells, so `c:azorius` and `c:wu` serialize to the identical rhs. Measured one request each against `api.scryfall.com`, then every accepted name checked against its letter spelling over the whole corpus: `c:bant` = `c:gwu` = 153, `c:esper` = `c:wub` = 146, `c:rainbow` = `c:wubrg` = 60, `c:brown` = `c:c` = 4,300, and so on. It's a boundary rather than a superset — un-hyphenated forms like `yore`/`glint`/`dune`/`witch` are rejected by Scryfall and correctly excluded, along with `five`/`mono`/`guild`/`shard`/`wedge`/`nephilim`/`chromatic`/`college`/`colleges`/`strixhaven`.

The colour vocabulary (`COLOR_CODE_TO_NAME`, and this new table) moves out of `db_info.py` into its own `colors.py` leaf module. `COLOR_NAME_TO_CODE` is replaced outright rather than left as dead code — `COLOR_ALIAS_TO_CODES` already covers the base colours it served.

Both parsers take the change; pyparsing's colour word is built from the same table so `test_parser_parity` keeps them from diverging.

Second commit simplifies the hyphenated-name handling in `parse_color_value`: instead of checking table membership before deciding to glue a `WORD MINUS WORD` sequence back together, it glues greedily first (same rule `parse_text_value` already uses for `name:`/`o:`) and validates once at the end. Changes the error for a word-word hyphen chain that isn't a real name (`c:red-fake`) from `"Unexpected '-'"` to `"Invalid color value 'red-fake'"` — arguably clearer, and nothing in the suite pinned the old message. `c:w-1` is unchanged, since the continuation only matches `TT.WORD`, not `TT.NUMBER`.

Third commit adds the five Strixhaven colleges (Lorehold, Prismari, Quandrix, Silverquill, Witherbloom), which Scryfall's own syntax docs list alongside guild/shard/wedge names but which didn't make it into the original PR's table. Verified live, corpus-wide: `c:witherbloom` = `c:bg` = 606, and so on for all five.

Carried by [daveycodez's PR #926](https://github.com/jbylund/sylvan_librarian/pull/926), commit `77e8eb640b`/`d94c260a29` ("The Guild Names, and the Quotes Every Keyboard Produces") — that commit bundles this with an unrelated smart-quote fix (tracked separately as #970), so this PR carries just the colour-names half, with `daveycodez` set as the author of the first commit since the table, the research, the hyphen-gluing insight, and the tests are his. The other two commits (simplification, colleges) are follow-ups from this branch's own review, authored normally.

Closes #969.