### PR TITLE
Add is:bikeland/surveilland/tricycleland/pathway via otag: Rewrite

### DIFF
--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -182,7 +182,6 @@ _SYNC_BOOLEAN_IS_TAGS_SQL = _build_boolean_is_tags_sql(BOOLEAN_IS_TAGS)
 
 CUSTOM_IS_TAGS = [
     "historic",  # artifact, legendary, saga
-    "pathway",  # land and name contains pathway
     "permanent",  # ...
     "reprint",
     "spell",  # ...

--- a/api/parsing/rewrite.py
+++ b/api/parsing/rewrite.py
@@ -85,6 +85,7 @@ _DERIVED_EXPANSIONS: dict[tuple[str, str], str] = {
     # enters-tapped-gain-life cycles Scryfall's list lacks -- with counts
     # last validated against api.scryfall.com on 2026-08-07.
     ("is", "battleland"): "otag:cycle-tangoland",  # 10
+    ("is", "bikeland"): "otag:cycle-dual-cycling-land",  # 10, exact
     ("is", "bondland"): "otag:cycle-bondland",  # 10
     ("is", "bounceland"): "otag:bounceland",  # 17, exact
     ("is", "canopyland"): "otag:cycle-horizon-land",  # 6, exact
@@ -97,6 +98,7 @@ _DERIVED_EXPANSIONS: dict[tuple[str, str], str] = {
     ("is", "gainland"): "otag:gainland",  # 42, self-updating superset of Scryfall's 15
     ("is", "manland"): "t:land o:become o:creature o:/still a.* land/",
     ("is", "painland"): "otag:cycle-painland",  # 10, exact
+    ("is", "pathway"): "otag:cycle-pathway",  # 10, exact
     ("is", "scryland"): "otag:cycle-block-ths-scry-land",  # 10, exact
     # shadowland/snarl: the reveal-or-tapped lands that reveal a BASIC LAND
     # TYPE card -- the basic-type regex is what separates them from the
@@ -111,7 +113,11 @@ _DERIVED_EXPANSIONS: dict[tuple[str, str], str] = {
         "is",
         "storageland",
     ): "otag:cycle-fem-storage-land or otag:cycle-mmq-storage-land or otag:cycle-tsp-storage-land",  # 15 vs 12
+    ("is", "surveilland"): "otag:cycle-dual-surveil-land",  # 10, exact
     ("is", "tangoland"): "otag:cycle-tangoland",  # 10; Scryfall accepts both names
+    # Same 10 cards as is:triome below (verified by name) -- another case of Scryfall
+    # accepting two names for one cycle, like tangoland/battleland above.
+    ("is", "tricycleland"): "otag:tricycle-land",  # 10, exact
     ("is", "triland"): "otag:cycle-ala-shardland or otag:cycle-ktk-wedgeland",  # 10, name-verified
     ("is", "triome"): "otag:cycle-iko-triome or otag:cycle-snc-triland",  # 10, name-verified
     # ── Non-land derivables ──────────────────────────────────────────────

--- a/api/parsing/tests/test_rewrite.py
+++ b/api/parsing/tests/test_rewrite.py
@@ -66,6 +66,10 @@ EQUIVALENCES = [
     ("is:shadowland", "t:land o:/reveal an? (Plains|Island|Swamp|Mountain|Forest)/"),
     ("is:snarl", "t:land o:/reveal an? (Plains|Island|Swamp|Mountain|Forest)/"),
     ("is:modal", "otag:modal"),
+    ("is:bikeland", "otag:cycle-dual-cycling-land"),
+    ("is:surveilland", "otag:cycle-dual-surveil-land"),
+    ("is:tricycleland", "otag:tricycle-land"),
+    ("is:pathway", "otag:cycle-pathway"),
     # composes under negation and inside compounds
     ("-frame:old", "-(frame:1993 or frame:1997)"),
     ("t:goblin frame:modern", "t:goblin frame:2003"),

--- a/client/query_sampler.py
+++ b/client/query_sampler.py
@@ -167,7 +167,7 @@ STATIC_VALUES: dict[str, list[str]] = {
     # Anything outside this set parses but falls through to a `card_is_tags` lookup, and that column
     # carries only the two booleans the import syncs from the bulk blob — `is:reserved` is the one to
     # reach for. Values with no key there still match zero cards, as `is:reprint`, `is:token` and
-    # `is:spell` did in the old load-generator list. All 44 are kept rather
+    # `is:spell` did in the old load-generator list. All 48 are kept rather
     # than a token few: the family's share of traffic is set by its weight, not by how many values
     # it holds, and each expands to a genuinely different shape — layout lookups, type unions, an
     # oracle-text heuristic, a numeric conjunction.
@@ -175,6 +175,7 @@ STATIC_VALUES: dict[str, list[str]] = {
         "is:adventure",
         "is:battleland",
         "is:bear",
+        "is:bikeland",
         "is:bondland",
         "is:bounceland",
         "is:canopyland",
@@ -203,6 +204,7 @@ STATIC_VALUES: dict[str, list[str]] = {
         "is:outlaw",
         "is:party",
         "is:painland",
+        "is:pathway",
         "is:permanent",
         "is:scryland",
         "is:shadowland",
@@ -211,8 +213,10 @@ STATIC_VALUES: dict[str, list[str]] = {
         "is:snarl",
         "is:split",
         "is:storageland",
+        "is:surveilland",
         "is:tangoland",
         "is:transform",
+        "is:tricycleland",
         "is:triland",
         "is:triome",
         "is:vanilla",


### PR DESCRIPTION
## Summary
- Part of #985 bucket B: adds `is:bikeland`, `is:surveilland`, `is:tricycleland`, `is:pathway` to `_DERIVED_EXPANSIONS`, each resolving to an `otag:` bulk-tag lookup — the same mechanism as their already-supported land-cycle siblings (`bondland`, `checkland`, `fetchland`, etc.).
- `is:tricycleland` resolves to the identical 10 cards as the existing `is:triome` alias (5 Ikoria + 5 Streets of New Capenna triomes, verified by name) — Scryfall just accepts two names for the same cycle, same as `tangoland`/`battleland` already noted in this file.
- Removed the now-stale `"pathway"` entry from `CUSTOM_IS_TAGS` (an unimplemented wishlist stub) since it's properly handled here now.
- Synced `client/query_sampler.py`'s separately-maintained `is:` tag list — it can't import `api/` (ships in the client image), so `test_is_tags_match_the_rewrite_table` asserts the two stay in sync, and caught the omission.

## Test plan
- [x] Added 4 cases to `EQUIVALENCES` in `api/parsing/tests/test_rewrite.py` — both parsers, AST + generated-SQL equivalence checks all pass
- [x] `make test-unit` — 3259 passed
- [x] `make lint` — clean
- [x] Live-verified each `otag:` value against a running instance: `cycle-dual-cycling-land` (10), `cycle-dual-surveil-land` (10), `tricycle-land` (10), `cycle-pathway` (10)