### PR TITLE
Add is:hybrid/is:phyrexian to BOOLEAN_IS_TAGS via mana_cost_text Regex

### DIFF
--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -90,17 +90,21 @@ IMPORT_LOCK_TIMEOUT = 2
 # total, and it halves the logged parameter too (see log_parameter_max_length in the pg config).
 _UPSERT_PAGE_SIZE = 3_000
 
-# is: values derivable from a single boolean SQL expression against a card's own
-# raw_card_blob, synced in one set-based statement after each import (see
-# _sync_boolean_is_tags) -- no per-tag API sweep, unlike CUSTOM_IS_TAGS below, and no
-# accumulation in the import loop. Each expression must reference the row alias `cards`
-# (it runs inside a correlated subquery, not a plain WHERE) -- adding a tag here is the
-# whole change. Density-gated at ~2% of the corpus (see docs/issues/00985): reserved
-# (1.1%) and gamechanger (0.4%) were the original two; the rest were added after a
-# corpus-wide survey of every is: tag on Scryfall's syntax page found these sitting at
-# or under masterpiece's 1.8%. foil/nonfoil/reprint/booster/hires (50-97%) are
-# deliberately NOT here -- "higher cardinality, memory check first" -- and stay a
-# candidate for a separate, more careful pass.
+# is: values derivable from a single boolean SQL expression against a card's own row,
+# synced in one set-based statement after each import (see _sync_boolean_is_tags) -- no
+# per-tag API sweep, unlike CUSTOM_IS_TAGS below, and no accumulation in the import loop.
+# Each expression must reference the row alias `cards` (it runs inside a correlated
+# subquery, not a plain WHERE) -- adding a tag here is the whole change. Most read
+# `cards.raw_card_blob`; hybrid/phyrexian read `cards.mana_cost_text` instead, per
+# docs/issues/done/00713-is-tag-recovery.md's own reasoning for putting them here rather
+# than in the query-rewrite table: the DSL only does exact-symbol containment, so a
+# rewrite would be a brittle ~15-term OR over an open, growing symbol set. Density-gated
+# at ~2% of the corpus (see docs/issues/00985): reserved (1.1%) and gamechanger (0.4%)
+# were the original two; the rest were added after a corpus-wide survey of every is: tag
+# on Scryfall's syntax page found these sitting at or under masterpiece's 1.8%.
+# foil/nonfoil/reprint/booster/hires (50-97%) are deliberately NOT here -- "higher
+# cardinality, memory check first" -- and stay a candidate for a separate, more careful
+# pass.
 BOOLEAN_IS_TAGS: dict[str, str] = {
     # Alphabetized by key. Expressions read either a plain top-level boolean (reserved,
     # gamechanger, spotlight), promo_types/keywords/finishes array membership, or a
@@ -114,6 +118,7 @@ BOOLEAN_IS_TAGS: dict[str, str] = {
     "gameday": "cards.raw_card_blob->'promo_types' @> '\"gameday\"'",
     "giftbox": "cards.raw_card_blob->'promo_types' @> '\"giftbox\"'",
     "glossy": "cards.raw_card_blob->'promo_types' @> '\"glossy\"'",
+    "hybrid": r"cards.mana_cost_text ~ '\{[WUBRG]/[WUBRG]\}'",
     "instore": "cards.raw_card_blob->'promo_types' @> '\"instore\"'",
     "intro_pack": "cards.raw_card_blob->'promo_types' @> '\"intropack\"'",
     "judge_gift": "cards.raw_card_blob->'promo_types' @> '\"judgegift\"'",
@@ -123,6 +128,7 @@ BOOLEAN_IS_TAGS: dict[str, str] = {
     # "Partner with <name>" cards carry a plain "Partner" keyword alongside it (verified
     # against the corpus), so checking for "Partner" alone already covers both.
     "partner": "cards.raw_card_blob->'keywords' @> '\"Partner\"'",
+    "phyrexian": r"cards.mana_cost_text ~ '\{[WUBRG]/P\}'",
     "planeswalker_deck": "cards.raw_card_blob->'promo_types' @> '\"planeswalkerdeck\"'",
     "player_rewards": "cards.raw_card_blob->'promo_types' @> '\"playerrewards\"'",
     "release": "cards.raw_card_blob->'promo_types' @> '\"release\"'",

--- a/api/tests/test_upsert_cards.py
+++ b/api/tests/test_upsert_cards.py
@@ -134,6 +134,35 @@ class TestBooleanIsTags:
         api_resource.admin._upsert_cards([card])
         assert _is_tags_for(api_resource, card["id"]).get("spotlight") is True
 
+    def test_hybrid_mana_symbol_lands_as_is_tag(self, api_resource: APIResource) -> None:
+        """hybrid/phyrexian read mana_cost_text, not raw_card_blob.
+
+        A regex, not a rewrite, per docs/issues/done/00713-is-tag-recovery.md (an open,
+        growing symbol set makes an enumerated rewrite brittle).
+        """
+        card = make_raw_card(name="Hybrid Mana Import Test")
+        card["mana_cost"] = "{R/G}"
+        api_resource.admin._upsert_cards([card])
+        tags = _is_tags_for(api_resource, card["id"])
+        assert tags.get("hybrid") is True
+        assert "phyrexian" not in tags
+
+    def test_phyrexian_mana_symbol_lands_as_is_tag(self, api_resource: APIResource) -> None:
+        card = make_raw_card(name="Phyrexian Mana Import Test")
+        card["mana_cost"] = "{W/P}"
+        api_resource.admin._upsert_cards([card])
+        tags = _is_tags_for(api_resource, card["id"])
+        assert tags.get("phyrexian") is True
+        assert "hybrid" not in tags
+
+    def test_plain_mana_cost_does_not_set_hybrid_or_phyrexian(self, api_resource: APIResource) -> None:
+        card = make_raw_card(name="Plain Mana Import Test")
+        card["mana_cost"] = "{2}{W}{W}"
+        api_resource.admin._upsert_cards([card])
+        tags = _is_tags_for(api_resource, card["id"])
+        assert "hybrid" not in tags
+        assert "phyrexian" not in tags
+
     def test_promo_types_membership_lands_as_is_tag(self, api_resource: APIResource) -> None:
         card = make_raw_card(name="FNM Import Test")
         card["promo_types"] = ["fnm"]


### PR DESCRIPTION
## Summary
- Follow-up to #1000 (merged): adds `is:hybrid`/`is:phyrexian` to `BOOLEAN_IS_TAGS`, using a regex against `mana_cost_text` instead of `raw_card_blob`.
- `docs/issues/done/00713-is-tag-recovery.md` already reasoned these belong in an "ingest flag," not the query-rewrite table (`_DERIVED_EXPANSIONS`): the DSL only does exact-symbol containment, so a rewrite would need a brittle ~15-term OR over an open, growing symbol set.
- `BOOLEAN_IS_TAGS` expressions aren't restricted to `raw_card_blob` (generalized in #1000), so this fits the exact same sync mechanism, just reading a different column.
- Density: 1,194 cards (1.2%) hybrid, 139 (0.14%) phyrexian, no overlap — same cost tier as everything landed in #1000.

## Test plan
- [x] Added 3 tests to `TestBooleanIsTags` (hybrid lands, phyrexian lands, plain mana cost sets neither) — 16 passed total against a real testcontainer Postgres
- [x] `make test-unit` — 3250 passed
- [x] `make lint` — clean
- [x] Dry-ran the generated SQL against the full live corpus (97,812 rows) in a rolled-back transaction: 1,333 rows updated (1,194 + 139, confirming no overlap)