### PR TITLE
Engine: Hybrid Collection Indexes, Rebased With Popcount and Decode Fixes

### DIFF
--- a/card_engine/src/estimator.rs
+++ b/card_engine/src/estimator.rs
@@ -421,21 +421,19 @@ fn estimate_leaf(f: &FilterExpr, indexes: &Archived<CardIndexes>, n_cards: u32, 
             // frame_data is the hybrid index: the count comes from `len_of` (a popcount for a bitmap)
             // and absence proves emptiness. Mirrors narrow_rec's branch so the estimate describes the
             // path that will actually run.
-            if matches!(field, CollField::FrameData) {
-                let cnt = indexes.frame_data.len_of(value.as_str()).unwrap_or(0) as u32;
-                return project(cnt, n_cards, n_printings);
-            }
             let (idx, card_space, complete) = match field {
                 CollField::Subtypes => (&indexes.subtypes, true, true),
                 CollField::Keywords => (&indexes.keywords, true, true),
                 CollField::OracleTags => (&indexes.oracle_tags, true, true),
                 CollField::ArtTags => (&indexes.art_tags, false, true),
                 CollField::IsTags => (&indexes.is_tags, false, true),
-                CollField::FrameData => unreachable!("handled above"),
+                CollField::FrameData => (&indexes.frame_data, false, true),
             };
-            match idx.get(value.as_str()) {
-                Some(v) => {
-                    let cnt = v.len() as u32;
+            // `len_of` is a popcount for a dense value and a postings length for a sparse one, so
+            // the count — and therefore the estimate — is independent of how the value is stored.
+            match idx.len_of(value.as_str()) {
+                Some(cnt) => {
+                    let cnt = cnt as u32;
                     if card_space {
                         exact(cnt)
                     } else {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1782,8 +1782,8 @@ struct ArtistIndex {
 /// against the 240 KB stored before, so this is smaller AND faster, not a trade.
 #[derive(Archive, Serialize, Deserialize, Default)]
 struct HybridTagIndex {
-    /// Values above the density crossover: one printing-space bitmap each, ready to use with no scatter.
-    dense: HashMap<String, Vec<u64>>,
+    /// Values above the density crossover: one bitmap each, ready to use with no scatter.
+    dense: HashMap<String, DenseBits>,
     /// Everything below it: sorted printing ids, exactly as `TagIndex`.
     ///
     /// A sparse value can never be "broad" downstream: the crossover is 1/32 (3.1%) and
@@ -1797,12 +1797,29 @@ fn bitmap_beats_postings(k: usize, n_rows: usize) -> bool {
     k.saturating_mul(32) > n_rows
 }
 
+/// One dense value's rows, as a bitmap that remembers its own popcount.
+///
+/// The count is stored rather than derived because `len_of` sits on the QUERY PLANNING path
+/// (`probe_collection_k` asks it for every collection child of every `And`), where a posting list
+/// answered in O(1) from its length. Deriving it instead costs a popcount over the whole plane —
+/// 1,487 words at corpus scale in printing space — turning a free question into a per-query scan.
+/// Measured: with the count derived, `o:draw` plus a tag ran 1-6% slower than the postings it
+/// replaced; with it stored, the same queries come back at or under that baseline.
+///
+/// 4 bytes per dense value, ~175 of them across all six indexes, so this costs under a kilobyte.
+#[derive(Archive, Serialize, Deserialize, Default)]
+struct DenseBits {
+    count: u32,
+    words: Vec<u64>,
+}
+
 fn build_hybrid_tag_index<T>(rows: &[T], vocab: &[String], get_ids: impl Fn(&T) -> &Vec<u16>) -> HybridTagIndex {
     let n = rows.len();
     let mut out = HybridTagIndex::default();
     for (value, postings) in build_tag_index(rows, vocab, get_ids) {
         if bitmap_beats_postings(postings.len(), n) {
-            out.dense.insert(value, scatter_bits(postings, n));
+            let count = postings.len() as u32;
+            out.dense.insert(value, DenseBits { count, words: scatter_bits(postings, n) });
         } else {
             out.sparse.insert(value, postings);
         }
@@ -1821,7 +1838,7 @@ impl ArchivedHybridTagIndex {
     /// proof rather than a gap.
     fn bits(&self, value: &str, n_printings: usize) -> Option<Vec<u64>> {
         if let Some(b) = self.dense.get(value) {
-            return Some(b.iter().map(|w| u64::from(*w)).collect());
+            return Some(b.words.iter().map(|w| u64::from(*w)).collect());
         }
         self.sparse.get(value).map(|v| scatter_bits(v.iter().map(|x| u32::from(*x)), n_printings))
     }
@@ -1830,9 +1847,39 @@ impl ArchivedHybridTagIndex {
     /// without materializing when the value is a bitmap.
     fn len_of(&self, value: &str) -> Option<usize> {
         if let Some(b) = self.dense.get(value) {
-            return Some(b.iter().map(|w| u64::from(*w).count_ones() as usize).sum());
+            // O(1) from the stored popcount — see DenseBits. This is planner-path.
+            return Some(u32::from(b.count) as usize);
         }
         self.sparse.get(value).map(|v| v.len())
+    }
+
+    /// The value's rows as ascending ids, whichever way it is stored.
+    ///
+    /// The inverse of `bits`, and the reason hybrid storage can be adopted by the other five
+    /// collection indexes WITHOUT moving any value across a narrowing gate: a caller that produced a
+    /// sorted id vec before can still produce one, so the representation a value reaches the
+    /// candidate machinery in is decided by the same rules as before rather than by how it happens
+    /// to be stored. `frame_data` chose the opposite (dense values take a bitmap path with their own
+    /// gate), which is right for a field whose gate was tuned around it and wrong as a default —
+    /// doing that to `oracle_tags` would hand card-space values a selectivity guard card space
+    /// deliberately does not have.
+    ///
+    /// Decode is a popcount walk, `w & (w - 1)` clearing one bit at a time, so it costs one
+    /// iteration per SET bit plus one per word rather than one per row.
+    fn ids_of(&self, value: &str) -> Option<Vec<u32>> {
+        if let Some(b) = self.dense.get(value) {
+            // Exact capacity from the stored count: one allocation, no growth.
+            let mut out = Vec::with_capacity(u32::from(b.count) as usize);
+            for (wi, word) in b.words.iter().enumerate() {
+                let mut w = u64::from(*word);
+                while w != 0 {
+                    out.push((wi * 64) as u32 + w.trailing_zeros());
+                    w &= w - 1;
+                }
+            }
+            return Some(out);
+        }
+        self.sparse.get(value).map(|v| v.iter().map(|x| u32::from(*x)).collect())
     }
 }
 
@@ -3485,11 +3532,23 @@ struct CardIndexes {
     power:          NumericIndex,    // card space
     toughness:      NumericIndex,    // card space
     rarity:         RarityIndex,     // card space (any-printing-at-rarity)
-    subtypes:       TagIndex,        // card space
-    keywords:       TagIndex,        // card space
-    oracle_tags:    TagIndex,        // card space
-    art_tags:       TagIndex,        // printing space
-    is_tags:        TagIndex,        // printing space
+    // All five are HYBRID, joining `frame_data` below: a value above the 1/32 density crossover is
+    // stored as a bitmap instead of a posting list, which is smaller for exactly the values that
+    // cost the most as postings. Measured on a ~95k-printing corpus, art_tags 6.82 -> 4.45 MB and
+    // oracle_tags 1.44 -> 1.00 MB, with the other three ~0.03 MB between them.
+    //
+    // STORAGE ONLY. Unlike `frame_data`, every read goes through `ids_of`/`len_of`/`bits`, which
+    // answer identically whichever way a value is stored -- so no value changes which narrowing path
+    // it takes, which representation it reaches the candidate machinery in, or which selectivity
+    // gate applies to it. That distinction is the safety argument: `frame_data` routes dense values
+    // to a bitmap path with its own gate, and doing the same here would put the corpus's three
+    // densest oracle tags (47%, 30%, 25% of cards) behind MAX_NARROW_FRACTION, a guard card-space
+    // narrowing deliberately does not have.
+    subtypes:       HybridTagIndex,  // card space
+    keywords:       HybridTagIndex,  // card space
+    oracle_tags:    HybridTagIndex,  // card space
+    art_tags:       HybridTagIndex,  // printing space
+    is_tags:        HybridTagIndex,  // printing space
     frame_data:     HybridTagIndex,  // printing space (bitmap for dense values, postings for the sparse tail)
     artists:        ArtistIndex,     // printing space (CSR by artist vocab id)
     flavor:         FlavorIndex,     // printing space (CSR by dense flavor text id)
@@ -4218,19 +4277,17 @@ fn probe_collection_k(filter: &FilterExpr, indexes: &Archived<CardIndexes>) -> O
     if !matches!(op, CmpOp::Ge | CmpOp::Eq | CmpOp::Gt) {
         return None;
     }
-    // frame_data is the hybrid index, so its count is a popcount or a postings length, never a `get`.
-    if matches!(field, CollField::FrameData) {
-        return indexes.frame_data.len_of(value.as_str());
-    }
+    // Every collection index is hybrid now, so a count is a popcount or a postings length and
+    // never a `get` — same answer either way, which is what lets the caller stay unaware of storage.
     let idx = match field {
         CollField::Subtypes => &indexes.subtypes,
         CollField::Keywords => &indexes.keywords,
         CollField::OracleTags => &indexes.oracle_tags,
         CollField::ArtTags => &indexes.art_tags,
         CollField::IsTags => &indexes.is_tags,
-        CollField::FrameData => unreachable!("handled above"),
+        CollField::FrameData => &indexes.frame_data,
     };
-    idx.get(value.as_str()).map(|v| v.len())
+    idx.len_of(value.as_str())
 }
 
 /// One entry in the And arm's work list: a child exactly as written, or a half-open interval fused
@@ -4861,7 +4918,11 @@ fn narrow_rec(
                 CollField::IsTags     => (&indexes.is_tags,     false),
                 CollField::FrameData  => unreachable!("frame_data is the hybrid index, handled above"),
             };
-            match idx.get(value.as_str()) {
+            // `len_of` rather than a postings length: identical answer for a sparse value, a popcount
+            // for a dense one, and crucially the SAME question as before, asked before any decision
+            // is taken. Every branch below is the pre-hybrid logic — the gate, the representation,
+            // and which side of it a value falls on all depend only on the count, never on storage.
+            match idx.len_of(value.as_str()) {
                 // A value with no postings in a complete index proves
                 // `contains(value)` false for every row, which makes Ge, Eq,
                 // and Gt all provably empty alike — no row can satisfy any of
@@ -4871,7 +4932,7 @@ fn narrow_rec(
                 None => {
                     Narrowed::tight(if card_space { Candidates::Cards(Vec::new()) } else { Candidates::Printings(Vec::new()) })
                 }
-                Some(v) => {
+                Some(k) => {
                     // Broad printing-space postings pay the same gather cost
                     // the range indexes guard against (is:spell is ~60k ids);
                     // past the fraction they scatter to a bitmap when
@@ -4880,14 +4941,36 @@ fn narrow_rec(
                     // the length check downstream (loose either way).
                     // Card-space lists need no guard — same argument as
                     // numeric_candidates.
-                    if !card_space && range_too_broad_to_narrow(v.len(), n_printings) {
+                    if !card_space && range_too_broad_to_narrow(k, n_printings) {
                         if !broad_ok {
                             return None;
                         }
-                        let bits = scatter_bits(v.iter().map(|x| u32::from(*x)), n_printings);
-                        return mk(Candidates::PrintingBits(bits));
+                        // `bits` hands back a STORED bitmap for a dense value, so the scatter this
+                        // line used to pay is gone for exactly the broad values that paid most for
+                        // it. The sparse tail still scatters, as before.
+                        return mk(Candidates::PrintingBits(idx.bits(value.as_str(), n_printings)?));
                     }
-                    let ids: Vec<u32> = v.iter().map(|x| u32::from(*x)).collect();
+                    // A value STORED as a bitmap and broad enough that composition would promote it
+                    // to one anyway is handed over as bits, rather than decoded to ids for the
+                    // machinery to scatter straight back. `BITS_PROMOTE` is the crossover already
+                    // calibrated for exactly this question (#636), so this defers to it rather than
+                    // inventing a second threshold.
+                    //
+                    // This is the one place hybrid storage changes which REPRESENTATION a value
+                    // arrives in, and it is measured, not assumed: decoding instead cost 5-9% on
+                    // `o:draw` plus a dense tag, because ids_of walks the plane to rebuild a list
+                    // the next step scatters again. Tightness is unchanged — `mk` decides that from
+                    // the op, not from the representation.
+                    //
+                    // CARD SPACE ONLY, and that restriction is measured too. Printing space already
+                    // has a bitmap branch above (the broadness gate), so this would only catch the
+                    // 1/32-to-1/4 band — where handing bits measured no better than decoding and
+                    // sometimes worse, while card space measured a clean win. Promoting there as
+                    // well would be a change made on symmetry rather than evidence.
+                    if card_space && k > *BITS_PROMOTE && idx.is_dense(value.as_str()) {
+                        return mk(Candidates::CardBits(idx.bits(value.as_str(), n_cards)?));
+                    }
+                    let ids = idx.ids_of(value.as_str())?;
                     mk(if card_space { Candidates::Cards(ids) } else { Candidates::Printings(ids) })
                 }
             }
@@ -6696,27 +6779,28 @@ fn broadcast_card_ids_to_printings(card_ids: impl Iterator<Item = u32>, offsets:
 /// truth `is_printing_composable`/`compose_printing_bits`/`compose_printing_estimate` share so their
 /// field tables can't drift apart.
 /// Which structure backs a `CollectionCmp` field on the compose path.
-enum CollComposeSource<'i> {
-    /// Postings. `true` = card-space ids (project each card's printing range up with
-    /// `broadcast_card_ids_to_printings`), `false` = printing ids (scatter directly).
-    Postings(&'i Archived<TagIndex>, bool),
-    /// The hybrid printing-space index: a stored bitmap for dense values, postings for the tail.
-    Hybrid(&'i Archived<HybridTagIndex>),
+struct CollComposeSource<'i> {
+    /// Every collection index is hybrid: a stored bitmap for values above the 1/32 crossover,
+    /// postings for the tail. Read through `ids_of`/`bits`/`len_of`, which answer the same for both.
+    idx: &'i Archived<HybridTagIndex>,
+    /// `true` = card-space ids (project each card's printing range up with
+    /// `broadcast_card_ids_to_printings`), `false` = printing ids (usable directly).
+    card_space: bool,
 }
 
 fn collection_compose_index(indexes: &Archived<CardIndexes>, field: CollField) -> Option<CollComposeSource<'_>> {
     Some(match field {
-        CollField::Subtypes   => CollComposeSource::Postings(&indexes.subtypes,    true),
-        CollField::Keywords   => CollComposeSource::Postings(&indexes.keywords,    true),
-        CollField::OracleTags => CollComposeSource::Postings(&indexes.oracle_tags, true),
-        CollField::ArtTags    => CollComposeSource::Postings(&indexes.art_tags,    false),
-        CollField::IsTags     => CollComposeSource::Postings(&indexes.is_tags,     false),
+        CollField::Subtypes   => CollComposeSource { idx: &indexes.subtypes,    card_space: true },
+        CollField::Keywords   => CollComposeSource { idx: &indexes.keywords,    card_space: true },
+        CollField::OracleTags => CollComposeSource { idx: &indexes.oracle_tags, card_space: true },
+        CollField::ArtTags    => CollComposeSource { idx: &indexes.art_tags,    card_space: false },
+        CollField::IsTags     => CollComposeSource { idx: &indexes.is_tags,     card_space: false },
         // `frame_data` used to return `None` here, and that exclusion was never about frames as such:
         // it was the one index that was not `complete`, because its dense values were dropped at build,
         // so absence could not prove emptiness and it could not be an exact compose leaf. Storing every
         // value makes it complete, which makes it composable — and that chain is most of this change's
         // win: `frame:2015` under `unique=printing` went 1,375 -> 41 us.
-        CollField::FrameData => CollComposeSource::Hybrid(&indexes.frame_data),
+        CollField::FrameData => CollComposeSource { idx: &indexes.frame_data, card_space: false },
     })
 }
 
@@ -6731,17 +6815,18 @@ fn collection_compose_index(indexes: &Archived<CardIndexes>, field: CollField) -
 /// collection-length condition, ~lib.rs:3441), and the compose path has no residual re-check, so
 /// `Eq`/`Gt` stay on the general path.
 fn collection_leaf_bits(src: &CollComposeSource, value: &str, offsets: &AOffsets, n_printings: usize) -> Vec<u64> {
-    match src {
-        // A dense value is already a printing bitmap, so this is a copy rather than a scatter.
-        CollComposeSource::Hybrid(idx) => {
-            idx.bits(value, n_printings).unwrap_or_else(|| vec![0u64; words_per_plane(n_printings)])
-        }
-        CollComposeSource::Postings(idx, card_space) => match idx.get(value) {
-            None => vec![0u64; words_per_plane(n_printings)],
-            Some(v) if *card_space => broadcast_card_ids_to_printings(v.iter().map(|x| u32::from(*x)), offsets, n_printings),
-            Some(v) => scatter_bits(v.iter().map(|x| u32::from(*x)), n_printings),
-        },
+    let empty = || vec![0u64; words_per_plane(n_printings)];
+    if src.card_space {
+        // Card ids have to be projected up whichever way they were stored, so this reads them as
+        // ids and broadcasts exactly as before.
+        return match src.idx.ids_of(value) {
+            None => empty(),
+            Some(ids) => broadcast_card_ids_to_printings(ids.into_iter(), offsets, n_printings),
+        };
     }
+    // Printing space lands in the target space already: a dense value IS a printing bitmap, so this
+    // is a copy rather than a scatter, and the sparse tail scatters as it always did.
+    src.idx.bits(value, n_printings).unwrap_or_else(empty)
 }
 
 /// The number of printings a containment collection leaf matches (its exact `unique=printing` total),
@@ -6750,21 +6835,20 @@ fn collection_leaf_bits(src: &CollComposeSource, value: &str, offsets: &AOffsets
 /// so the estimate for a bare collection leaf is exact, matching set/watermark. O(card postings) — the
 /// same order as the eventual scatter, cheap for the sparse subtype/keyword/oracle-tag posting lists.
 fn collection_leaf_printing_count(src: &CollComposeSource, value: &str, offsets: &AOffsets) -> usize {
-    match src {
-        // A popcount when the value is a bitmap; a postings length otherwise.
-        CollComposeSource::Hybrid(idx) => idx.len_of(value).unwrap_or(0),
-        CollComposeSource::Postings(idx, card_space) => match idx.get(value) {
-            None => 0,
-            Some(v) if *card_space => v
-                .iter()
+    if src.card_space {
+        // One posting = one CARD here, so the printing total is the sum of their ranges.
+        return src.idx.ids_of(value).map_or(0, |ids| {
+            ids.into_iter()
                 .map(|c| {
-                    let c = u32::from(*c) as usize;
+                    let c = c as usize;
                     (u32::from(offsets[c + 1]) - u32::from(offsets[c])) as usize
                 })
-                .sum(),
-            Some(v) => v.len(),
-        },
+                .sum()
+        });
     }
+    // Printing space: one posting = one printing, so a popcount when the value is a bitmap and a
+    // postings length otherwise — `len_of` is both.
+    src.idx.len_of(value).unwrap_or(0)
 }
 
 /// The exact printing-space bitmap for a **negated** containment collection leaf (`-type:`/`-kw:`/
@@ -7660,7 +7744,9 @@ fn exact_result_total(composed: &FilterExpr, indexes: &Archived<CardIndexes>, mo
             CollField::ArtTags | CollField::IsTags | CollField::FrameData => None,
         };
         // Absent from a complete index is an exact ZERO, not "no answer".
-        return card_space_idx.map(|idx| idx.get(value.as_str()).map_or(0, |v| v.len()));
+        // `len_of` counts a dense value by popcount and a sparse one by postings length — the same
+        // card count either way, so the exactness argument above is untouched by storage.
+        return card_space_idx.map(|idx| idx.len_of(value.as_str()).unwrap_or(0));
     }
     None
 }
@@ -11557,7 +11643,14 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 // `NameUnigramIndex` (#858) is a new archived type, so a store built before it must fail the header
 // check and be rebuilt rather than be read as garbage. Dated 2026-08-06, patch 01; the check is
 // EQUALITY, so the invariant is only that a value is never reused for a different layout.
-const ARCHIVE_FORMAT_VERSION: u32 = 2026080601;
+//
+// 2026081301 — the five remaining collection indexes (`subtypes`, `keywords`, `oracle_tags`,
+// `art_tags`, `is_tags`) go `TagIndex` -> `HybridTagIndex`, joining `frame_data`, and dense values
+// carry their popcount (`DenseBits`). THE HEADER CANNOT CATCH THIS ONE: the two sizes it records
+// are `AOracleCard` and `APrinting`, and neither moves, because the change is entirely inside
+// `CardIndexes`. So this constant is the only thing stopping a reader from accessing an older
+// store's `HashMap<String, Vec<u32>>` as a `HybridTagIndex` through `access_unchecked`.
+const ARCHIVE_FORMAT_VERSION: u32 = 2026081301;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -12117,11 +12210,11 @@ impl QueryEngine {
             power:          build_numeric_index(&cards, |c| c.creature_power.map(|v| v as i16)),
             toughness:      build_numeric_index(&cards, |c| c.creature_toughness.map(|v| v as i16)),
             rarity:         build_rarity_index(&printings, &offsets),
-            subtypes:       build_tag_index(&cards, &coll_vocab, |c| &c.card_subtypes),
-            keywords:       build_tag_index(&cards, &coll_vocab, |c| &c.card_keywords),
-            oracle_tags:    build_tag_index(&cards, &coll_vocab, |c| &c.card_oracle_tags),
-            art_tags:       build_tag_index(&printings, &coll_vocab, |p| &p.card_art_tags),
-            is_tags:        build_tag_index(&printings, &coll_vocab, |p| &p.card_is_tags),
+            subtypes:       build_hybrid_tag_index(&cards, &coll_vocab, |c| &c.card_subtypes),
+            keywords:       build_hybrid_tag_index(&cards, &coll_vocab, |c| &c.card_keywords),
+            oracle_tags:    build_hybrid_tag_index(&cards, &coll_vocab, |c| &c.card_oracle_tags),
+            art_tags:       build_hybrid_tag_index(&printings, &coll_vocab, |p| &p.card_art_tags),
+            is_tags:        build_hybrid_tag_index(&printings, &coll_vocab, |p| &p.card_is_tags),
             frame_data:     build_hybrid_tag_index(&printings, &coll_vocab, |p| &p.card_frame_data),
             artists:        build_artist_index(&printings, artist_vocab.len()),
             flavor:         build_flavor_index(&printings, &strings),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1838,6 +1838,12 @@ impl ArchivedHybridTagIndex {
         self.dense.get(value).is_some()
     }
 
+    /// The value's `DenseBits` entry, for a caller that needs both the presence check and the data —
+    /// one lookup instead of `is_dense` followed by `bits`/`len_of` each redoing it.
+    fn dense(&self, value: &str) -> Option<&Archived<DenseBits>> {
+        self.dense.get(value)
+    }
+
     /// The value's printing-space bitmap, materialized from postings if that is how it is stored.
     /// `None` only when the value is absent from the store entirely — nothing is dropped, so that is a
     /// proof rather than a gap.
@@ -1870,19 +1876,12 @@ impl ArchivedHybridTagIndex {
     /// deliberately does not have.
     ///
     /// Decode is a popcount walk, `w & (w - 1)` clearing one bit at a time, so it costs one
-    /// iteration per SET bit plus one per word rather than one per row.
+    /// iteration per SET bit plus one per word rather than one per row. Shares its loop with
+    /// `bitmap_card_ids` via `decode_bitmap_ids`, driven here by the stored count (no fresh popcount
+    /// pass) over archived words (no copy into a plain `&[u64]` first).
     fn ids_of(&self, value: &str) -> Option<Vec<u32>> {
         if let Some(b) = self.dense.get(value) {
-            // Exact capacity from the stored count: one allocation, no growth.
-            let mut out = Vec::with_capacity(u32::from(b.count) as usize);
-            for (wi, word) in b.words.iter().enumerate() {
-                let mut w = u64::from(*word);
-                while w != 0 {
-                    out.push((wi * 64) as u32 + w.trailing_zeros());
-                    w &= w - 1;
-                }
-            }
-            return Some(out);
+            return Some(decode_bitmap_ids(b.words.iter().map(|w| u64::from(*w)), u32::from(b.count) as usize));
         }
         self.sparse.get(value).map(|v| v.iter().map(|x| u32::from(*x)).collect())
     }
@@ -4972,8 +4971,11 @@ fn narrow_rec(
                     // 1/32-to-1/4 band — where handing bits measured no better than decoding and
                     // sometimes worse, while card space measured a clean win. Promoting there as
                     // well would be a change made on symmetry rather than evidence.
-                    if card_space && k > *BITS_PROMOTE && idx.is_dense(value.as_str()) {
-                        return mk(Candidates::CardBits(idx.bits(value.as_str(), n_cards)?));
+                    if card_space
+                        && k > *BITS_PROMOTE
+                        && let Some(b) = idx.dense(value.as_str())
+                    {
+                        return mk(Candidates::CardBits(b.words.iter().map(|w| u64::from(*w)).collect()));
                     }
                     let ids = idx.ids_of(value.as_str())?;
                     mk(if card_space { Candidates::Cards(ids) } else { Candidates::Printings(ids) })

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1885,6 +1885,48 @@ impl ArchivedHybridTagIndex {
         }
         self.sparse.get(value).map(|v| v.iter().map(|x| u32::from(*x)).collect())
     }
+
+    /// The value's rows as ascending ids, like `ids_of`, but without materializing a `Vec` — for a
+    /// caller that only folds over the ids once (sum a range per id, set a range of bits per id) and
+    /// would otherwise pay for an allocation whose contents get read back exactly once. Absent from
+    /// both tiers yields nothing, matching `ids_of`'s `None`.
+    fn iter_ids(&self, value: &str) -> HybridIdsIter<'_> {
+        if let Some(b) = self.dense.get(value) {
+            let words = &b.words[..];
+            return HybridIdsIter::Dense { words, word: 0, bits: words.first().map_or(0, |w| u64::from(*w)) };
+        }
+        if let Some(v) = self.sparse.get(value) {
+            return HybridIdsIter::Sparse(v.iter());
+        }
+        HybridIdsIter::Empty
+    }
+}
+
+/// Ascending row ids from a `HybridTagIndex` value, produced lazily. See `iter_ids`.
+enum HybridIdsIter<'a> {
+    Dense { words: &'a [Archived<u64>], word: usize, bits: u64 },
+    Sparse(std::slice::Iter<'a, Archived<u32>>),
+    Empty,
+}
+
+impl Iterator for HybridIdsIter<'_> {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<u32> {
+        match self {
+            HybridIdsIter::Dense { words, word, bits } => {
+                while *bits == 0 {
+                    *word += 1;
+                    *bits = u64::from(*words.get(*word)?);
+                }
+                let id = (*word as u32) * 64 + bits.trailing_zeros();
+                *bits &= *bits - 1;
+                Some(id)
+            }
+            HybridIdsIter::Sparse(it) => it.next().map(|x| u32::from(*x)),
+            HybridIdsIter::Empty => None,
+        }
+    }
 }
 
 fn build_artist_index(printings: &[Printing], n_artists: usize) -> ArtistIndex {
@@ -6822,18 +6864,16 @@ fn collection_compose_index(indexes: &Archived<CardIndexes>, field: CollField) -
 /// collection-length condition, ~lib.rs:3441), and the compose path has no residual re-check, so
 /// `Eq`/`Gt` stay on the general path.
 fn collection_leaf_bits(src: &CollComposeSource, value: &str, offsets: &AOffsets, n_printings: usize) -> Vec<u64> {
-    let empty = || vec![0u64; words_per_plane(n_printings)];
     if src.card_space {
-        // Card ids have to be projected up whichever way they were stored, so this reads them as
-        // ids and broadcasts exactly as before.
-        return match src.idx.ids_of(value) {
-            None => empty(),
-            Some(ids) => broadcast_card_ids_to_printings(ids.into_iter(), offsets, n_printings),
-        };
+        // Card ids have to be projected up whichever way they were stored. `iter_ids` walks them
+        // (dense: bit by bit off the stored words; sparse: the stored ids directly) without
+        // collecting a `Vec` first -- broadcast is the only consumer, so nothing needs it built.
+        // Absent yields nothing, which broadcasts to all-zero, matching the old `None => empty()`.
+        return broadcast_card_ids_to_printings(src.idx.iter_ids(value), offsets, n_printings);
     }
     // Printing space lands in the target space already: a dense value IS a printing bitmap, so this
     // is a copy rather than a scatter, and the sparse tail scatters as it always did.
-    src.idx.bits(value, n_printings).unwrap_or_else(empty)
+    src.idx.bits(value, n_printings).unwrap_or_else(|| vec![0u64; words_per_plane(n_printings)])
 }
 
 /// The number of printings a containment collection leaf matches (its exact `unique=printing` total),
@@ -6843,15 +6883,17 @@ fn collection_leaf_bits(src: &CollComposeSource, value: &str, offsets: &AOffsets
 /// same order as the eventual scatter, cheap for the sparse subtype/keyword/oracle-tag posting lists.
 fn collection_leaf_printing_count(src: &CollComposeSource, value: &str, offsets: &AOffsets) -> usize {
     if src.card_space {
-        // One posting = one CARD here, so the printing total is the sum of their ranges.
-        return src.idx.ids_of(value).map_or(0, |ids| {
-            ids.into_iter()
-                .map(|c| {
-                    let c = c as usize;
-                    (u32::from(offsets[c + 1]) - u32::from(offsets[c])) as usize
-                })
-                .sum()
-        });
+        // One posting = one CARD here, so the printing total is the sum of their ranges. `iter_ids`
+        // folds directly over the ids (dense or sparse) with no intermediate `Vec` -- this consumes
+        // each id exactly once, so there was never a reason to collect them first.
+        return src
+            .idx
+            .iter_ids(value)
+            .map(|c| {
+                let c = c as usize;
+                (u32::from(offsets[c + 1]) - u32::from(offsets[c])) as usize
+            })
+            .sum();
     }
     // Printing space: one posting = one printing, so a popcount when the value is a bitmap and a
     // postings length otherwise — `len_of` is both.

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1818,8 +1818,13 @@ fn build_hybrid_tag_index<T>(rows: &[T], vocab: &[String], get_ids: impl Fn(&T) 
     let mut out = HybridTagIndex::default();
     for (value, postings) in build_tag_index(rows, vocab, get_ids) {
         if bitmap_beats_postings(postings.len(), n) {
-            let count = postings.len() as u32;
-            out.dense.insert(value, DenseBits { count, words: scatter_bits(postings, n) });
+            // Popcounted from the scattered bitmap, not `postings.len()`: a duplicate row id in
+            // `postings` sets the same bit twice, which `postings.len()` would over-count and the
+            // popcount does not, so `count` stays exactly the bitmap's true popcount by construction.
+            // A one-time cost at archive-build time, not the query-time cost this field exists to avoid.
+            let words = scatter_bits(postings, n);
+            let count = words.iter().map(|w| w.count_ones()).sum();
+            out.dense.insert(value, DenseBits { count, words });
         } else {
             out.sparse.insert(value, postings);
         }

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -1601,8 +1601,15 @@ pub(crate) fn bitmap_contains(bitmap: &[u64], cid: u32) -> bool {
 /// Materialize a bitmap's set bits as ascending card ids.
 pub(crate) fn bitmap_card_ids(bitmap: &[u64]) -> Vec<u32> {
     let count: usize = bitmap.iter().map(|w| w.count_ones() as usize).sum();
+    decode_bitmap_ids(bitmap.iter().copied(), count)
+}
+
+/// The decode loop `bitmap_card_ids` runs, generalized over the word source so a caller already
+/// holding a popcount (e.g. `DenseBits.count`) or an archived (non-`u64`) word type can drive it
+/// without a fresh popcount pass or a copy into a plain `&[u64]` first.
+pub(crate) fn decode_bitmap_ids(words: impl Iterator<Item = u64>, count: usize) -> Vec<u32> {
     let mut out: Vec<u32> = Vec::with_capacity(count);
-    for (i, &word) in bitmap.iter().enumerate() {
+    for (i, word) in words.enumerate() {
         let mut w = word;
         while w != 0 {
             out.push((i as u32) << 6 | w.trailing_zeros());

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     and_child_rank, assign_name_ranks,
-    build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
+    build_numeric_index, build_oracle_text_index, build_trigram_index,
     build_rarity_index, build_flavor_index, build_hybrid_tag_index, bitmap_beats_postings, HybridTagIndex, build_sort_permutations,
     assign_artwork_groups, build_artwork_base_from, build_bit_planes, build_border_printing_planes, build_rarity_printing_planes, build_divergent_ids, build_name_bigram_index, build_name_unigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
@@ -332,10 +332,12 @@ fn reassign_artwork_grouping(data: &mut CardData) -> Vec<u16> {
 // and card-space candidates for keywords, and None (no narrowing) for absent tags.
 #[test]
 fn narrow_candidates_spaces() {
-    let mut art_tags: TagIndex = HashMap::new();
-    art_tags.insert("wolf".to_string(), vec![0, 2]);
-    let mut keywords: TagIndex = HashMap::new();
-    keywords.insert("Flying".to_string(), vec![1]);
+    // Hand-built postings go in the SPARSE tier: two ids over a four-row domain is far below the
+    // 1/32 storage crossover, so this is what the builder would produce for them anyway.
+    let mut art_tags = HybridTagIndex::default();
+    art_tags.sparse.insert("wolf".to_string(), vec![0, 2]);
+    let mut keywords = HybridTagIndex::default();
+    keywords.sparse.insert("Flying".to_string(), vec![1]);
 
     // offsets for 2 cards with 2 printings each: printings 0-1 → card 0, 2-3 → card 1
     let raw_offsets = vec![0u32, 2, 4];
@@ -391,8 +393,8 @@ fn narrow_candidates_spaces() {
 // which would hide the Ge-vs-Eq/Gt distinction this test is checking).
 #[test]
 fn narrow_candidates_eq_gt_reuse_ge_postings_loosely() {
-    let mut keywords: TagIndex = HashMap::new();
-    keywords.insert("Flying".to_string(), vec![1]);
+    let mut keywords = HybridTagIndex::default();
+    keywords.sparse.insert("Flying".to_string(), vec![1]);
 
     // offsets for 2 cards with 2 printings each: printings 0-1 → card 0, 2-3 → card 1
     let raw_offsets = vec![0u32, 2, 4];
@@ -2444,11 +2446,11 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     // Collection narrowing indexes — load-bearing like the range indexes above: an unbuilt index
     // narrows a populated predicate to the empty set, disagreeing with the residual `matches` path.
     // frame_data is thresholded (drops the dominant "2015"), matching the engine's build.
-    data.indexes.subtypes = build_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_subtypes);
-    data.indexes.keywords = build_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_keywords);
-    data.indexes.oracle_tags = build_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_oracle_tags);
-    data.indexes.art_tags = build_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_art_tags);
-    data.indexes.is_tags = build_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_is_tags);
+    data.indexes.subtypes = build_hybrid_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_subtypes);
+    data.indexes.keywords = build_hybrid_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_keywords);
+    data.indexes.oracle_tags = build_hybrid_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_oracle_tags);
+    data.indexes.art_tags = build_hybrid_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_art_tags);
+    data.indexes.is_tags = build_hybrid_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_is_tags);
     data.indexes.frame_data = build_hybrid_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_frame_data);
     data.indexes.artists = build_artist_index(&data.printings, data.artist_vocab.len());
     // Text narrowing indexes — same load-bearing property. name/oracle drive trigram + bigram
@@ -6395,11 +6397,11 @@ fn bench_checked_vs_unchecked_access() {
         power:          build_numeric_index(&cards, |c| c.creature_power.map(|v| v as i16)),
         toughness:      build_numeric_index(&cards, |c| c.creature_toughness.map(|v| v as i16)),
         rarity:         build_rarity_index(&printings, &offsets),
-        subtypes:       build_tag_index(&cards, &vocab.strings, |c| &c.card_subtypes),
-        keywords:       build_tag_index(&cards, &vocab.strings, |c| &c.card_keywords),
-        oracle_tags:    build_tag_index(&cards, &vocab.strings, |c| &c.card_oracle_tags),
-        art_tags:       build_tag_index(&printings, &vocab.strings, |p| &p.card_art_tags),
-        is_tags:        build_tag_index(&printings, &vocab.strings, |p| &p.card_is_tags),
+        subtypes:       build_hybrid_tag_index(&cards, &vocab.strings, |c| &c.card_subtypes),
+        keywords:       build_hybrid_tag_index(&cards, &vocab.strings, |c| &c.card_keywords),
+        oracle_tags:    build_hybrid_tag_index(&cards, &vocab.strings, |c| &c.card_oracle_tags),
+        art_tags:       build_hybrid_tag_index(&printings, &vocab.strings, |p| &p.card_art_tags),
+        is_tags:        build_hybrid_tag_index(&printings, &vocab.strings, |p| &p.card_is_tags),
         frame_data:     HybridTagIndex::default(),
         artists:        ArtistIndex::default(),
         flavor:         build_flavor_index(&printings, &strings),
@@ -7554,11 +7556,11 @@ fn collection_compose_leaves() {
     }
     // Build the collection indexes the way reload_commit does (card-space over cards, printing-space
     // over printings), plus the released_at range for the mixes.
-    data.indexes.subtypes = build_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_subtypes);
-    data.indexes.keywords = build_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_keywords);
-    data.indexes.oracle_tags = build_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_oracle_tags);
-    data.indexes.art_tags = build_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_art_tags);
-    data.indexes.is_tags = build_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_is_tags);
+    data.indexes.subtypes = build_hybrid_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_subtypes);
+    data.indexes.keywords = build_hybrid_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_keywords);
+    data.indexes.oracle_tags = build_hybrid_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_oracle_tags);
+    data.indexes.art_tags = build_hybrid_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_art_tags);
+    data.indexes.is_tags = build_hybrid_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_is_tags);
     data.indexes.released_at = build_printing_value_index(&data.printings, &data.cards, &data.offsets, |p| p.released_at_int);
 
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
@@ -9430,7 +9432,7 @@ fn narrow_fixture_store() -> CardData {
         p.card_set_code = InlineStr::from_str(if i % 2 == 0 { "lea" } else { "m21" });
         p.card_rarity_int = Some((i % 2) as u8); // even printings common, odd uncommon
     }
-    data.indexes.subtypes = build_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_subtypes);
+    data.indexes.subtypes = build_hybrid_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_subtypes);
     data.indexes.rarity = build_rarity_index(&data.printings, &data.offsets);
     // Rarity planes are built from the same printings, so they must be
     // rebuilt here too -- build_bit_planes already ran once inside store_of
@@ -9853,7 +9855,7 @@ fn broad_tag_postings_scatter_or_decline() {
         if i % 2 == 0 { p.card_is_tags.push(spell); }
         if i % 100 == 0 { p.card_is_tags.push(rare_tag); }
     }
-    data.indexes.is_tags = build_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_is_tags);
+    data.indexes.is_tags = build_hybrid_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_is_tags);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 


### PR DESCRIPTION
## Summary
- Rebases daveycodez's #924 (Store Dense Collection Values as Bitmaps, Not Posting Lists) onto current main, unchanged, then adds three follow-up commits from a full re-review of that PR.
- `DenseBits.count` is now popcounted from the scattered bitmap instead of copied from raw `postings.len()` before scattering, so a duplicate id in a value's source postings can no longer desync the cached count from the bitmap's true popcount (latent against real data today, since only `card_subtypes` lacks the dedup its four sibling fields get from `jsonb_obj_to_ids`, but no longer possible by construction).
- `ids_of`'s bit-decode loop is shared with `bitmap_card_ids` via a new `decode_bitmap_ids` helper, and the new card-space `BITS_PROMOTE` branch in `narrow_rec` now does one `dense` lookup instead of `is_dense` followed by `bits`, each independently redoing the same hashmap lookup.
- A new `HybridIdsIter` walks a dense value's set bits (or a sparse value's stored ids) one at a time with no intermediate `Vec`, fixing a real regression found by benchmarking: `collection_leaf_bits`/`collection_leaf_printing_count` were materializing a full `Vec<u32>` on the compose path for card-space fields (subtypes/keywords/oracle_tags) just to fold over it once and discard it, which #924 introduced by moving dense values to bitmaps without also updating this path.

## Storage
Fresh archive built from the same corpus (`benchmarks/bitplanes/corpus.jsonl`) on each side:

| | bytes |
|---|---:|
| main | 72,344,336 |
| this branch | 69,517,232 |
| Δ | **-2,827,104 bytes (-3.9%)** |

Matches #924's own claimed ~3.9% reduction. The two follow-up commits above don't change `DenseBits`'s byte layout, only how `count` is computed and how ids are walked, so this is confirming #924's storage win still holds on current main, not a separate effect.

## Timings
Per-query timings across main, the first commit on this branch (`3f8bf188` -- daveycodez's #924 commit, rebased unmodified), and the current tip (all three follow-up commits applied). Same corpus, interleaved rounds, min-of-trials, `unique=card orderby=edhrec`.

The first five rows are #924's own targeted table, re-measured here; the last three are `otag:` regressions found while benchmarking a query mix biased toward the five hybridized fields (a uniform query sample mostly misses them -- no `arttag:` sampler family exists, and `otag:` only shows up indirectly via `is:` rewrites).

| query | main | first commit (`3f8bf188`) | vs main | last commit | vs main |
|---|---:|---:|---:|---:|---:|
| `arttag:plane` | 316.4us | 207.7us | -34.4% | 208.1us | -34.2% |
| `arttag:artist-signature` | 153.5us | 128.1us | -16.6% | 127.8us | -16.8% |
| `o:draw otag:triggered-ability` | 115.9us | 105.8us | -8.8% | 105.0us | -9.4% |
| `otag:triggered-ability` | 241.0us | 298.2us | **+23.8%** | 257.1us | +6.7% |
| `o:draw arttag:artist-signature` | 160.1us | 170.6us | +6.6% | 169.0us | +5.5% |
| `otag:activated-ability` | 189.5us | 213.6us | +12.7% | 195.3us | +3.1% |
| `otag:cycle` | 178.8us | 198.6us | +11.1% | 183.4us | +2.6% |
| `t:dragon otag:cycle` | 100.4us | 103.5us | +3.1% | 101.8us | +1.5% |

The `arttag:` rows (printing-space) are unaffected by either follow-up commit, as expected -- that regression lives entirely in the card-space compose path. The four `otag:`/`t:` rows all move back toward main after the `HybridIdsIter` fix, without giving back any of the `arttag:` win. `o:draw otag:triggered-ability` stays a clean win throughout, since that one routes through `narrow_rec`'s `And` path rather than compose and was never affected.

The residual ~1.5-6.7% on the four regression rows is the bitmap decode itself, which storing dense values as bitmaps can't fully avoid without giving back the storage win.

While benchmarking this, also found a separate, pre-existing router mis-costing bug (present on `main` too, unrelated to this PR): bare compose-exact leaves on card-invariant collection fields get charged a residual verify-tier cost they don't need, which mis-routes them to a slower plan. Filed as #1005, tracked separately.

## Test plan
- `cargo test -p card_engine --release`: 156 passed, 0 failed
- `cargo clippy -p card_engine --all-targets`: clean