### PR TITLE
Engine: Give Bare Card-Space Collection Leaves the Same Verify-Tier Carve-Out Legality Gets

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -10407,11 +10407,19 @@ fn acquire_plan_features(
         // accuracy, beating every threshold on the two alternative signals tried. Its 26% false positives
         // over-cost both materializing plans by the same factor, which an argmin largely absorbs; the false
         // negatives are what were losing `GatheredScan vs StreamedSelect`, so recall is the side to favour.
-        let (eval_domain, scan_units) = if range_too_broad_to_narrow(printing_matches, n_printings as usize) {
-            (n_cards as usize, n_printings as usize)
-        } else {
-            (eval_domain, scan_units)
-        };
+        // The broadness guard this asks about is `MAX_NARROW_FRACTION`, which card-space collection
+        // narrowing does not have ("Card-space lists need no guard" — narrow_rec's CollectionCmp Ge
+        // arm). So a bare card-space collection leaf never actually falls back to visiting every card
+        // the way a broad range or legality predicate can; charging it as if it did is the same gap
+        // `compose_leaf_nothing_to_verify` closes for the tier, applied to this feature instead (#1005).
+        // Scoped to that check alone, not the wider `nothing_to_verify` OR: legality's own broadness
+        // behavior here is untouched, and unverified by this fix.
+        let (eval_domain, scan_units) =
+            if !compose_leaf_nothing_to_verify(filter) && range_too_broad_to_narrow(printing_matches, n_printings as usize) {
+                (n_cards as usize, n_printings as usize)
+            } else {
+                (eval_domain, scan_units)
+            };
         // The tier is what the MATERIALIZING alternatives pay per candidate, so it must be asked about
         // the predicate THEY see (`filter` + `plane`), not about `composed` — and gated exactly as
         // `prepare_candidates` gates it, or the router charges a `card_pass` the kernels will skip. On a

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -8518,6 +8518,34 @@ fn plane_leaves_nothing_to_verify(
         })
 }
 
+/// The compose-side counterpart to `plane_leaves_nothing_to_verify`: whether a bare `Ge` (containment)
+/// `CollectionCmp` on a CARD-space field leaves the match kernels nothing to verify.
+///
+/// `subtypes`/`keywords`/`oracle_tags` are pure card properties — every printing of a card agrees —
+/// unlike `art_tags`/`is_tags`/`frame_data`, which vary printing to printing (see `collection`,
+/// filter.rs). So when the WHOLE filter is one of these leaves, `card_pass`/`card_match_count` resolve
+/// it at the card level for every candidate, exactly like a card-invariant legality format: nothing is
+/// left to check per printing, or even per candidate beyond the narrowing that already happened.
+///
+/// `Ge` only: `Eq`/`Gt` need the collection-length check a containment leaf does not prove, so
+/// `is_printing_composable` never hands compose a bare `Eq`/`Gt` collection leaf in the first place
+/// (see `collection_leaf_bits`'s doc) — this mirrors that gate rather than re-deriving it.
+///
+/// Bare leaf only, deliberately: `otag:X t:human` loses the guarantee the moment a printing-varying
+/// predicate joins it as a partner — `card_pass` then returns `PrintingDep` and the kernels must walk
+/// every printing regardless, the same caveat `plane_leaves_nothing_to_verify`'s legality callers
+/// already live with for a divergent format.
+///
+/// #1005: `otag:triggered-ability` (47% dense) measured `StreamedSelect` predicted at 1026us against
+/// 45.7us real — a 22x over-charge from this gap — which routed the query to `PrintingCompose`
+/// (176.5us measured) despite it being ~4x slower.
+fn compose_leaf_nothing_to_verify(filter: &FilterExpr) -> bool {
+    matches!(
+        filter,
+        FilterExpr::CollectionCmp { field: CollField::Subtypes | CollField::Keywords | CollField::OracleTags, op: CmpOp::Ge, .. }
+    )
+}
+
 /// The candidate materialization + filter rewriting shared by `StreamedSelect`
 /// and `GatheredScan`, extracted verbatim from `run_query`. Mutates `filter` via
 /// `memoize_text_predicates` + `order_children_by_verify_cost` under the same
@@ -10392,7 +10420,15 @@ fn acquire_plan_features(
         // terms; charging them anyway was 92-94% of P3's predicted cost on `f:modern`, `f:gladiator`,
         // `f:commander` and `f:predh`. `residual_exact` is unavailable here (this branch never narrows),
         // so this is the conservative half of the executor's disjunction: it can over-charge, never under.
-        let nothing_to_verify = plane_leaves_nothing_to_verify(filter, mode, plane, indexes);
+        //
+        // `compose_leaf_nothing_to_verify` closes the analogous gap for a bare compose-exact collection
+        // leaf: `otag:triggered-ability` (47% dense) measured StreamedSelect predicted at 1026us against
+        // 45.7us real, a 22x over-charge from exactly this branch's `False` default, which routed the
+        // query to `PrintingCompose` (176.5us) despite it being ~4x slower (#1005). `plane_leaves_
+        // nothing_to_verify` cannot see this — it only recognizes the legality plane's rewrite to `True`,
+        // and a compose-exact leaf is never rewritten that way.
+        let nothing_to_verify =
+            plane_leaves_nothing_to_verify(filter, mode, plane, indexes) || compose_leaf_nothing_to_verify(filter);
         let tier = if nothing_to_verify { 0 } else { verify_cost_tier(composed) };
         // `GatheredScan` walks every printing of every candidate card, so its scan feature is the candidate
         // SPAN. `scan_all` estimates that span as `est_cards x` the corpus-average printings-per-card `x 2.1`,


### PR DESCRIPTION
Fixes #1005.

## Summary
Two commits, and the second exists because the first one, taken alone, was incomplete in a way worth explaining.

**Commit 1** -- `otag:triggered-ability` (`unique=card orderby=edhrec`, 47% dense) picked `PrintingCompose` over a `StreamedSelect` that measured ~4x cheaper, because `StreamedSelect`'s predicted cost was 1026us against a real 45.7us. `plane_leaves_nothing_to_verify` zeroes the router's verify-tier cost when a filter reduces to `FilterExpr::True` (what the legality-plane machinery does to a card-invariant format), but has no equivalent for compose: a bare compose-exact leaf like `otag:triggered-ability` is never rewritten to `True`. `subtypes`/`keywords`/`oracle_tags` are pure card properties -- every printing agrees -- so they get the same carve-out via a new `compose_leaf_nothing_to_verify` (bare `Ge` leaf, card-space field only; `art_tags`/`is_tags`/`frame_data` are printing-space and don't qualify).

**Commit 2** -- that alone fixed `otag:triggered-ability` and `otag:activated-ability` but left `otag:cycle` still mis-picking `PrintingCompose` (77.8k predicted vs `StreamedSelect`'s 83.8k -- a near-tie against a real 3.9x gap). Rather than write that off as unrelated cost-model noise, traced it with `explain_analyze`'s acquire dict: `eval_domain` was still being forced to `n_cards` (31,508) for all three queries instead of the true match count (7,960-14,802). The cause is the same shape as commit 1: `range_too_broad_to_narrow(printing_matches, n_printings)` assumes a broad predicate falls back to visiting every card, which is true for a range or legality predicate past `MAX_NARROW_FRACTION` but never true for a card-space collection leaf -- `narrow_rec` narrows those exactly regardless of density ("Card-space lists need no guard"). Skipped the override specifically via `compose_leaf_nothing_to_verify`, not the wider tier check, so legality's own (separately tuned) broadness behavior is untouched.

## Blast radius: why this can't touch other queries

Both new checks are a pure structural match on `filter`: `CollectionCmp` on one of the 3 card-space fields, `Ge`, and -- for `compose_leaf_nothing_to_verify` -- nothing else in the expression. Every other query shape makes both checks return `false`, leaving the code path byte-for-byte what it was before.

The one interaction worth actually checking: `plane_leaves_nothing_to_verify` also consults whether an accompanying `plane` is existentially divergent (a divergent legality format can be split off into its own `PlaneExpr`, leaving a collection leaf behind as the residual `filter`). If that split could happen, my filter-only check could wrongly call a query "nothing to verify" while the plane side still needs real per-printing checking. It can't: `compile_plane` (`planes.rs:1235`) has no arm for `CollectionCmp`, and its `And`/`Or` handling requires *every* child to compile into a plane or the whole group fails (`compile_plane_children(...)?`). So a collection leaf anywhere in a compound expression blocks plane extraction entirely -- whenever `filter` could possibly be a bare `CollectionCmp` (the only case either new check fires on), `plane` is structurally guaranteed `None`. Confirmed empirically too: `otag:triggered-ability f:oldschool` (`oldschool` is the corpus's one documented divergent format) under `unique=printing` and `unique=artwork` produces bit-for-bit identical `residual_tier_ns100`/`eval_domain`/`scan_units` before and after this fix, because `filter` there is the whole `And`, never reduced to a bare leaf.

## Verification

`explain_analyze` against the real corpus, after both commits:

| query | predicted | measured | picked |
|---|---:|---:|---|
| `otag:triggered-ability` | 41.2k | 45.3k | `StreamedSelect` (was `PrintingCompose`, 168.6k) |
| `otag:activated-ability` | 27.0k | 28.6k | `StreamedSelect` (was `PrintingCompose`, 111.1k) |
| `otag:cycle` | 23.0k | 24.6k | `StreamedSelect` (was `PrintingCompose`, 98.5k) |

All three now predict within 6-9% of measured and route correctly -- `otag:cycle` included, once eval_domain stopped lying about the candidate count.

`plan_cost_model_matches_gold`: 94.3% (80 gold-match / 3 near-tie / 5 real-miss of 88), up from a 93.2% baseline. Its fixed query set has nothing dense enough in card-space collections to exercise this branch directly, so this is a no-regression check (and a small side-effect improvement), not a direct positive test of this fix -- a real gap in that test's coverage, worth closing separately.

**A/B against main, uniform query sampler**, counterbalanced ABBA order with a discarded warmup pair (to rule out first/second-mover bias -- main always ran first in an earlier, uncontrolled pass): no detectable real difference -- `B - A = +0.1us, 95% CI [+0.0, +0.2]` on a ~64us baseline. The label a strict CI-vs-zero rule produces is "slower," but at ~0.16% this sits inside the noise floor the harness's own same-build canary already documents (swings of several us from nothing changing, at this sample size). Counterbalancing didn't move this number, so it isn't an order artifact -- it's the expected, uninformative result for this instrument: the fix affects a narrow slice of query space (bare leaf, one of 3 fields, broad enough to trigger the bad override), and `uniform` mode spreads evenly across the entire DSL, diluting that slice into the noise.

**A/B against main, biased toward the affected fields** (`Shape(families={"type","keyword","tag"})` + the `otag:`/`arttag:` fixed set), same counterbalanced protocol: a real, statistically detectable win, and slightly *stronger* than the uncontrolled first pass -- `B - A = -0.566us, 95% CI [-0.686, -0.442]` on a ~27us baseline. The fixed-query breakdown makes the mechanism obvious:

| query | main | this branch | ratio |
|---|---:|---:|---:|
| `otag:triggered-ability` | 247.2us | 142.1us | **0.575** |
| `otag:activated-ability` | 195.9us | 113.2us | **0.578** |
| `otag:cycle` | 184.5us | 108.4us | **0.587** |
| `t:dragon otag:cycle` (compound, unaffected) | 105.2us | 100.7us | 0.957 |
| `arttag:plane` (printing-space, unaffected) | 207.9us | 206.6us | 0.994 |
| `o:draw otag:triggered-ability` (compound, unaffected) | 108.1us | 107.1us | 0.990 |

The three bare card-space queries this fix targets are 41-43% faster against current main; everything the fix doesn't touch (compound queries, printing-space fields) stays within ~5% either way, consistent with noise rather than a systematic effect.

## Test plan
- `cargo test -p card_engine --release`: 156 passed, 0 failed
- `cargo clippy -p card_engine --all-targets`: clean
- `plan_cost_model_matches_gold` (`--ignored`, rebuilt `benchmarks/verify-order/real.store` against current archive format first): 94.3% pass, up from 93.2% baseline