### PR TITLE
Fix is:new to Map to frame:new Instead of frame:2015

### DIFF
--- a/api/parsing/rewrite.py
+++ b/api/parsing/rewrite.py
@@ -37,15 +37,14 @@ if TYPE_CHECKING:
 #
 # `frame:modern/old/new` are undocumented-but-live Scryfall aliases (the syntax docs list
 # only the numeric frames + frame-effects); mirrored because they see real use. `is:old`
-# and `is:new` ARE documented. Note `is:new` is the 2015 frame *only* -- deliberately
-# narrower than `frame:new` (every post-"classic" frame) -- and both are mirrored as-is
-# rather than reconciled, since diverging from Scryfall would be the real bug.
+# and `is:new` ARE documented, and match their `frame:` counterparts exactly (live count
+# 2026-08-22: `is:new` = `frame:new` = 90058, vs `frame:2015` alone at 72564 -- issue #974).
 _DERIVED_EXPANSIONS: dict[tuple[str, str], str] = {
     ("frame", "modern"): "frame:2003",
     ("frame", "old"): "frame:1993 or frame:1997",
     ("frame", "new"): "frame:2003 or frame:2015 or frame:future",
     ("is", "old"): "frame:1993 or frame:1997",
-    ("is", "new"): "frame:2015",
+    ("is", "new"): "frame:2003 or frame:2015 or frame:future",
     # Type / subtype based. `kw:changeling` (an ability keyword, subtype is Shapeshifter) picks up
     # the all-creature-type cards Scryfall counts. Note party IS creature-restricted while outlaw is
     # NOT (it also matches Kindred non-creature cards carrying an outlaw subtype).

--- a/api/parsing/tests/test_rewrite.py
+++ b/api/parsing/tests/test_rewrite.py
@@ -18,7 +18,7 @@ EQUIVALENCES = [
     ("frame:old", "frame:1993 or frame:1997"),
     ("frame:new", "frame:2003 or frame:2015 or frame:future"),
     ("is:old", "frame:1993 or frame:1997"),
-    ("is:new", "frame:2015"),
+    ("is:new", "frame:2003 or frame:2015 or frame:future"),
     # type / subtype based
     ("is:historic", "t:legendary or t:artifact or t:saga"),
     ("is:permanent", "t:creature or t:artifact or t:enchantment or t:land or t:planeswalker or t:battle"),

--- a/docs/issues/done/00713-is-tag-recovery.md
+++ b/docs/issues/done/00713-is-tag-recovery.md
@@ -76,7 +76,7 @@ Confidence: ✓ = definition doc-confirmed / measured; ~ = approximate, **valida
 |---|---|---|
 | `frame:modern` | `frame:2003` | ✓ |
 | `is:old` / `frame:old` | `(frame:1993 or frame:1997)` | ✓ |
-| `is:new` | `frame:2015` | ✓ |
+| `is:new` | `frame:2003 or frame:2015 or frame:future` — matches `frame:new` exactly (live count 90058 == 90058); the original `frame:2015`-only mapping undercounted by ~9,201 cards, fixed in #974 | ✓ |
 | `frame:new` | `frame:2003 or frame:2015 or frame:future` (undocumented alias; positive union — matches the validated Scryfall count and is safe against any frameless printing, unlike a `-(old)` complement) | ✓ |
 | `is:historic` | `t:legendary or t:artifact or t:saga` | ✓ **exact** (7881=7881) |
 | `is:permanent` | `t:creature or t:artifact or t:enchantment or t:land or t:planeswalker or t:battle` | ✓ near-exact (+2 / 25954) |


### PR DESCRIPTION
## Summary
- `is:new` was rewriting to `frame:2015` only, but Scryfall's `is:new` means the current/modern frame (`frame:new`: 2003, 2015, and future) — confirmed live: `is:new` and `frame:new` both return 90058 cards, `frame:2015` alone returns 72564.
- Updates the `("is", "new")` expansion in `api/parsing/rewrite.py`, the matching test case in `api/parsing/tests/test_rewrite.py`, and the stale table row + rationale in `docs/issues/done/00713-is-tag-recovery.md`.

## Test plan
- [x] `python -m pytest api/parsing/tests/test_rewrite.py -k new` — 9 passed
- [x] `python -m pytest api/parsing/tests/` — 2300 passed
- [x] `ruff check` / `ruff format --check` on changed files

Fixes #974