### PR TITLE
Docs: Name the First Release "Ancestral Recall"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
 All notable changes to this project are documented here. Versions follow
-[CalVer](https://calver.org/) (`YYYY.MM.DD.PATCH`) rather than semantic versioning.
+[CalVer](https://calver.org/) (`YYYY.MM.DD.PATCH`) rather than semantic versioning. Each release also
+gets a hand-picked Magic card name, purely for fun — no meaning beyond vibes.
 
-## [2026.08.21.0]
+## [2026.08.21.0] — "Ancestral Recall"
 
 Initial release.
 


### PR DESCRIPTION
## Summary
Adds a hand-picked Magic card name to the CHANGELOG heading for 2026.08.21.0, matching the GitHub release title.
First release captures everything since the project's origin, so the pun (recalling everything that came before) fits.
Future releases get their own codename, hand-picked per release rather than randomly generated.

## Test plan
- [ ] Confirm this matches the GitHub release title once that's updated