### PR TITLE
Fix Card Details Page Resolving to Wrong Printing on Collector-Number Collision

### DIFF
--- a/api/static/card.js
+++ b/api/static/card.js
@@ -188,7 +188,9 @@ async function main() {
   try {
     const resp = await fetch(`/search?q=${encodeURIComponent(`set:${setCode} cn:${collectorNumber}`)}&unique=printing`);
     const data = await resp.json();
-    card = data.cards?.[0];
+    // cn: matches on collector_number_int, which collapses numbers differing only by
+    // letters/symbols (e.g. "2018" vs "2018A") — pick the exact printing, not data.cards[0].
+    card = data.cards?.find(c => c.collector_number === collectorNumber) ?? data.cards?.[0];
   } catch (_) {
     document.getElementById('card-loading').textContent = 'Failed to load card.';
     return;


### PR DESCRIPTION
## Summary
Clicking into a search result's card-details page (e.g. `/card/ovnt/2018`) could load the wrong printing entirely.
The page re-fetches its data with a `set:+cn:` search query and trusted `data.cards[0]`, but `cn:` on a bare integer matches `collector_number_int`, which strips all non-digit characters — so `"2018"`, `"2018A"`, and `"2018NA"` all collapse to the same value and the query returns all three cards.
With no explicit sort order, the default `prefer_score DESC` tiebreak could put a different card first, so the page silently rendered a different printing than the one the user clicked (reported case: clicking Ancestral Recall in set `ovnt` loaded Timetwister).
Fix: filter the response for the printing whose `collector_number` exactly matches the URL segment instead of blindly taking index `0`.

## Test plan
- [ ] Search `set:ovnt cn:2018` locally and confirm `/card/ovnt/2018`, `/card/ovnt/2018A`, `/card/ovnt/2018NA` each load their own correct card
- [ ] Click through a normal (non-colliding) search result and confirm the details page still loads correctly