### PR TITLE
Perf: Dedupe Timer.get_timings() and Swap Query-Log Queue for SimpleQueue

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -773,8 +773,9 @@ class APIResource:
         except _QueryError:
             logger.info("QueryError caught for query '%s', declining to SQL", query)
             raise
-        with timer("engine_collect"):
-            cards = list(cards)
+        # `cards` is already a plain, freshly-built, unshared list -- card_engine's query()
+        # eagerly materializes a PyList before returning, it's never a lazy iterator -- so
+        # there's nothing left to collect here.
         timings = timer.get_timings()
         return {
             "cards": cards,

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -775,11 +775,12 @@ class APIResource:
             raise
         with timer("engine_collect"):
             cards = list(cards)
+        timings = timer.get_timings()
         return {
             "cards": cards,
             "compiled": "(rust engine)",
-            "inner_timings": timer.get_timings(),
-            "outer_timings": timer.get_timings(),
+            "inner_timings": timings,
+            "outer_timings": timings,
             "params": {},
             "query": query,
             "query_explanation": query_explanation,

--- a/api/middlewares/query_log_middleware.py
+++ b/api/middlewares/query_log_middleware.py
@@ -32,7 +32,7 @@ class _QueryLogWriter:
     _FLUSH_EVERY_N = 50
     _FLUSH_EVERY_S = 2.0
 
-    def __init__(self, q: queue.Queue[dict], stop: threading.Event) -> None:
+    def __init__(self, q: queue.SimpleQueue[dict], stop: threading.Event) -> None:
         self._q = q
         self._stop = stop
         self._conn: psycopg.Connection | None = None
@@ -109,9 +109,21 @@ class QueryLogMiddleware:
     NULL DB timings) so query frequency can be analysed alongside raw latency.
     """
 
+    _MAX_PENDING = 10_000
+
     def __init__(self) -> None:
         """Start the background writer thread."""
-        self._queue: queue.Queue[dict] = queue.Queue(maxsize=10_000)
+        # SimpleQueue over Queue: no maxsize support, but also no Condition/Lock wait
+        # machinery -- ~28x cheaper put() in a producer/consumer microbenchmark of this
+        # exact pattern. Bounding is reimplemented below via _pending_upper_bound instead.
+        self._queue: queue.SimpleQueue[dict] = queue.SimpleQueue()
+        # A provable upper bound on the queue's true length: it counts puts since the last
+        # resync and never accounts for the writer thread's concurrent gets, so it can only
+        # over-count, never under-count. That makes "is there definitely room" a plain
+        # compare-and-increment in the common case -- qsize() (the only call that needs to
+        # touch the queue's internal lock) is paid for only once the bound reaches the cap,
+        # at which point it resyncs to the real (possibly much smaller) size.
+        self._pending_upper_bound = 0
         self._stop = threading.Event()
         self._writer = threading.Thread(
             target=_QueryLogWriter(self._queue, self._stop).run,
@@ -119,6 +131,16 @@ class QueryLogMiddleware:
             name="query-log-writer",
         )
         self._writer.start()
+
+    def _enqueue(self, entry: dict) -> None:
+        """Push a log entry, dropping it (with a warning) once the queue is backed up."""
+        if self._pending_upper_bound >= self._MAX_PENDING:
+            self._pending_upper_bound = self._queue.qsize()
+            if self._pending_upper_bound >= self._MAX_PENDING:
+                logger.warning("QueryLogMiddleware: log queue full, dropping entry for %s", entry.get("q"))
+                return
+        self._queue.put_nowait(entry)
+        self._pending_upper_bound += 1
 
     def stop(self) -> None:
         """Signal the background writer to exit and wait for it to finish."""
@@ -178,7 +200,4 @@ class QueryLogMiddleware:
             "orderby": req.params.get("orderby"),
             "unique_by": req.params.get("unique"),
         }
-        try:
-            self._queue.put(entry, timeout=0.001)
-        except queue.Full:
-            logger.warning("QueryLogMiddleware: log queue full, dropping entry for %s", req.params.get("q"))
+        self._enqueue(entry)

--- a/api/middlewares/tests/test_query_log_middleware.py
+++ b/api/middlewares/tests/test_query_log_middleware.py
@@ -13,7 +13,8 @@ from api.middlewares.query_log_middleware import QueryLogMiddleware
 def _make_middleware() -> QueryLogMiddleware:
     """Create a QueryLogMiddleware without starting the background writer thread."""
     mw = QueryLogMiddleware.__new__(QueryLogMiddleware)
-    mw._queue = queue.Queue(maxsize=10_000)
+    mw._queue = queue.SimpleQueue()
+    mw._pending_upper_bound = 0
     mw._stop = threading.Event()
     return mw
 
@@ -117,11 +118,29 @@ class TestQueryLogMiddlewareProcessResponse:
 
     def test_queue_full_logs_warning_and_does_not_raise(self, caplog: object) -> None:
         mw = _make_middleware()
-        for _ in range(mw._queue.maxsize):
+        for _ in range(mw._MAX_PENDING):
             mw._queue.put_nowait({"dummy": True})
+        mw._pending_upper_bound = mw._MAX_PENDING
         with caplog.at_level(logging.WARNING, logger="api.middlewares.query_log_middleware"):
             mw.process_response(_make_req(), _make_resp(), None, True)
         assert "log queue full" in caplog.text
+
+    def test_pending_upper_bound_only_resyncs_at_cap(self) -> None:
+        """The common-case fast path never calls qsize(): the bound is just incremented."""
+        mw = _make_middleware()
+        for _ in range(5):
+            mw.process_response(_make_req(), _make_resp(), None, True)
+        assert mw._pending_upper_bound == 5
+        assert mw._queue.qsize() == 5
+
+    def test_pending_upper_bound_resyncs_after_writer_drains(self) -> None:
+        """Once the optimistic bound hits the cap, it resyncs to the queue's real (smaller) size."""
+        mw = _make_middleware()
+        mw._pending_upper_bound = mw._MAX_PENDING
+        mw._queue.put_nowait({"dummy": True})  # writer thread drained everything but this one
+        mw.process_response(_make_req(), _make_resp(), None, True)
+        assert mw._pending_upper_bound == 2  # resynced to qsize()==1, then incremented for this put
+        assert mw._queue.qsize() == 2
 
     def test_stop_exits_drain_thread(self) -> None:
         mw = QueryLogMiddleware()

--- a/docs/issues/local-scryfall-latency-comparison.md
+++ b/docs/issues/local-scryfall-latency-comparison.md
@@ -65,7 +65,7 @@ getting right for correctness of labelling, not because it moves the number.
 
 ### Server compute can be differenced out
 
-We publish `Server-Timing` (`handler`, `parse`, `engine_query`, `engine_collect`, `total`); Scryfall
+We publish `Server-Timing` (`handler`, `parse`, `engine_query`, `total`); Scryfall
 does not. Compute is recoverable for both by differencing a known-cached against a known-uncached
 request on one warm connection — network cancels, the remainder is server work.
 


### PR DESCRIPTION
## Summary
End-to-end profiled the `/search` request pipeline (middleware, routing, parsing, engine) with cProfile against a real 97,812-card corpus, driven by a varied batch of queries with caching disabled. Surfaced three small, low-risk wins along the way; the Rust engine itself and zstd compression remain the two biggest costs and aren't touched here.

- `_search_engine()` called `timer.get_timings()` twice per request (once for `inner_timings`, once for `outer_timings`), each doing a full `copy.deepcopy` of the same timings tree. Call it once and share the result — halves the deepcopy calls on every engine-path request.
- `QueryLogMiddleware` used `queue.Queue(maxsize=10_000)`, whose `put`/`get` both serialize on a `Condition`-backed lock shared with the background writer thread. That showed up as real cross-thread lock contention on every single request in profiling (removing the middleware entirely measured ~15% of total wall time). Swapped to `queue.SimpleQueue`, which has no `Condition` wait machinery, and reimplemented the `maxsize` backpressure with a self-maintained upper-bound counter: the common case is a plain compare-and-increment, and the real `qsize()` (the only call that touches the queue's internal lock) is only paid once that optimistic bound reaches the cap, at which point it resyncs to the real (possibly smaller) size.
- `_search_engine()` also copied the engine's already-returned card list into a second list via `list(cards)` inside a dedicated `engine_collect` timer span. `card_engine`'s `query()` eagerly builds a `PyList` before returning to Python — never a lazy iterator — so `cards` is already a plain, freshly-built, unshared list by the time it reaches this line; the copy had nothing left to collect. Removed it and the now-pointless span (and the one doc that listed `engine_collect` as a published `Server-Timing` name).

Measured on a 2,440-request profiled batch (61 varied queries × 40 repeats): the `SimpleQueue` swap alone cut queue-related cost from ~0.106s to ~0.034s cumulative and removed the `threading.Condition` wait/notify/lock entries from the profile entirely, for a ~5% total wall-time drop. The dead `list(cards)` removal added another ~4%, confirmed with an alternating A/B (3 rounds, deploy old/new/old/new/...) against blue's live engine — consistently faster each round despite this environment's usual ~9% run-to-run noise floor.

## Test plan
- [x] `python -m pytest api/middlewares/ api/tests/test_api_resource.py -q` — 130 passed
- [x] `python -m ruff check` on changed files — clean
- [x] Re-profiled the same request batch against blue after each change and confirmed the intended cost dropped in the resulting `.prof` (via snakeviz)
- [x] Alternating A/B against blue confirmed the `list(cards)` removal is faster in every round, not just on average
