### PR TITLE
Engine: Exact ValueTotals for Colors/Identity/Produced-Mana and the Five Collection Fields

### DIFF
--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -301,6 +301,25 @@ fn card_colors(card: &AOracleCard, f: ColorField) -> u8 {
     }
 }
 
+/// The `ColorCmp` predicate against one card's (or, for an exact-total lookup, one stored
+/// combination's) bits. Shared by `matches()` and `exact_result_total`'s color arm so the two answers
+/// cannot drift apart -- a query bare enough to reach the totals table still has to agree with the
+/// residual path a compound query would fall back to.
+pub(crate) fn color_cmp_matches(op: CmpOp, mask: u8, bits: u8) -> bool {
+    match op {
+        // mask == 0 means the query was literally "c"/"colorless" (see
+        // get_colors_comparison_object on the Python side), not "at
+        // least zero colors" -- bits & 0 == 0 is vacuously true for
+        // every card, so Ge must fall back to exact equality here.
+        CmpOp::Ge => if mask == 0 { bits == 0 } else { bits & mask == mask },
+        CmpOp::Eq => bits == mask,
+        CmpOp::Le => bits & !mask == 0,
+        CmpOp::Lt => bits & !mask == 0 && bits != mask,
+        CmpOp::Gt => bits & mask == mask && bits != mask,
+        CmpOp::Ne => bits != mask,
+    }
+}
+
 #[derive(Clone, Copy)]
 pub(crate) enum CollField {
     Subtypes,
@@ -1401,21 +1420,7 @@ impl FilterExpr {
                 }
             }
 
-            FilterExpr::ColorCmp { field, op, mask } => {
-                let bits = card_colors(card, *field);
-                tri_bool(match op {
-                    // mask == 0 means the query was literally "c"/"colorless" (see
-                    // get_colors_comparison_object on the Python side), not "at
-                    // least zero colors" -- bits & 0 == 0 is vacuously true for
-                    // every card, so Ge must fall back to exact equality here.
-                    CmpOp::Ge => if *mask == 0 { bits == 0 } else { bits & mask == *mask },
-                    CmpOp::Eq => bits == *mask,
-                    CmpOp::Le => bits & !mask == 0,
-                    CmpOp::Lt => bits & !mask == 0 && bits != *mask,
-                    CmpOp::Gt => bits & mask == *mask && bits != *mask,
-                    CmpOp::Ne => bits != *mask,
-                })
-            }
+            FilterExpr::ColorCmp { field, op, mask } => tri_bool(color_cmp_matches(*op, *mask, card_colors(card, *field))),
 
             FilterExpr::TypeCmp { mask, op } => {
                 let bits = u16::from(card.card_types);

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2532,6 +2532,20 @@ struct ValueTotals {
     layout: HashMap<String, SpaceTotals>,
     /// `frame:` and `is:new`/`is:old` — printing-space, 29 values. Keyed by the `coll_vocab` string.
     frame_data: HashMap<String, SpaceTotals>,
+    /// `t:`/`keyword:`/`otag:` — card-space, one entry per distinct `coll_vocab` string the field uses.
+    /// `HybridTagIndex::len_of` already gives these an exact CARD count for nothing; what it cannot
+    /// give is printings or artworks, the same gap `frame_data` closes for its own dimension. A bare
+    /// `otag:triggered-ability` under `unique=printing`/`artwork` had NO exact answer before this and
+    /// fell to the same biased `scan_all` estimate a plane-backed field would (#1005/#1006's `otag:`
+    /// mis-routing was this gap's first symptom, closed there for the router's OWN cost features;
+    /// this closes it for `compose_printing_estimate`'s answer too).
+    subtypes: HashMap<String, SpaceTotals>,
+    keywords: HashMap<String, SpaceTotals>,
+    oracle_tags: HashMap<String, SpaceTotals>,
+    /// `art:`/`is:` — printing-space, the mirror gap: `bits`/`len_of` already give these an exact
+    /// PRINTING count for nothing; cards and artworks are what's missing.
+    art_tags: HashMap<String, SpaceTotals>,
+    is_tags: HashMap<String, SpaceTotals>,
     /// `f:X` / `banned:X` / `restricted:X`, keyed `(shift << 2) | status`.
     ///
     /// One entry per (format, status) pair rather than per format, because `FilterExpr::Legality`
@@ -2543,6 +2557,15 @@ struct ValueTotals {
     /// gold border) contribute their printings' own words. Reading the card word for those would
     /// mis-count exactly the cards the divergence flag exists to flag.
     legality: HashMap<u16, SpaceTotals>,
+    /// `c:`/`id:`/`produces:` — card-space, keyed by the raw bitmask byte. Unlike the other dimensions
+    /// here, a bare leaf rarely names one combination exactly: `c:>=g` (`Ge`) matches every combination
+    /// whose bits are a superset of green, not just the all-green one. `exact_result_total` sums over
+    /// every stored combination `color_cmp_matches` accepts, which is why this stays a `HashMap<u8, _>`
+    /// (iterable in full) rather than needing a dedicated range-style structure -- at most 256 keys,
+    /// almost all of them absent, and even a full scan is a few dozen entries at most.
+    colors: HashMap<u8, SpaceTotals>,
+    color_identity: HashMap<u8, SpaceTotals>,
+    produced_mana: HashMap<u8, SpaceTotals>,
 }
 
 /// The key `ValueTotals::legality` uses. `shift` is even and < 64, so this cannot collide.
@@ -2842,10 +2865,28 @@ fn build_all_value_totals(
         frame_data: totals!(|_card: &OracleCard, p: &Printing| {
             p.card_frame_data.iter().map(|v| coll_vocab[*v as usize].clone()).collect()
         }),
+        subtypes: totals!(|card: &OracleCard, _p: &Printing| {
+            card.card_subtypes.iter().map(|v| coll_vocab[*v as usize].clone()).collect()
+        }),
+        keywords: totals!(|card: &OracleCard, _p: &Printing| {
+            card.card_keywords.iter().map(|v| coll_vocab[*v as usize].clone()).collect()
+        }),
+        oracle_tags: totals!(|card: &OracleCard, _p: &Printing| {
+            card.card_oracle_tags.iter().map(|v| coll_vocab[*v as usize].clone()).collect()
+        }),
+        art_tags: totals!(|_card: &OracleCard, p: &Printing| {
+            p.card_art_tags.iter().map(|v| coll_vocab[*v as usize].clone()).collect()
+        }),
+        is_tags: totals!(|_card: &OracleCard, p: &Printing| {
+            p.card_is_tags.iter().map(|v| coll_vocab[*v as usize].clone()).collect()
+        }),
         legality: totals!(|card: &OracleCard, p: &Printing| {
             let word = if card.legality_divergent { p.card_legalities } else { card.card_legalities };
             shifts.iter().map(|&shift| legality_totals_key(shift, (word >> shift) & 0b11)).collect()
         }),
+        colors: totals!(|card: &OracleCard, _p: &Printing| vec![card.card_colors]),
+        color_identity: totals!(|card: &OracleCard, _p: &Printing| vec![card.card_color_identity]),
+        produced_mana: totals!(|card: &OracleCard, _p: &Printing| vec![card.produced_mana]),
     }
 }
 
@@ -7763,39 +7804,41 @@ fn exact_result_total(composed: &FilterExpr, indexes: &Archived<CardIndexes>, mo
         FilterExpr::CollectionCmp { field: CollField::FrameData, op: CmpOp::Ge, value, .. } => {
             return Some(vt.frame_data.get(value.as_str()).map_or(0, |t| t.get(mode)));
         }
+        FilterExpr::CollectionCmp { field: CollField::Subtypes, op: CmpOp::Ge, value, .. } => {
+            return Some(vt.subtypes.get(value.as_str()).map_or(0, |t| t.get(mode)));
+        }
+        FilterExpr::CollectionCmp { field: CollField::Keywords, op: CmpOp::Ge, value, .. } => {
+            return Some(vt.keywords.get(value.as_str()).map_or(0, |t| t.get(mode)));
+        }
+        FilterExpr::CollectionCmp { field: CollField::OracleTags, op: CmpOp::Ge, value, .. } => {
+            return Some(vt.oracle_tags.get(value.as_str()).map_or(0, |t| t.get(mode)));
+        }
+        FilterExpr::CollectionCmp { field: CollField::ArtTags, op: CmpOp::Ge, value, .. } => {
+            return Some(vt.art_tags.get(value.as_str()).map_or(0, |t| t.get(mode)));
+        }
+        FilterExpr::CollectionCmp { field: CollField::IsTags, op: CmpOp::Ge, value, .. } => {
+            return Some(vt.is_tags.get(value.as_str()).map_or(0, |t| t.get(mode)));
+        }
         FilterExpr::Legality { shift: Some(shift), expected } => {
             return Some(vt.legality.get(&legality_totals_key(*shift, *expected).into()).map_or(0, |t| t.get(mode)));
         }
         // A format absent from all loaded data matches nothing, in every space.
         FilterExpr::Legality { shift: None, .. } => return Some(0),
+        // Unlike the dimensions above, a bare leaf rarely names one stored combination exactly -- `c:>=g`
+        // matches every combination whose bits are a superset of green. Sum over every combination the
+        // corpus actually produced (a HashMap of at most 256 entries, almost always far fewer), filtered
+        // by the same predicate `matches()` uses, so the two can't disagree about which combos qualify.
+        FilterExpr::ColorCmp { field, op, mask } => {
+            let table = match field {
+                ColorField::Colors => &vt.colors,
+                ColorField::ColorIdentity => &vt.color_identity,
+                ColorField::ProducedMana => &vt.produced_mana,
+            };
+            return Some(
+                table.iter().filter(|(bits, _)| color_cmp_matches(*op, *mask, **bits)).map(|(_, t)| t.get(mode)).sum(),
+            );
+        }
         _ => {}
-    }
-    // The remaining shapes are exact in CARD space only, so any other mode falls back to the estimator.
-    if !matches!(mode, Mode::Card) {
-        return None;
-    }
-    // A CARD-space containment leaf (`t:`/`keyword:`/`otag:`) posts card ids, so its postings length IS
-    // the exact distinct-card count -- the same "the answer was already computed and then discarded"
-    // shape the legality arm above fixes. The acquire was projecting the leaf's PRINTING count through
-    // balls-into-bins instead, which reads 1.27x on `t:human` (5,411 estimated against 4,249 exact) and
-    // up to 2.24x on `t:angel`.
-    //
-    // `Ge` only. `Eq`/`Gt` share these postings as a loose superset -- they prove containment but not the
-    // collection-length condition -- so their count is an upper bound, not a total.
-    if let FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value, .. } = composed {
-        let card_space_idx = match field {
-            CollField::Subtypes => Some(&indexes.subtypes),
-            CollField::Keywords => Some(&indexes.keywords),
-            CollField::OracleTags => Some(&indexes.oracle_tags),
-            // Printing-space: postings are printing ids, so their length is not a card count. These want
-            // an import-time count table (the artwork side needs one for every family, including the
-            // ranges and formats that are already exact in card space).
-            CollField::ArtTags | CollField::IsTags | CollField::FrameData => None,
-        };
-        // Absent from a complete index is an exact ZERO, not "no answer".
-        // `len_of` counts a dense value by popcount and a sparse one by postings length — the same
-        // card count either way, so the exactness argument above is untouched by storage.
-        return card_space_idx.map(|idx| idx.len_of(value.as_str()).unwrap_or(0));
     }
     None
 }
@@ -11743,7 +11786,11 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 // are `AOracleCard` and `APrinting`, and neither moves, because the change is entirely inside
 // `CardIndexes`. So this constant is the only thing stopping a reader from accessing an older
 // store's `HashMap<String, Vec<u32>>` as a `HybridTagIndex` through `access_unchecked`.
-const ARCHIVE_FORMAT_VERSION: u32 = 2026081301;
+//
+// 2026082301 — `ValueTotals` gains `colors`/`color_identity`/`produced_mana`, exact per-combination
+// totals for `ColorCmp`. Same blind spot as the previous bump: entirely inside `CardIndexes`, so the
+// header's `AOracleCard`/`APrinting` sizes don't move and can't catch it.
+const ARCHIVE_FORMAT_VERSION: u32 = 2026082301;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2829,7 +2829,7 @@ fn build_pair_totals(
     out
 }
 
-/// Build all four `ValueTotals` maps. One call site, so the four cannot be built from different
+/// Build all twelve `ValueTotals` maps. One call site, so they cannot be built from different
 /// snapshots of the same printings.
 fn build_all_value_totals(
     cards: &[OracleCard],
@@ -2840,7 +2840,7 @@ fn build_all_value_totals(
     max_artwork_groups: usize,
 ) -> ValueTotals {
     // A macro rather than a closure alias: each `keys_of` is a distinct closure type returning a
-    // distinct key type, so one generic-over-both helper binding cannot serve all four.
+    // distinct key type, so one generic-over-both helper binding cannot serve all twelve.
     macro_rules! totals {
         ($keys_of:expr) => {
             build_value_totals(cards, printings, printing_to_card, max_artwork_groups, $keys_of)

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3503,6 +3503,56 @@ fn value_totals_are_exact_in_all_three_spaces() {
     assert!(nonzero >= leaves.len(), "too many zero totals ({nonzero}); the sweep is not exercising the table");
 }
 
+/// `exact_result_total`'s `ColorCmp` arm (colors/color_identity/produced_mana) must be exact in all
+/// three spaces, for every op against every one of the 32 possible WUBRG masks, against the same
+/// brute-force reference the fuzz differential uses.
+///
+/// This arm is not yet reachable via real routing (`is_printing_composable` has no `ColorCmp` arm,
+/// so `PrintingCompose` never applies to a bare color query), which is exactly why it needs its own
+/// direct sweep rather than relying on the fuzz differential to exercise it incidentally.
+#[test]
+fn value_totals_are_exact_for_color_fields() {
+    // Same rationale as `value_totals_are_exact_in_all_three_spaces`: this only asserts something
+    // when the table is switched on.
+    if !*EXACT_VALUE_TOTALS {
+        return;
+    }
+
+    use rand::SeedableRng;
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(20_260_805);
+    let data = fuzz_store_n(&mut rng, 2_000);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let mut nonzero = 0usize;
+    let mut checked = 0usize;
+    for (label, field) in [
+        ("colors", ColorField::Colors),
+        ("color_identity", ColorField::ColorIdentity),
+        ("produced_mana", ColorField::ProducedMana),
+    ] {
+        for op in [CmpOp::Ge, CmpOp::Eq, CmpOp::Le, CmpOp::Lt, CmpOp::Gt, CmpOp::Ne] {
+            for mask in 0u8..32 {
+                let f = FilterExpr::ColorCmp { field, op, mask };
+                for (mode_label, mode) in [("printing", Mode::Printing), ("card", Mode::Card), ("artwork", Mode::Artwork)] {
+                    let got = exact_result_total(&f, &archived.indexes, mode)
+                        .unwrap_or_else(|| panic!("{label} op={op:?} mask={mask} / {mode_label}: the table must answer, not decline"));
+                    assert_eq!(
+                        got,
+                        fuzz_reference_total(archived, &f, mode_label),
+                        "{label} op={op:?} mask={mask} / {mode_label}",
+                    );
+                    nonzero += usize::from(got > 0);
+                    checked += 1;
+                }
+            }
+        }
+    }
+    // Otherwise a table that answered 0 to everything would pass every assertion above.
+    assert!(nonzero > 0, "no color-field case produced a nonzero total; the sweep is not exercising the table");
+    assert_eq!(checked, 3 * 6 * 32 * 3, "field x op x mask x mode combinations swept");
+}
+
 /// `exact_result_total`'s rarity arm must be exact in all three spaces, for every op against every
 /// rarity value, against the same brute-force reference the fuzz differential uses.
 ///

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3454,6 +3454,25 @@ fn value_totals_are_exact_in_all_three_spaces() {
             value_id: None,
         }));
     }
+    // The five siblings `frame_data` already covered here: each gets an exact total from `HybridTagIndex`
+    // in its OWN space for nothing (card for subtypes/keywords/oracle_tags, printing for art_tags/is_tags)
+    // -- this table's job is the other two, the same gap frame_data closed for its dimension.
+    for (label, field, values) in [
+        ("subtypes", CollField::Subtypes, FUZZ_SUBTYPES.as_slice()),
+        ("keywords", CollField::Keywords, FUZZ_KEYWORDS.as_slice()),
+        ("oracle_tags", CollField::OracleTags, FUZZ_ORACLE_TAGS.as_slice()),
+        ("art_tags", CollField::ArtTags, FUZZ_ART_TAGS.as_slice()),
+        ("is_tags", CollField::IsTags, FUZZ_IS_TAGS.as_slice()),
+    ] {
+        for &(value, _) in values {
+            leaves.push((format!("{label}:{value}"), FilterExpr::CollectionCmp {
+                field,
+                op: CmpOp::Ge,
+                value: value.to_string(),
+                value_id: None,
+            }));
+        }
+    }
     for shift in FUZZ_SHIFTS {
         for expected in 0..4u64 {
             leaves.push((format!("legality shift={shift} status={expected}"), FilterExpr::Legality {


### PR DESCRIPTION
Draft -- follow-up to #1005/#1006. Extends the existing `ValueTotals`/`SpaceTotals` table (already covering `border`/`layout`/`frame_data`/`legality`) to the five collection fields it was missing, plus colors/identity/produced-mana as groundwork for #754.

## Summary

**subtypes/keywords/oracle_tags/art_tags/is_tags**: each already gets an exact answer in its own native space for free (`HybridTagIndex::len_of`/`bits`), same as `frame_data` before this table existed. What was missing is the *other* two spaces. Closed using `build_value_totals` exactly as `frame_data` already does -- the generic helper needed no changes, this is the same shape of dimension.

Removed `exact_result_total`'s old CARD-only fallback for subtypes/keywords/oracle_tags (the direct `HybridTagIndex::len_of` call) -- fully superseded now that the table answers all three modes, and it was already dead for art_tags/is_tags/frame_data.

**colors/color_identity/produced_mana**: `u8`-bitmask-keyed, summed over every stored combination `color_cmp_matches` accepts. Extracted `color_cmp_matches` out of `matches()`'s inline logic so the two can't disagree about which combinations a predicate accepts. **Not yet reachable via real routing** -- `is_printing_composable` has no `ColorCmp` arm, so `PrintingCompose` is never applicable for a bare color query (confirmed empirically: every color query tested shows `count_source` as `"candidates"`/`"plane"`, never `"printing_compose"`). This is groundwork for #754 ("Plane-Subtree Compose Leaf"), which proposes making color/identity/type compose-eligible; it has no live effect until that lands.

## Verification (revised -- see note below)

An earlier version of this description claimed 3.3-4.4x artwork-mode speedups for `otag:triggered-ability`/`otag:cycle`. **That was wrong -- those flips belong to #1006** (already merged; its `compose_leaf_nothing_to_verify` check never looked at `mode`, so it fixed routing for all three `unique=` values at once, not just `Card`). Caught by re-measuring against `main` at its *current* tip rather than a stale pre-#1006 baseline, and re-verified against a freshly re-exported corpus (the old one was ~7 weeks stale and had zero `is_tags` data at all -- #1000-#1002 added 21 real tags since then).

Full sweep, fresh corpus (97,812 printings), `main` (current tip, #1006 included) vs this branch, `orderby=edhrec`:

| query | mode | picked plan (both builds) | matches: main -> this branch |
|---|---|---|---|
| `otag:triggered-ability` | card | StreamedSelect | 14,931 -> 14,931 (unchanged, already exact) |
| `otag:triggered-ability` | printing | PrintingCompose | 41,216 -> 41,216 (unchanged, already exact) |
| `otag:triggered-ability` | artwork | StreamedSelect | 18,567 -> **20,171** |
| `otag:cycle` | card | StreamedSelect | 7,998 -> 7,998 (unchanged) |
| `otag:cycle` | printing | PrintingCompose | 31,206 -> 31,206 (unchanged) |
| `otag:cycle` | artwork | StreamedSelect | 10,912 -> **14,044** |
| `arttag:plane` | card | PrintingCompose | 23,202 -> **26,625** |
| `arttag:plane` | artwork | PrintingCompose | 34,854 -> 34,789 (~unchanged) |
| `arttag:artist-signature` | card | PrintingCompose | 10,678 -> **7,788** |
| `arttag:artist-signature` | artwork | PrintingCompose | 14,892 -> **8,883** |
| `is:masterpiece` | card | GatheredScan | 957 -> **866** |
| `is:masterpiece` | artwork | PrintingCompose | 1,244 -> **1,331** |
| `is:reserved` | card | GatheredScan | 593 -> **566** |
| `is:reserved` | artwork | GatheredScan | 769 -> **625** |

**The picked plan is identical in all 14 rows.** What this PR verifiably delivers is exact `result_total`/count answers where the estimator used to run -- real corrections (up to ~30%), previously reported as estimates -- for:
- `subtypes`/`keywords`/`oracle_tags` under `artwork` mode specifically (`card`/`printing` already had an independent exact path and don't move)
- `art_tags`/`is_tags` under `card` and `artwork` mode (`printing` was already exact via `bits`/`len_of`)

It does **not** demonstrate a routing or timing change in any of the 14 representative cases tested. Where `PrintingCompose`/`GatheredScan` already won, they remain clearly fastest regardless of the `matches`/`eval_domain` correction size -- the correction narrows the competing plans' cost estimates without flipping the decision here. This is a correctness fix (exact counts instead of estimates, useful for pagination/result totals and for reducing mis-route *risk* generally) rather than a demonstrated performance fix.

## Test plan
- `cargo test -p card_engine --release`: 156 passed, 0 failed (includes `value_totals_are_exact_in_all_three_spaces`, extended to cover the five new fields against the brute-force fuzz reference)
- `cargo clippy -p card_engine --all-targets`: clean
- `explain_analyze` sweep above, against a freshly re-exported corpus (`benchmarks/bitplanes/corpus.jsonl`, 97,812 rows, includes real `is_tags` data from #1000-#1002)