### PR TITLE
Generalize BOOLEAN_IS_TAGS to Arbitrary Expressions, Add 21 Low-Density is: Tags

### DIFF
--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -102,35 +102,34 @@ _UPSERT_PAGE_SIZE = 3_000
 # deliberately NOT here -- "higher cardinality, memory check first" -- and stay a
 # candidate for a separate, more careful pass.
 BOOLEAN_IS_TAGS: dict[str, str] = {
-    # Plain top-level booleans, same shape as the original two.
-    "reserved": "cards.raw_card_blob->'reserved' = 'true'::jsonb",
-    "gamechanger": "cards.raw_card_blob->'game_changer' = 'true'::jsonb",
-    "spotlight": "cards.raw_card_blob->'story_spotlight' = 'true'::jsonb",
-    # Nested/array fields: promo_types membership (bulk's own vocabulary, no renaming),
-    # keywords/finishes array membership, and two single-field lookups (set_type,
-    # preview.source).
-    "league": "cards.raw_card_blob->'promo_types' @> '\"league\"'",
-    "glossy": "cards.raw_card_blob->'promo_types' @> '\"glossy\"'",
-    "giftbox": "cards.raw_card_blob->'promo_types' @> '\"giftbox\"'",
-    "intro_pack": "cards.raw_card_blob->'promo_types' @> '\"intropack\"'",
-    "convention": "cards.raw_card_blob->'promo_types' @> '\"convention\"'",
-    "player_rewards": "cards.raw_card_blob->'promo_types' @> '\"playerrewards\"'",
-    "release": "cards.raw_card_blob->'promo_types' @> '\"release\"'",
+    # Alphabetized by key. Expressions read either a plain top-level boolean (reserved,
+    # gamechanger, spotlight), promo_types/keywords/finishes array membership, or a
+    # single-field lookup (set_type, preview.source).
     "arena_league": "cards.raw_card_blob->'promo_types' @> '\"arenaleague\"'",
-    "gameday": "cards.raw_card_blob->'promo_types' @> '\"gameday\"'",
     "buyabox": "cards.raw_card_blob->'promo_types' @> '\"buyabox\"'",
-    "judge_gift": "cards.raw_card_blob->'promo_types' @> '\"judgegift\"'",
-    "instore": "cards.raw_card_blob->'promo_types' @> '\"instore\"'",
-    "planeswalker_deck": "cards.raw_card_blob->'promo_types' @> '\"planeswalkerdeck\"'",
+    "convention": "cards.raw_card_blob->'promo_types' @> '\"convention\"'",
+    "etched": "cards.raw_card_blob->'finishes' @> '\"etched\"'",
     "fnm": "cards.raw_card_blob->'promo_types' @> '\"fnm\"'",
+    "gamechanger": "cards.raw_card_blob->'game_changer' = 'true'::jsonb",
+    "gameday": "cards.raw_card_blob->'promo_types' @> '\"gameday\"'",
+    "giftbox": "cards.raw_card_blob->'promo_types' @> '\"giftbox\"'",
+    "glossy": "cards.raw_card_blob->'promo_types' @> '\"glossy\"'",
+    "instore": "cards.raw_card_blob->'promo_types' @> '\"instore\"'",
+    "intro_pack": "cards.raw_card_blob->'promo_types' @> '\"intropack\"'",
+    "judge_gift": "cards.raw_card_blob->'promo_types' @> '\"judgegift\"'",
+    "league": "cards.raw_card_blob->'promo_types' @> '\"league\"'",
+    "masterpiece": "cards.raw_card_blob->>'set_type' = 'masterpiece'",
     "media_insert": "cards.raw_card_blob->'promo_types' @> '\"mediainsert\"'",
-    "set_promo": "cards.raw_card_blob->'promo_types' @> '\"setpromo\"'",
     # "Partner with <name>" cards carry a plain "Partner" keyword alongside it (verified
     # against the corpus), so checking for "Partner" alone already covers both.
     "partner": "cards.raw_card_blob->'keywords' @> '\"Partner\"'",
-    "etched": "cards.raw_card_blob->'finishes' @> '\"etched\"'",
-    "masterpiece": "cards.raw_card_blob->>'set_type' = 'masterpiece'",
+    "planeswalker_deck": "cards.raw_card_blob->'promo_types' @> '\"planeswalkerdeck\"'",
+    "player_rewards": "cards.raw_card_blob->'promo_types' @> '\"playerrewards\"'",
+    "release": "cards.raw_card_blob->'promo_types' @> '\"release\"'",
+    "reserved": "cards.raw_card_blob->'reserved' = 'true'::jsonb",
     "scryfallpreview": "cards.raw_card_blob->'preview'->>'source' = 'Scryfall'",
+    "set_promo": "cards.raw_card_blob->'promo_types' @> '\"setpromo\"'",
+    "spotlight": "cards.raw_card_blob->'story_spotlight' = 'true'::jsonb",
 }
 
 

--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -90,34 +90,79 @@ IMPORT_LOCK_TIMEOUT = 2
 # total, and it halves the logged parameter too (see log_parameter_max_length in the pg config).
 _UPSERT_PAGE_SIZE = 3_000
 
-# is: values Scryfall ships as BOOLEANS on every bulk card object, synced
-# in one set-based statement from raw_card_blob after each import (see
-# _sync_boolean_is_tags) -- no per-tag API sweep, unlike CUSTOM_IS_TAGS
-# below, and no accumulation in the import loop. card_is_tags key -> raw
-# blob key; adding a field here is the whole change. foil/promo/reprint are
-# deliberately NOT here yet (higher cardinality, memory check first).
+# is: values derivable from a single boolean SQL expression against a card's own
+# raw_card_blob, synced in one set-based statement after each import (see
+# _sync_boolean_is_tags) -- no per-tag API sweep, unlike CUSTOM_IS_TAGS below, and no
+# accumulation in the import loop. Each expression must reference the row alias `cards`
+# (it runs inside a correlated subquery, not a plain WHERE) -- adding a tag here is the
+# whole change. Density-gated at ~2% of the corpus (see docs/issues/00985): reserved
+# (1.1%) and gamechanger (0.4%) were the original two; the rest were added after a
+# corpus-wide survey of every is: tag on Scryfall's syntax page found these sitting at
+# or under masterpiece's 1.8%. foil/nonfoil/reprint/booster/hires (50-97%) are
+# deliberately NOT here -- "higher cardinality, memory check first" -- and stay a
+# candidate for a separate, more careful pass.
 BOOLEAN_IS_TAGS: dict[str, str] = {
-    "reserved": "reserved",
-    "gamechanger": "game_changer",
+    # Plain top-level booleans, same shape as the original two.
+    "reserved": "cards.raw_card_blob->'reserved' = 'true'::jsonb",
+    "gamechanger": "cards.raw_card_blob->'game_changer' = 'true'::jsonb",
+    "spotlight": "cards.raw_card_blob->'story_spotlight' = 'true'::jsonb",
+    # Nested/array fields: promo_types membership (bulk's own vocabulary, no renaming),
+    # keywords/finishes array membership, and two single-field lookups (set_type,
+    # preview.source).
+    "league": "cards.raw_card_blob->'promo_types' @> '\"league\"'",
+    "glossy": "cards.raw_card_blob->'promo_types' @> '\"glossy\"'",
+    "giftbox": "cards.raw_card_blob->'promo_types' @> '\"giftbox\"'",
+    "intro_pack": "cards.raw_card_blob->'promo_types' @> '\"intropack\"'",
+    "convention": "cards.raw_card_blob->'promo_types' @> '\"convention\"'",
+    "player_rewards": "cards.raw_card_blob->'promo_types' @> '\"playerrewards\"'",
+    "release": "cards.raw_card_blob->'promo_types' @> '\"release\"'",
+    "arena_league": "cards.raw_card_blob->'promo_types' @> '\"arenaleague\"'",
+    "gameday": "cards.raw_card_blob->'promo_types' @> '\"gameday\"'",
+    "buyabox": "cards.raw_card_blob->'promo_types' @> '\"buyabox\"'",
+    "judge_gift": "cards.raw_card_blob->'promo_types' @> '\"judgegift\"'",
+    "instore": "cards.raw_card_blob->'promo_types' @> '\"instore\"'",
+    "planeswalker_deck": "cards.raw_card_blob->'promo_types' @> '\"planeswalkerdeck\"'",
+    "fnm": "cards.raw_card_blob->'promo_types' @> '\"fnm\"'",
+    "media_insert": "cards.raw_card_blob->'promo_types' @> '\"mediainsert\"'",
+    "set_promo": "cards.raw_card_blob->'promo_types' @> '\"setpromo\"'",
+    # "Partner with <name>" cards carry a plain "Partner" keyword alongside it (verified
+    # against the corpus), so checking for "Partner" alone already covers both.
+    "partner": "cards.raw_card_blob->'keywords' @> '\"Partner\"'",
+    "etched": "cards.raw_card_blob->'finishes' @> '\"etched\"'",
+    "masterpiece": "cards.raw_card_blob->>'set_type' = 'masterpiece'",
+    "scryfallpreview": "cards.raw_card_blob->'preview'->>'source' = 'Scryfall'",
 }
 
-_SYNC_BOOLEAN_IS_TAGS_SQL = """
-WITH tag_map(tag, blob_key) AS (
-    SELECT key, value FROM jsonb_each_text(%(tag_map)s::jsonb)
-),
-proposed AS (
+
+def _build_boolean_is_tags_sql(tags: dict[str, str]) -> str:
+    """Build the one-shot BOOLEAN_IS_TAGS sync statement from `tags`.
+
+    Each `(tag, expr)` pair becomes one row of a VALUES list correlated against the outer
+    `cards` row (`expr` reads `cards.raw_card_blob`), so `expr` may be any boolean SQL
+    expression -- not just "this top-level key is literally true" -- letting one mechanism
+    cover both plain booleans and promo_types/keywords/finishes array membership or
+    nested-object lookups. `tags` is a static, developer-authored module constant, never
+    user input, so embedding its keys and expressions as literal SQL text here (rather than
+    binding them as query parameters, which can't carry per-tag SQL syntax anyway) is safe.
+    """
+    managed = ", ".join(f"'{tag}'" for tag in tags)
+    values = ",\n                        ".join(f"('{tag}', ({expr}))" for tag, expr in tags.items())
+    return f"""
+WITH proposed AS (
     SELECT
         cards.scryfall_id,
-        (cards.card_is_tags - (SELECT array_agg(tag_map.tag) FROM tag_map))
+        (cards.card_is_tags - ARRAY[{managed}]::text[])
             || COALESCE(
                    (
-                       SELECT jsonb_object_agg(tag_map.tag, true)
-                       FROM tag_map
-                       WHERE cards.raw_card_blob -> tag_map.blob_key = 'true'::jsonb
+                       SELECT jsonb_object_agg(t.tag, true)
+                       FROM (VALUES
+                        {values}
+                       ) AS t(tag, is_true)
+                       WHERE t.is_true
                    ),
-                   '{}'::jsonb
+                   '{{}}'::jsonb
                ) AS proposed_is_tags
-    FROM magic.cards
+    FROM magic.cards cards
 )
 UPDATE magic.cards
 SET card_is_tags = proposed.proposed_is_tags
@@ -126,6 +171,9 @@ WHERE
     cards.scryfall_id = proposed.scryfall_id AND
     cards.card_is_tags IS DISTINCT FROM proposed.proposed_is_tags
 """
+
+
+_SYNC_BOOLEAN_IS_TAGS_SQL = _build_boolean_is_tags_sql(BOOLEAN_IS_TAGS)
 
 CUSTOM_IS_TAGS = [
     "historic",  # artifact, legendary, saga
@@ -730,9 +778,9 @@ class AdminResource:
         """Sync the boolean-backed is: tags (BOOLEAN_IS_TAGS) from raw_card_blob, one-shot.
 
         Rebuilds each card's managed keys as (existing minus managed) plus the keys whose
-        blob boolean is true, touching only rows whose result actually differs -- so list
-        churn (a card entering or leaving the game-changer roster) converges on every
-        import, and unrelated card_is_tags entries are never disturbed.
+        blob-derived expression is true, touching only rows whose result actually differs
+        -- so list churn (a card entering or leaving the game-changer roster) converges on
+        every import, and unrelated card_is_tags entries are never disturbed.
 
         Args:
         ----
@@ -744,7 +792,7 @@ class AdminResource:
 
         """
         with conn.cursor() as cursor:
-            cursor.execute(_SYNC_BOOLEAN_IS_TAGS_SQL, {"tag_map": orjson.dumps(BOOLEAN_IS_TAGS).decode("utf-8")})
+            cursor.execute(_SYNC_BOOLEAN_IS_TAGS_SQL)
             updated_count = cursor.rowcount
         conn.commit()
         if updated_count:

--- a/api/tests/test_upsert_cards.py
+++ b/api/tests/test_upsert_cards.py
@@ -127,6 +127,71 @@ class TestBooleanIsTags:
         assert tags.get("historic") is True
         assert tags.get("reserved") is True
 
+    def test_plain_boolean_lands_as_is_tag(self, api_resource: APIResource) -> None:
+        """story_spotlight -> spotlight, same top-level-boolean shape as reserved/gamechanger."""
+        card = make_raw_card(name="Spotlight Import Test")
+        card["story_spotlight"] = True
+        api_resource.admin._upsert_cards([card])
+        assert _is_tags_for(api_resource, card["id"]).get("spotlight") is True
+
+    def test_promo_types_membership_lands_as_is_tag(self, api_resource: APIResource) -> None:
+        card = make_raw_card(name="FNM Import Test")
+        card["promo_types"] = ["fnm"]
+        api_resource.admin._upsert_cards([card])
+        assert _is_tags_for(api_resource, card["id"]).get("fnm") is True
+
+    def test_promo_types_absent_does_not_set_unrelated_tags(self, api_resource: APIResource) -> None:
+        card = make_raw_card(name="Instore Import Test")
+        card["promo_types"] = ["instore"]
+        api_resource.admin._upsert_cards([card])
+        tags = _is_tags_for(api_resource, card["id"])
+        assert tags.get("instore") is True
+        assert "fnm" not in tags
+        assert "buyabox" not in tags
+
+    def test_partner_keyword_lands_as_is_tag(self, api_resource: APIResource) -> None:
+        card = make_raw_card(name="Partner Import Test")
+        card["keywords"] = ["Partner"]
+        api_resource.admin._upsert_cards([card])
+        assert _is_tags_for(api_resource, card["id"]).get("partner") is True
+
+    def test_partner_with_keyword_alone_does_not_set_partner(self, api_resource: APIResource) -> None:
+        """Verify the sync itself, not the corpus assumption it relies on.
+
+        Real bulk data always pairs "Partner with" alongside a plain "Partner" keyword
+        (verified against the corpus); a card carrying only "Partner with" is not tagged,
+        so `is:partner` stays exact rather than papering over a blob that turns out not to
+        follow the usual pairing.
+        """
+        card = make_raw_card(name="Partner With Alone Test")
+        card["keywords"] = ["Partner with"]
+        api_resource.admin._upsert_cards([card])
+        assert "partner" not in _is_tags_for(api_resource, card["id"])
+
+    def test_etched_finish_lands_as_is_tag(self, api_resource: APIResource) -> None:
+        card = make_raw_card(name="Etched Import Test")
+        card["finishes"] = ["nonfoil", "etched"]
+        api_resource.admin._upsert_cards([card])
+        assert _is_tags_for(api_resource, card["id"]).get("etched") is True
+
+    def test_masterpiece_set_type_lands_as_is_tag(self, api_resource: APIResource) -> None:
+        card = make_raw_card(name="Masterpiece Import Test")
+        card["set_type"] = "masterpiece"
+        api_resource.admin._upsert_cards([card])
+        assert _is_tags_for(api_resource, card["id"]).get("masterpiece") is True
+
+    def test_scryfallpreview_source_lands_as_is_tag(self, api_resource: APIResource) -> None:
+        card = make_raw_card(name="Scryfall Preview Import Test")
+        card["preview"] = {"source": "Scryfall"}
+        api_resource.admin._upsert_cards([card])
+        assert _is_tags_for(api_resource, card["id"]).get("scryfallpreview") is True
+
+    def test_other_preview_source_does_not_set_scryfallpreview(self, api_resource: APIResource) -> None:
+        card = make_raw_card(name="Other Preview Source Test")
+        card["preview"] = {"source": "The Command Zone"}
+        api_resource.admin._upsert_cards([card])
+        assert "scryfallpreview" not in _is_tags_for(api_resource, card["id"])
+
 
 # ---------------------------------------------------------------------------
 # _CardStream counting tests


### PR DESCRIPTION
## Summary
- Part of #985: `BOOLEAN_IS_TAGS` previously only supported "this top-level `raw_card_blob` key is literally `true`" (covering `reserved`/`gamechanger`). Generalized each entry to an arbitrary boolean SQL expression over `raw_card_blob`, evaluated via a correlated `VALUES` subquery in `_sync_boolean_is_tags`.
- This unlocks the same one-shot, per-import sync mechanism for `promo_types`/`keywords`/`finishes` array membership and nested-object lookups (`preview.source`, `set_type`), not just flat booleans.
- Added 21 tags found at or under `masterpiece`'s ~1.8% density in a corpus-wide density survey of every currently-unsupported `is:` tag (posted in #985): `spotlight`, `league`, `glossy`, `giftbox`, `intro_pack`, `convention`, `player_rewards`, `release`, `arena_league`, `gameday`, `buyabox`, `judge_gift`, `instore`, `planeswalker_deck`, `fnm`, `partner`, `media_insert`, `set_promo`, `etched`, `masterpiece`, `scryfallpreview`.
- `foil`/`nonfoil`/`reprint`/`booster`/`hires` (50-97% density) are deliberately excluded, same as before this change — that's a separate, more careful pass.

## Test plan
- [x] Extended `TestBooleanIsTags` in `api/tests/test_upsert_cards.py` with real import-cycle tests for each new mechanism (promo_types membership, keywords membership including the "Partner with" edge case, finishes membership, set_type equality, preview.source equality, plain boolean) — 13 passed against a real testcontainer Postgres
- [x] `make test-unit` — 3247 passed
- [x] `make lint` — clean
- [x] Dry-ran the generated SQL against a full copy of the live corpus (97,812 rows) inside a rolled-back transaction: updates 7,470 rows on first run, 0 on a second immediate run (idempotent)