### PR TITLE
Explain Colour-Name and Letter-Code Queries with Icons, Deduped and Canonical

### DIFF
--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -186,6 +186,10 @@ class CardAttributeNode(AttributeNode):
 
 _COLOR_BITS: dict[str, int] = {"W": 16, "U": 8, "B": 4, "R": 2, "G": 1}
 
+# Canonical WUBRG(C) ordering for rendering a set of color codes back to a human, e.g. so
+# "brgb" explains as "Black/Red/Green" rather than echoing input order.
+_CANONICAL_COLOR_ORDER = "wubrgc"
+
 
 def _color_dict_to_mask(color_dict: dict[str, bool]) -> int:
     return sum(bit for color, bit in _COLOR_BITS.items() if color_dict.get(color))
@@ -688,13 +692,32 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
         if isinstance(context_node, CardAttributeNode):
             db_column_name = context_node.attribute_name.lower()
             if db_column_name in ("card_colors", "card_color_identity"):
+                # A color NAME ('temur', 'azorius', 'blue', 'colorless') spells a letter set
+                # via COLOR_ALIAS_TO_CODES. Single-letter spellings expand the same as bare
+                # letter codes below ('blue' -> 'Blue'); multi-letter names show the letters
+                # alongside the name as {G}{U}{R}-style bracket tokens so the reader isn't left
+                # to memorize which colors a guild/shard/wedge name means (#990). The frontend's
+                # showResults() runs the whole message through convertManaSymbols() after
+                # escaping, which turns exactly these tokens into real mana-font icons -- so
+                # this is the one spot in the string a server response is allowed to steer
+                # frontend HTML, and only ever with this fixed A-Z/digit token vocabulary.
+                alias_codes = COLOR_ALIAS_TO_CODES.get(value.lower())
+                if alias_codes is not None:
+                    if len(alias_codes) == 1:
+                        return COLOR_CODE_TO_NAME[alias_codes].capitalize()
+                    tokens = "".join(f"{{{c.upper()}}}" for c in alias_codes)
+                    return f"{value.capitalize()} ({tokens})"
                 # Try to expand single-letter color codes
                 if len(value) == 1 and value.lower() in COLOR_CODE_TO_NAME:
                     return COLOR_CODE_TO_NAME[value.lower()].capitalize()
-                # Try to expand multi-letter color codes (e.g., "ug" -> "Blue/Green")
+                # Try to expand multi-letter color codes (e.g., "ug" -> "Blue/Green"), deduped
+                # and in canonical WUBRG(C) order so a repeated/scrambled letter string like
+                # "brgb" reads as "Black/Red/Green" rather than echoing every input letter in
+                # input order ("Black/Red/Green/Black").
                 max_colors = 5
                 if len(value) <= max_colors and all(c.lower() in COLOR_CODE_TO_NAME for c in value):
-                    color_names = [COLOR_CODE_TO_NAME[c.lower()].capitalize() for c in value.lower()]
+                    present = {c.lower() for c in value}
+                    color_names = [COLOR_CODE_TO_NAME[c].capitalize() for c in _CANONICAL_COLOR_ORDER if c in present]
                     return "/".join(color_names)
 
             # If context is a format-related attribute, try to expand format codes

--- a/api/parsing/tests/test_explanation.py
+++ b/api/parsing/tests/test_explanation.py
@@ -194,6 +194,29 @@ def test_explain_color_combinations(parse_query) -> None:
         assert expected_colors in explanation
 
 
+@pytest.mark.parametrize(
+    argnames=["query_str", "expected_explanation"],
+    argvalues=[
+        # Repeated/scrambled letters dedupe and land in canonical WUBRG order, not input order.
+        ("c=brgb", "the color is Black/Red/Green"),
+        ("id=brgb", "the color identity is Black/Red/Green"),
+        ("c=gwbur", "the color is White/Blue/Black/Red/Green"),
+        # Guild/shard/wedge names show the letters they spell alongside the name, as
+        # {G}{U}{R}-style bracket tokens the frontend renders into mana-font icons (#990).
+        ("c=temur", "the color is Temur ({G}{U}{R})"),
+        ("id=temur", "the color identity is Temur ({G}{U}{R})"),
+        ("c=azorius", "the color is Azorius ({W}{U})"),
+        # Single-color names expand the same as bare letter codes.
+        ("c=blue", "the color is Blue"),
+        ("c=colorless", "the color is Colorless"),
+    ],
+)
+def test_explain_color_dedup_and_names(parse_query, query_str: str, expected_explanation: str) -> None:
+    """Color explanations dedupe/canonicalize letters and expand alias names with their letters."""
+    parsed_query = parse_query(query_str)
+    assert parsed_query.to_human_explanation() == expected_explanation
+
+
 def test_explain_format_expansion(parse_query) -> None:
     """Test format code expansion."""
     test_cases = [

--- a/api/static/app.js
+++ b/api/static/app.js
@@ -1299,7 +1299,11 @@ class CardSearch {
     }
     if (this.statusMessage) {
       const cssClass = count === 0 ? 'no-results' : 'results-count';
-      this.statusMessage.innerHTML = `<div class="${cssClass}">${this.escapeHtml(msg)}</div>`;
+      // Escape first, then convert: escaping preserves protection for any raw query text
+      // embedded in msg, and convertManaSymbols only ever turns an exact, server-controlled
+      // {W}/{U}/etc. token vocabulary into markup -- never anything derived from unescaped
+      // user text -- so this composes safely with the escaping rather than replacing it.
+      this.statusMessage.innerHTML = `<div class="${cssClass}">${this.convertManaSymbols(this.escapeHtml(msg))}</div>`;
     }
   }
 

--- a/api/static/app.test.js
+++ b/api/static/app.test.js
@@ -396,6 +396,55 @@ describe('CardSearch convertManaSymbolsToText', () => {
   });
 });
 
+describe('CardSearch showResults', () => {
+  // beforeEach() at the top of this file replaces showResults with a jest.fn() mock on
+  // `search` (an existence check only), so real behavior needs its own un-mocked instance.
+  const manaSpan = css => `<span class="mana-symbol ${css}"></span>`;
+  const temurIcons = manaSpan('ms ms-g ms-cost') + manaSpan('ms ms-u ms-cost') + manaSpan('ms ms-r ms-cost');
+
+  let realSearch;
+
+  beforeEach(() => {
+    buildDOM();
+    realSearch = new CardSearch();
+  });
+
+  it('renders {G}{U}{R}-style server tokens as mana-font icons', () => {
+    realSearch.showResults(1, 'c:temur', 'the color is Temur ({G}{U}{R})', 5);
+    expect(realSearch.statusMessage.innerHTML).toBe(
+      `<div class="results-count">1 card where the color is Temur (${temurIcons}) (completed in 5ms)</div>`
+    );
+  });
+
+  it('escapes HTML in the raw query when there is no explanation to fall back to', () => {
+    realSearch.showResults(0, '<script>alert(1)</script>', '', 2);
+    expect(realSearch.statusMessage.innerHTML).toBe(
+      '<div class="no-results">No cards found matching "&lt;script&gt;alert(1)&lt;/script&gt;" (completed in 2ms)</div>'
+    );
+  });
+
+  it('pluralizes the item type based on count', () => {
+    realSearch.showResults(0, 'c:temur', 'the color is Temur ({G}{U}{R})', 3);
+    expect(realSearch.statusMessage.innerHTML).toBe(
+      `<div class="no-results">No cards found where the color is Temur (${temurIcons}) (completed in 3ms)</div>`
+    );
+  });
+
+  it('shows a random-selection message when there is no query', () => {
+    realSearch.showResults(12, null, null, null);
+    expect(realSearch.statusMessage.innerHTML).toBe(
+      '<div class="results-count">Showing a random selection of 12 cards</div>'
+    );
+  });
+
+  it('omits the elapsed-time suffix when elapsed is not a number', () => {
+    realSearch.showResults(1, 'c:temur', 'the color is Temur ({G}{U}{R})', null);
+    expect(realSearch.statusMessage.innerHTML).toBe(
+      `<div class="results-count">1 card where the color is Temur (${temurIcons})</div>`
+    );
+  });
+});
+
 describe('CardSearch balanceQuery', () => {
   it.each(BALANCE_QUERIES)('matches parity fixture for $input', ({ input, suffix }) => {
     expect(search.balanceSuffix(input)).toBe(suffix);


### PR DESCRIPTION
## Summary
- Closes #990: guild/shard/wedge colour names (`c:temur`, `id:azorius`) now explain with the letters they spell, as `{G}{U}{R}`-style tokens the frontend renders into mana-font icons, instead of echoing the name back verbatim.
- Fixes a related bug: letter-code queries like `color:brgb` now dedupe and render in canonical WUBRG order (`Black/Red/Green`) instead of echoing every input letter in input order (`Black/Red/Green/Black`).
- Both fixes apply identically to `color:`/`c:` and `id:`/`identity:`/`ci:`/`commander:`, which already share this explanation code path.

## Test plan
- [x] `python -m pytest api/parsing/tests/test_explanation.py -q` — 124 passed (new cases for dedup/order and alias-name expansion, covering both parsers)
- [x] `npx jest app.test.js` (in `api/static/`) — 1837 passed, including new real-behavior tests for `showResults` (previously only existence-checked)
- [x] `make test-unit` — 3238 passed
- [x] `make lint` — clean