### PR TITLE
Engine: Fix Routing-Regret Sweep's Top Cost-Model Bugs

### DIFF
--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -153,6 +153,11 @@
 //! support for that ordering -- P3's dispatch median is 32 us against P4's 4 us, and its finish phase is
 //! 12% of all measured ns at mean |log| 2.06.
 //!
+//! **That "applying both arms together" attempt happened (2026-08-23, `bench_streamed_loop`'s own
+//! module docs), after a real feature fix, and still regressed -- through P3/P4-vs-`PrintingCompose`
+//! distortion, not P3-vs-P4 compensating error. See the sixth row of that file's history table before
+//! trying this again: a joint refit needs every plan in the same argmin refit together, not just P3+P4.
+//!
 //! One further limit on all of these: `LIMIT` is fixed, so nothing here constrains how the rates
 //! behave as the page grows.
 //!

--- a/card_engine/src/bench_streamed_loop.rs
+++ b/card_engine/src/bench_streamed_loop.rs
@@ -102,6 +102,54 @@
 //!     P4 reparameterised                        +40%
 //!     P3 and P4 both refit                      +30%
 //!     ... plus symmetric residual floors        +90%
+//!     P3+P4 refit AGAIN after fixing scan_units +54% (mean regret 0.50 -> 0.56 us/query)
+//!
+//! **The sixth attempt (2026-08-23) is not a repeat of the first four.** It came after fixing a real
+//! feature bug (`scan_units`'s card-mode overcharge, `local-engine-card-residual-pass-rate.md`'s
+//! companion) and refitting P3+P4 jointly on the corrected data -- the exact prerequisite this file's
+//! own conclusion asked for. It still regressed, but through a DIFFERENT mechanism than the first five:
+//! not P3-vs-P4 compensating error (fixing the feature and refitting both arms together handles that),
+//! but P3/P4-vs-`PrintingCompose` distortion. `PrintingCompose` was deliberately left unrefit (its own
+//! `Perm` arm is missing a `cards_visited` feature -- see `local-engine-compose-build-rates.md`), so
+//! making P3/P4 cheaper without touching it made them win against `PrintingCompose` in cases where
+//! `PrintingCompose` was actually correct: `PrintingCompose -> StreamedSelect` went from a minor cell to
+//! 309 queries at 99% miss rate and 32% of all lost time, and the `printing_compose` acquire branch's
+//! total share jumped to 72%. Reverted. The lesson generalizes past this one pair: **a joint refit is
+//! only as joint as every plan that competes in the same argmin, not just the two you fixed a feature
+//! for.** `PrintingCompose` needs its own feature fix (the `cards_visited` estimator) before ANY of its
+//! rates -- or any rate for a plan that regularly competes against it -- can be safely moved again.
+//! Full mechanism and revert data:
+//! [local-engine-p3-p4-joint-refit-vs-compose.md](../../docs/issues/local-engine-p3-p4-joint-refit-vs-compose.md).
+//!
+//! The fitted values that attempt computed, for whoever builds the `PrintingCompose` feature fix and
+//! retries this (`fit_cost_model.py` on ~111k/~83k rows post `scan_units` fix, `mirror_matches_engine`
+//! 99.8%; `x` is fitted/shipped):
+//!
+//!     GatheredScan                          shipped  fitted     x
+//!       GATHER_LOOP_PER_CARD_NS                3.88    4.52  1.17
+//!       GATHER_SCAN_PER_ROW_NS                 2.06    2.71  1.32
+//!       CARD_PASS+FLOOR (call held at 3.00)   21.89   24.07  1.10   -> floor 21.07
+//!       GATHER_PUSH_PER_MATCH_NS               2.24    2.05  0.92
+//!       GATHER_SELECT_PER_PAGE_SLOT_NS         3.51    3.32  0.94
+//!       GATHER_COLLECT_PER_PAGE_ROW_NS         9.79    8.41  0.86
+//!       GATHER_ARTWORK_PER_PRINTING_NS         0.50    0.51  1.02   (kernel-measured; left alone)
+//!       GATHER_FIXED_COST_NS                 169.60   93.59  0.55   (curvature-confounded; NOT applied)
+//!
+//!     StreamedSelect                         shipped  fitted     x
+//!       STREAM_LOOP_PER_CARD_NS                2.58    3.20  1.24
+//!       STREAM_SCAN_PER_ROW_NS                 5.97    5.90  0.99
+//!       CARD_PASS+FLOOR (call held at 2.47)    9.05   10.42  1.15   -> floor 7.95
+//!       STREAM_EMIT_PER_MATCH_NS               0.12    0.11  0.95
+//!       STREAM_PERM_STEP_NS                    1.00    1.24  1.24
+//!       STREAM_ARTWORK_SEEN_PER_CARD_NS        1.21    1.10  0.91
+//!       STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS   1.02    0.98  0.96   (already confirmed; left alone)
+//!       STREAM_CORPUS_PASS_PER_CARD_NS         0.02    0.01  0.67   (2 sig figs on an unseparable
+//!                                                                    constant; left alone)
+//!       STREAM_FIXED_COST_NS                 217.00  192.69  0.89   (curvature-confounded; NOT applied)
+//!
+//! `plan_cost_model_matches_gold` on these: 97.7% -> 98.9%. Total routing regret on a uniform sample:
+//! 0.50 -> 0.56 us/query mean, i.e. the gold-test metric improved while the thing that actually matters
+//! got worse -- the reason to gate on the full regret-matrix breakdown, not a single summary number.
 //!
 //! Every one regressed, and the best was the one that moved LEAST from the shipped values. Two of the
 //! attempts were diagnosed and corrected mid-flight -- artwork needed its own arm, and leaving P4's

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -207,6 +207,11 @@ pub(crate) struct PlanFeatures {
     /// uniformly across the whole permutation. `None` everywhere except a bare card-space collection
     /// leaf ordered by EDHREC, which is the only dimension `WalkCheckpoints` covers today.
     pub walked_hint: Option<f64>,
+    /// Printings a CARD-SPACE collection leaf's build broadcasts (`ids_of` +
+    /// `broadcast_card_ids_to_printings`). See `ComposeEstimate::collection_broadcast`'s doc for why
+    /// this is not just folded into `scatter_printings`. `0` for everything except `PrintingCompose`
+    /// on a card-space `subtypes`/`keywords`/`oracle_tags` leaf.
+    pub collection_broadcast_printings: u32,
 }
 
 // ─── P1: PrintingRangeScan ──────────────────────────────────────────────────
@@ -620,6 +625,22 @@ const GATHER_FIXED_COST_NS: f64 = 169.6;
 pub(crate) const COMPOSE_LINEAR_PASS_PER_PRINTING_NS: f64 = 1.93;
 /// Range-slice scatter into the printing bitmap during build.
 pub(crate) const COMPOSE_SCATTER_PER_PRINTING_NS: f64 = 0.48;
+
+/// A CARD-SPACE collection leaf's build (`ids_of` + `broadcast_card_ids_to_printings`) used to ride
+/// `COMPOSE_SCATTER_PER_PRINTING_NS`, on the assumption that it was the same shape of operation as a
+/// range's contiguous slice-scatter. It measurably is not: a card-cursor lookup per id (`offsets[c]`/
+/// `offsets[c+1]`) plus a variable-width printing-range fill, against a range's single contiguous
+/// write.
+///
+/// Backed out of `otag:triggered-ability`/`otag:cycle`/`otag:activated-ability` (`unique=printing`,
+/// EDHREC): with `printings_walked` corrected (`WalkCheckpoints`) and every other term in
+/// `PhysicalPlan::PrintingCompose`'s formula computed from measured features, the residual against real
+/// wall time scaled cleanly with `collection_broadcast_printings` (not a flat offset), implying 1.41,
+/// 1.30, and 1.31 ns/printing -- tight enough (2.7-2.9x `COMPOSE_SCATTER_PER_PRINTING_NS`, all three
+/// within 8% of each other) to be a real rate and not sampling noise, but from 3 points on one corpus
+/// size, not the corpus-scaling sweep the rates above this comment were fit with. Revisit if a wider
+/// measurement disagrees.
+pub(crate) const COMPOSE_COLLECTION_BROADCAST_PER_PRINTING_NS: f64 = 1.34;
 /// Result-space bitmap words popcounted for the total.
 const COMPOSE_POPCOUNT_PER_WORD_NS: f64 = 1.07;
 /// Per printing stepped over by the Perm / OrderbyWalk page fill.
@@ -746,6 +767,7 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
         PhysicalPlan::PrintingCompose => {
             let build = f64::from(f.broadcast_printings) * COMPOSE_LINEAR_PASS_PER_PRINTING_NS  // legality broadcast-down into the printing bitmap (border/rarity read a plane → 0)
                 + f64::from(f.scatter_printings) * COMPOSE_SCATTER_PER_PRINTING_NS  // range-slice scatter into the printing bitmap (cheap: no card cursor)
+                + f64::from(f.collection_broadcast_printings) * COMPOSE_COLLECTION_BROADCAST_PER_PRINTING_NS  // card-space collection leaf's build (ids_of + broadcast_card_ids_to_printings) — a card cursor per id, pricier than a range's contiguous scatter
                 + f64::from(f.project_printings) * COMPOSE_LINEAR_PASS_PER_PRINTING_NS  // second pass: project printing→card/artwork (0 for printing mode) — the pass CardRangePopcount fuses away
                 + f64::from(f.popcount_words) * COMPOSE_POPCOUNT_PER_WORD_NS; // popcount the result-space bitmap for the total (printing/card/artwork words)
             let page = match f.compose_paging {

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -136,6 +136,14 @@ pub(crate) struct PlanFeatures {
     /// Cards `run_query_streamed` visits in ARTWORK mode, i.e. `eval_domain` there and `0` in card and
     /// printing mode. Charged at `STREAM_ARTWORK_SEEN_PER_CARD_NS`.
     pub artwork_seen_cards: u32,
+    /// Printings `exec_gathered_scan` visits in ARTWORK mode, i.e. `scan_units` there and `0` in card
+    /// and printing mode. `push_card_matches`'s `Mode::Artwork` branch does a `group_best`/`touched`
+    /// dedupe check on every printing in a candidate's span (`Mode::Printing` does not), so unlike
+    /// `artwork_seen_cards` this rides `scan_units` (a printing count) rather than `eval_domain` (a
+    /// card count) -- the two plans' artwork overhead differ in SHAPE, not just rate, because
+    /// `run_query_streamed` dedupes with a fixed per-card bitmask while this loop dedupes per
+    /// printing. Charged at `GATHER_ARTWORK_PER_PRINTING_NS`.
+    pub artwork_seen_printings: u32,
     /// Printings compose's **Gather** paging branch bit-tests, which is NOT `scan_units`.
     ///
     /// `scan_units` is every printing under a candidate card — right for GatheredScan and
@@ -463,6 +471,20 @@ const STREAM_EMIT_PER_MATCH_NS: f64 = 0.12;
 /// sign. One mechanism showing up twice, so it belongs in its own term rather than as a mode-specific
 /// copy of each rate. ~16 word-ops per card is the right order for 2.4 ns.
 const STREAM_ARTWORK_SEEN_PER_CARD_NS: f64 = 1.21;
+/// ns per printing scanned, for `GatheredScan`'s ARTWORK-mode dedupe check
+/// (`push_card_matches`'s `Mode::Artwork` branch: read `artwork_group_col[pid]`, check
+/// `group_best[gid].is_some()`, on every printing in the candidate's span). Unlike
+/// `STREAM_ARTWORK_SEEN_PER_CARD_NS` this could not be fit from an end-to-end query A/B: the two
+/// modes' `matches_pushed` differ sharply (printing pushes every printing, artwork only distinct
+/// groups), so `GATHER_PUSH_PER_MATCH_NS`'s much larger swing dominated the raw delta and even its
+/// sign, and a pooled regression over natural queries hit multicollinearity between
+/// cards_visited/printing_span/matches_pushed and came back negative.
+///
+/// Fit from a kernel test instead (`gather_artwork_kernel_costs`): `push_card_matches` called
+/// directly over the same 5,000-card real-corpus slice with `all_match: true` (no residual
+/// evaluation cost), `Mode::Printing` vs `Mode::Artwork`, min-of-150 rounds. Four runs (two repeats,
+/// one on a different 5,000-card slice): 0.489, 0.528, 0.508, 0.489 ns/printing.
+const GATHER_ARTWORK_PER_PRINTING_NS: f64 = 0.50;
 /// ns per card scanned in the small-total gather (`for cid in 0..n_cards`,
 /// counts[cid]==0 check). Cheaper than a match-phase visit (no filter work). Fit
 /// from the narrow-query floor: cmc>=15 / o:annihilator / cmc==7 card SHALLOW all
@@ -907,6 +929,7 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 + matches * GATHER_PUSH_PER_MATCH_NS
                 + page_span * GATHER_SELECT_PER_PAGE_SLOT_NS
                 + page_rows * GATHER_COLLECT_PER_PAGE_ROW_NS
+                + f64::from(f.artwork_seen_printings) * GATHER_ARTWORK_PER_PRINTING_NS
                 + GATHER_FIXED_COST_NS
         }
     }

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -202,6 +202,11 @@ pub(crate) struct PlanFeatures {
     /// in ~`page_span/selectivity` steps), while the permutation-free gather visits every match — so
     /// the formula branches on this rather than assuming one. Ignored by every other plan.
     pub compose_paging: super::ComposePaging,
+    /// Interpolated walk length from `WalkCheckpoints`, when the acquire branch found one for this
+    /// value/sort-column -- `printings_walked` uses this directly instead of assuming matches spread
+    /// uniformly across the whole permutation. `None` everywhere except a bare card-space collection
+    /// leaf ordered by EDHREC, which is the only dimension `WalkCheckpoints` covers today.
+    pub walked_hint: Option<f64>,
 }
 
 // ─── P1: PrintingRangeScan ──────────────────────────────────────────────────
@@ -687,6 +692,11 @@ const COMPOSE_BUILD_PER_PRINTING_NS: f64 = 0.0835;
 /// entirely on this quantity and nothing else validates them.
 pub(crate) fn printings_walked(f: &PlanFeatures) -> f64 {
     let page_span = f64::from((f.offset.saturating_add(f.limit)).min(f.matches));
+    // `WalkCheckpoints`: an exact-anchored interpolation for a value whose cards' EDHREC positions are
+    // known, in place of assuming they spread uniformly across the whole permutation. See its doc.
+    if let Some(hint) = f.walked_hint {
+        return hint;
+    }
     let match_rate = (f64::from(f.matches) / f64::from(f.n_printings.max(1))).max(MATCH_RATE_FLOOR);
     page_span / match_rate * WALK_LENGTH_BIAS
 }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -10277,6 +10277,10 @@ fn mk_plan_feats(
         // artwork mode only — so it rides `eval_domain` there and vanishes elsewhere. See
         // STREAM_ARTWORK_SEEN_PER_CARD_NS for the mechanism and the measurement.
         artwork_seen_cards: if matches!(params.mode, Mode::Artwork) { eval_domain } else { 0 },
+        // `exec_gathered_scan` pays its dedupe check unconditionally (no `all_match_known` shortcut
+        // like `run_query_streamed`'s stored-group-count fast path), so unlike `artwork_seen_cards`
+        // above this is never zeroed by `candidate_feats`'s all-match/card-invariant overrides.
+        artwork_seen_printings: if matches!(params.mode, Mode::Artwork) { scan_units } else { 0 },
         compose_scan_printings: 0, // set by every branch that costs a PrintingCompose (its own, or as a competitor)
         gather_group_printings: 0, // only the compose branch, and only when its grouping arm runs
     }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1814,9 +1814,15 @@ struct DenseBits {
 }
 
 fn build_hybrid_tag_index<T>(rows: &[T], vocab: &[String], get_ids: impl Fn(&T) -> &Vec<u16>) -> HybridTagIndex {
-    let n = rows.len();
+    finish_hybrid_tag_index(build_tag_index(rows, vocab, get_ids), rows.len())
+}
+
+/// The bitmap-vs-postings storage decision `build_hybrid_tag_index` makes, factored out so a caller
+/// with values already grouped by String (not a `coll_vocab` id) can share it without going through
+/// `build_tag_index`'s `Vec<u16>` id scheme -- see `build_layout_hybrid_index`.
+fn finish_hybrid_tag_index(by_value: HashMap<String, Vec<u32>>, n: usize) -> HybridTagIndex {
     let mut out = HybridTagIndex::default();
-    for (value, postings) in build_tag_index(rows, vocab, get_ids) {
+    for (value, postings) in by_value {
         if bitmap_beats_postings(postings.len(), n) {
             // Popcounted from the scattered bitmap, not `postings.len()`: a duplicate row id in
             // `postings` sets the same bit twice, which `postings.len()` would over-count and the
@@ -1830,6 +1836,20 @@ fn build_hybrid_tag_index<T>(rows: &[T], vocab: &[String], get_ids: impl Fn(&T) 
         }
     }
     out
+}
+
+/// `layout` is a CARD-scalar text field (every printing of a card shares one layout, unlike
+/// `border`/`frame_data` which vary printing to printing) interned through the general string table
+/// rather than `coll_vocab`, so it cannot use `build_hybrid_tag_index`'s `Vec<u16>`-of-vocab-ids
+/// shape directly -- this groups by the resolved String instead and hands the result to the same
+/// storage decision. Card ids land in each bucket in ascending order because `cards` is walked in
+/// order, matching every other index's sorted-postings convention.
+fn build_layout_hybrid_index(cards: &[OracleCard], strings: &[String]) -> HybridTagIndex {
+    let mut by_value: HashMap<String, Vec<u32>> = HashMap::new();
+    for (cid, card) in cards.iter().enumerate() {
+        by_value.entry(strings[card.card_layout_id as usize].clone()).or_default().push(cid as u32);
+    }
+    finish_hybrid_tag_index(by_value, cards.len())
 }
 
 impl ArchivedHybridTagIndex {
@@ -3811,6 +3831,12 @@ struct CardIndexes {
     subtypes:       HybridTagIndex,  // card space
     keywords:       HybridTagIndex,  // card space
     oracle_tags:    HybridTagIndex,  // card space
+    // Scalar, not a collection (every card has exactly one layout) -- narrow_rec's TextExact::Eq
+    // arm for it is a direct tight bucket lookup, unlike the CollectionCmp arm above it shares
+    // storage with. `layout:` (is:split/dfc/meld/...) had NO narrowing at all before this, so an
+    // unnarrowable `is:` predicate fell back to "assume ~everything matches" and badly mis-costed
+    // both materializing plans by different factors, flipping routing between them.
+    layout:         HybridTagIndex,  // card space (scalar, not a collection)
     art_tags:       HybridTagIndex,  // printing space
     is_tags:        HybridTagIndex,  // printing space
     frame_data:     HybridTagIndex,  // printing space (bitmap for dense values, postings for the sparse tail)
@@ -5268,6 +5294,35 @@ fn narrow_rec(
                 return None;
             }
             Narrowed::tight(Candidates::Printings(expand_flavor_ids(flavor, dense_ids, n_printings)))
+        }
+
+        // layout: (`is:split`/`is:dfc`/`is:meld`/... rewrite to this in api/parsing/rewrite.py) is a
+        // CARD-scalar text field -- every printing of a card shares one
+        // layout, unlike `border`/`frame_data` which vary printing to printing -- narrowed the same
+        // way `subtypes`/`keywords`/`oracle_tags` are: a `HybridTagIndex` bucket per value. Tight,
+        // unlike those fields' own Eq/Gt (which need a downstream length check because containment
+        // isn't equality for a multi-valued collection): a scalar field's bucket membership IS
+        // equality, so there is no ambiguity to re-verify.
+        //
+        // Before this, `layout:` had no narrowing arm at all, so `is:split eur>0.07`-shaped queries
+        // fell through with `raw_candidates: None` and the acquire path assumed ~100% selectivity
+        // (`matches` read 31,724 of 31,724 cards) against a real match rate of 0.4-1.6% --
+        // mis-costing StreamedSelect and GatheredScan by different multipliers of the same wrong
+        // scan_units and flipping which one the router picked.
+        FilterExpr::TextExact { field: TextField::Layout, op: CmpOp::Eq, value } => {
+            let idx = &indexes.layout;
+            match idx.len_of(value.as_str()) {
+                // No card has this layout value: proves the predicate false everywhere.
+                None => Narrowed::tight(Candidates::Cards(Vec::new())),
+                Some(k) => {
+                    if k > *BITS_PROMOTE
+                        && let Some(b) = idx.dense(value.as_str())
+                    {
+                        return Narrowed::tight(Candidates::CardBits(b.words.iter().map(|w| u64::from(*w)).collect()));
+                    }
+                    Narrowed::tight(Candidates::Cards(idx.ids_of(value.as_str())?))
+                }
+            }
         }
 
         FilterExpr::TextExact { field: TextField::SetCode, op: CmpOp::Eq, value } => {
@@ -12030,7 +12085,11 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 //
 // 2026082302 — new `CardIndexes` field `edhrec_walk_checkpoints` (`WalkCheckpoints` for subtypes/
 // keywords/oracle_tags against the EDHREC permutation). Same blind spot again.
-const ARCHIVE_FORMAT_VERSION: u32 = 2026082302;
+//
+// 2026082303 — new `CardIndexes` field `layout` (a `HybridTagIndex` giving `layout:` -- and so
+// `is:split`/`is:dfc`/`is:meld`/... -- real candidate narrowing for the first time). Same blind spot
+// again: entirely inside `CardIndexes`.
+const ARCHIVE_FORMAT_VERSION: u32 = 2026082303;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -12598,6 +12657,7 @@ impl QueryEngine {
             subtypes:       build_hybrid_tag_index(&cards, &coll_vocab, |c| &c.card_subtypes),
             keywords:       build_hybrid_tag_index(&cards, &coll_vocab, |c| &c.card_keywords),
             oracle_tags:    build_hybrid_tag_index(&cards, &coll_vocab, |c| &c.card_oracle_tags),
+            layout:         build_layout_hybrid_index(&cards, &strings),
             art_tags:       build_hybrid_tag_index(&printings, &coll_vocab, |p| &p.card_art_tags),
             is_tags:        build_hybrid_tag_index(&printings, &coll_vocab, |p| &p.card_is_tags),
             frame_data:     build_hybrid_tag_index(&printings, &coll_vocab, |p| &p.card_frame_data),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -10405,6 +10405,25 @@ fn candidate_feats(ctx: &QueryCtx, params: &QueryParams, prep: &PreparedCandidat
         } else {
             verify_cost_tier_unproven(filter, prep.proven_conjuncts)
         });
+    // Card mode, default prefer, all_match_known: `push_card_matches`/`card_match_count`'s Mode::Card
+    // arm breaks at the FIRST printing every time (`all_match` is true unconditionally, so the loop's
+    // `if all_match || ...` fires on `pid == start`), so `printings_examined` is exactly `count` (one
+    // per candidate) -- never the `n_printings/n_cards` SPAN `scan` estimates. Measured: GatheredScan's
+    // `scan_units/printings_examined` on this population reads flat at 3.08 (== n_printings/n_cards)
+    // from p10 to p90, not a tail effect. Only `all_match_known` -- with a residual, `card_match_count`
+    // still breaks at the first MATCHING printing, but which one that is depends on the residual's
+    // selectivity, so `count` would under-charge instead; that harder case is unfixed here. Only
+    // `Prefer::Default` -- custom prefer's arm scores every printing even under `all_match` (it must,
+    // to find the best-scoring one), so `span` is the right estimate there and already reads 1.00.
+    //
+    // GatheredScan reads this directly (no tier gate on its scan term, unlike StreamedSelect's), so the
+    // 3.08x error rides straight into `GATHER_SCAN_PER_ROW_NS * scan_units` on every such query. Harmless
+    // for StreamedSelect: its own term is `if tier_ns > 0.0 { stream_scan_units * RATE } else { 0.0 }`,
+    // and `all_match_known` means `tier_ns == 0`, so it never reads this value in the case it is wrong.
+    if matches!(params.mode, Mode::Card) && matches!(params.prefer, Prefer::Default) && prep.all_match_known {
+        feats.scan_units = count;
+        feats.stream_scan_units = count; // inherited default; harmless per the tier gate above, kept in sync
+    }
     // Diagnostic only (`explain`), so the residual-pass-rate population can be split by traffic before any
     // rate moves. A card-invariant residual answers `True`/`False` per card and never `PrintingDep`, so a
     // matching candidate contributes its WHOLE printing span and a non-matching one none of it — the

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2573,6 +2573,183 @@ fn legality_totals_key(shift: u8, expected: u64) -> u16 {
     (u16::from(shift) << 2) | (expected as u16 & 0b11)
 }
 
+/// Cumulative PRINTING counts at which `WalkCheckpoints` records a position (see
+/// `WalkCheckpoints::from_weighted_positions` for why printings, not cards). Chosen to bracket real
+/// traffic rather than spread evenly: `REALISTIC_OFFSET_WEIGHTS`/`LIMITS` in the client's sampler top
+/// out around `offset + limit` ~875, so checkpoint[800] sits almost exactly at the deepest page real
+/// queries ask for, and the four gaps below it give the interpolation four independent anchors across
+/// the range that matters instead of one.
+const WALK_CHECKPOINT_COUNTS: [u32; 5] = [1, 100, 200, 400, 800];
+
+/// Positions (within one EDHREC permutation direction) at which cumulative PRINTINGS from matching
+/// cards reaches 1/100/200/400/800, for card-space collection fields whose `Perm`-branch walk length
+/// (`cost::printings_walked`) is otherwise a single global rate blind to WHERE a value's cards sit in
+/// EDHREC order.
+///
+/// #1005/#1006/#1007 fixed the tier and candidate-count features on this branch; this is the
+/// remaining piece docs/issues/local-engine-compose-paging-cost-based.md leaves unresolved --
+/// `otag:triggered-ability` measured a 3.2x walk-length miss (predicted 602, realized 1,942) that a
+/// ~10% printings-per-matching-card skew cannot explain, so the error is genuine EDHREC-order
+/// clumping, not a rate. `matches`/`SpaceTotals` give an exact total; this gives the SHAPE of where
+/// those matches fall, which no scalar total can.
+///
+/// 20 bytes per (value, direction) — five `u32` positions, no separate rate to fit.
+#[derive(Archive, Serialize, Deserialize, Default, Clone, Copy)]
+struct WalkCheckpoints {
+    /// Ascending by construction (each is a position further into the walk than the last). Fewer than
+    /// `WALK_CHECKPOINT_COUNTS.len()` meaningful entries when the value has fewer total matches --
+    /// `len` says how many of `positions` are real; the rest are zero and must not be read.
+    positions: [u32; 5],
+    len: u8,
+}
+
+impl WalkCheckpoints {
+    /// Builds from a value's `(position, printing_span)` pairs in ONE permutation direction, not
+    /// necessarily sorted yet -- one pair per matching card, `printing_span` that card's own printing
+    /// count. NOT one card per checkpoint slot: `unique=printing` needs "cumulative PRINTINGS reaches
+    /// N", and a card-level predicate's matching cards can each contribute more than one printing at
+    /// once, so this walks matches in permutation order accumulating printing span, not card count,
+    /// and records a checkpoint's position the moment that running total reaches it.
+    fn from_weighted_positions(mut entries: Vec<(u32, u32)>) -> WalkCheckpoints {
+        entries.sort_unstable_by_key(|&(pos, _)| pos);
+        let mut out = WalkCheckpoints::default();
+        let mut cumulative: u64 = 0;
+        let mut next = 0usize;
+        for (pos, span) in entries {
+            cumulative += u64::from(span);
+            while next < WALK_CHECKPOINT_COUNTS.len() && cumulative >= u64::from(WALK_CHECKPOINT_COUNTS[next]) {
+                out.positions[next] = pos;
+                out.len = (next + 1) as u8;
+                next += 1;
+            }
+            if next >= WALK_CHECKPOINT_COUNTS.len() {
+                break;
+            }
+        }
+        out
+    }
+}
+
+impl ArchivedWalkCheckpoints {
+    /// Estimated walk length (permutation entries to visit) to accumulate `k` matches, by linear
+    /// interpolation between the two stored checkpoints bracketing `k` -- or extrapolation from the
+    /// last segment's slope past the final checkpoint. `None` when there are no checkpoints at all
+    /// (an empty value, which `len_of`/`SpaceTotals` already answer as an exact zero elsewhere).
+    fn walk_length_for(&self, k: u32) -> Option<f64> {
+        let len = usize::from(self.len);
+        if len == 0 {
+            return None;
+        }
+        let count_at = |i: usize| WALK_CHECKPOINT_COUNTS[i] as f64;
+        let pos_at = |i: usize| f64::from(u32::from(self.positions[i]));
+        // Below the first checkpoint: interpolate from the origin (position 0, count 0) -- the walk
+        // has not found anything yet at that point, so the origin is an exact anchor, not an estimate.
+        if k as f64 <= count_at(0) {
+            return Some(pos_at(0) * (k as f64 / count_at(0)));
+        }
+        // Between two stored checkpoints: interpolate the segment they bound.
+        for i in 1..len {
+            if k as f64 <= count_at(i) {
+                let (c0, c1, p0, p1) = (count_at(i - 1), count_at(i), pos_at(i - 1), pos_at(i));
+                return Some(p0 + (p1 - p0) * (k as f64 - c0) / (c1 - c0));
+            }
+        }
+        // Past the last checkpoint: extrapolate the final segment's slope. `len == 1` has no segment to
+        // slope from, so it falls back to the same origin-to-first-checkpoint rate used below count(0).
+        let (c0, c1, p0, p1) = if len >= 2 {
+            (count_at(len - 2), count_at(len - 1), pos_at(len - 2), pos_at(len - 1))
+        } else {
+            (0.0, count_at(0), 0.0, pos_at(0))
+        };
+        let rate = (p1 - p0) / (c1 - c0);
+        Some(p1 + rate * (k as f64 - c1))
+    }
+}
+
+/// One value's `(position, printing_span)` pairs in each EDHREC direction, in one pass over `cards`.
+/// Generic over the key exactly like `build_value_totals`, for the same reason: subtypes/keywords/
+/// oracle_tags are the same shape of dimension (multi-valued, `coll_vocab`-keyed, card-space), just
+/// answering a different question here.
+/// Prefix sum, in EACH permutation direction, of every VISITED card's printing span -- matching or
+/// not. The walk bit-tests every card it steps past, so "how many printings has the walk examined by
+/// position P" is this, not P itself: a card position is a CARD-count quantity (0..n_cards), while
+/// `printings_walked` answers in PRINTING units (0..n_printings, ~3.1x larger on this corpus) because
+/// that is what it is compared against (`printings_examined`). One array per direction, shared by
+/// every value's checkpoints -- not itself keyed by value.
+fn build_perm_prefix_printings(offsets: &[u32], edhrec_perm: &[Vec<u32>; 2]) -> [Vec<u32>; 2] {
+    let prefix_of = |perm: &[u32]| -> Vec<u32> {
+        let mut cumulative = 0u32;
+        perm.iter()
+            .map(|&cid| {
+                cumulative += offsets[cid as usize + 1] - offsets[cid as usize];
+                cumulative
+            })
+            .collect()
+    };
+    [prefix_of(&edhrec_perm[0]), prefix_of(&edhrec_perm[1])]
+}
+
+fn build_walk_checkpoints<K: Eq + std::hash::Hash>(
+    cards: &[OracleCard],
+    offsets: &[u32],
+    edhrec_inv: &[Vec<u32>; 2],
+    perm_prefix_printings: &[Vec<u32>; 2],
+    keys_of: impl Fn(&OracleCard) -> Vec<K>,
+) -> HashMap<K, [WalkCheckpoints; 2]> {
+    let mut entries: HashMap<K, [Vec<(u32, u32)>; 2]> = HashMap::new();
+    for (cid, card) in cards.iter().enumerate() {
+        let span = offsets[cid + 1] - offsets[cid];
+        for key in keys_of(card) {
+            let e = entries.entry(key).or_insert_with(|| [Vec::new(), Vec::new()]);
+            for dir in 0..2 {
+                let pos = edhrec_inv[dir][cid] as usize;
+                // The "position" a checkpoint records is printings examined walking up to and
+                // including THIS card, not the card's own rank -- exact, since it comes straight off
+                // the prefix sum, not an averaged printings-per-card ratio.
+                e[dir].push((perm_prefix_printings[dir][pos], span));
+            }
+        }
+    }
+    entries
+        .into_iter()
+        .map(|(k, [asc, desc])| {
+            (k, [WalkCheckpoints::from_weighted_positions(asc), WalkCheckpoints::from_weighted_positions(desc)])
+        })
+        .collect()
+}
+
+/// `WalkCheckpoints` for the three card-space collection fields, EDHREC only -- the dimension that
+/// produced every `Perm`-branch mis-route measured this session, and (per `REALISTIC_FAMILY_WEIGHTS`)
+/// the dominant orderby by far. `art_tags`/`is_tags` are printing-space (no card permutation to build
+/// checkpoints against) and `frame_data` already routes around this via its own gate; not attempted.
+#[derive(Archive, Serialize, Deserialize, Default)]
+struct EdhrecWalkCheckpoints {
+    subtypes: HashMap<String, [WalkCheckpoints; 2]>,
+    keywords: HashMap<String, [WalkCheckpoints; 2]>,
+    oracle_tags: HashMap<String, [WalkCheckpoints; 2]>,
+}
+
+fn build_edhrec_walk_checkpoints(
+    cards: &[OracleCard],
+    offsets: &[u32],
+    coll_vocab: &[String],
+    edhrec_perm: &[Vec<u32>; 2],
+    edhrec_inv: &[Vec<u32>; 2],
+) -> EdhrecWalkCheckpoints {
+    let perm_prefix_printings = build_perm_prefix_printings(offsets, edhrec_perm);
+    EdhrecWalkCheckpoints {
+        subtypes: build_walk_checkpoints(cards, offsets, edhrec_inv, &perm_prefix_printings, |card| {
+            card.card_subtypes.iter().map(|v| coll_vocab[*v as usize].clone()).collect()
+        }),
+        keywords: build_walk_checkpoints(cards, offsets, edhrec_inv, &perm_prefix_printings, |card| {
+            card.card_keywords.iter().map(|v| coll_vocab[*v as usize].clone()).collect()
+        }),
+        oracle_tags: build_walk_checkpoints(cards, offsets, edhrec_inv, &perm_prefix_printings, |card| {
+            card.card_oracle_tags.iter().map(|v| coll_vocab[*v as usize].clone()).collect()
+        }),
+    }
+}
+
 /// A value is worth PAIRING only if it is broad enough that an estimate about it can change a routing
 /// decision. `STREAM_MIN_MATCHES` is that line: below it the sparse floor decides the plan, not the
 /// estimate's precision, and min-over-singles is already within a small factor of the truth.
@@ -3669,6 +3846,9 @@ struct CardIndexes {
     /// Exact 3-space totals for PAIRS of dense low-cardinality values (~14 KB), so a two-leaf `And` over
     /// them is answered rather than bounded by `min`.
     pair_totals:    PairTotals,
+    /// Where a card-space collection value's cards fall in EDHREC order, so the `Perm`-branch walk
+    /// length can be interpolated instead of assumed uniform. See `WalkCheckpoints`.
+    edhrec_walk_checkpoints: EdhrecWalkCheckpoints,
     sort_perms:     SortPermutations,          // card space (streamed selection)
     artwork_groups: Vec<u16>,                  // card space: distinct illustration groups
     // card space, n_cards+1 entries: prefix sum of artwork_groups, so card c's artworks are the
@@ -8589,6 +8769,23 @@ fn compose_leaf_nothing_to_verify(filter: &FilterExpr) -> bool {
     )
 }
 
+/// `WalkCheckpoints` for a bare card-space collection leaf, in the direction the query walks --
+/// `None` for every other filter shape (compound, wrong field, wrong op) and for a value the table
+/// happens not to cover (never built, so `len == 0`). Deliberately the SAME shape
+/// `compose_leaf_nothing_to_verify` matches: both ask "is this filter a bare Ge leaf on one of the
+/// three card-space fields", just for different reasons.
+fn edhrec_walk_checkpoints_for<'i>(indexes: &'i Archived<CardIndexes>, filter: &FilterExpr, descending: bool) -> Option<&'i Archived<WalkCheckpoints>> {
+    let FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value, .. } = filter else { return None };
+    let table = match field {
+        CollField::Subtypes => &indexes.edhrec_walk_checkpoints.subtypes,
+        CollField::Keywords => &indexes.edhrec_walk_checkpoints.keywords,
+        CollField::OracleTags => &indexes.edhrec_walk_checkpoints.oracle_tags,
+        CollField::ArtTags | CollField::IsTags | CollField::FrameData => return None,
+    };
+    let cp = &table.get(value.as_str())?[usize::from(descending)];
+    (cp.len > 0).then_some(cp)
+}
+
 /// The candidate materialization + filter rewriting shared by `StreamedSelect`
 /// and `GatheredScan`, extracted verbatim from `run_query`. Mutates `filter` via
 /// `memoize_text_predicates` + `order_children_by_verify_cost` under the same
@@ -10049,6 +10246,7 @@ fn mk_plan_feats(
         project_printings: 0,  // PrintingCompose's card/artwork projection pass; CardRangePopcount sets it too (for costing compose)
         popcount_words: 0,     // PrintingCompose overrides this (result-space bitmap words)
         compose_paging: ComposePaging::Gather, // PrintingCompose overrides this (which paging strategy it'll actually use)
+        walked_hint: None, // PrintingCompose's bare-collection-leaf-on-EDHREC branch overrides this
         // `run_query_streamed`'s per-card artwork overhead applies to every candidate it visits, in
         // artwork mode only — so it rides `eval_domain` there and vanishes elsewhere. See
         // STREAM_ARTWORK_SEEN_PER_CARD_NS for the mechanism and the measurement.
@@ -10571,6 +10769,14 @@ fn acquire_plan_features(
             .flatten();
         feats.compose_paging =
             compose_paging_with_total(indexes, cards.len(), composed, mode, sort_col, descending, Some(result_total), gather_declines);
+        // `WalkCheckpoints` only covers `unique=printing` ordered by EDHREC today (see its doc for why
+        // printing mode specifically: a card-level match can contribute more than one printing at
+        // once, which is what the table is built to weight by). `filter`, not `composed`: the same
+        // "ask about what the WALK sees" reasoning `compose_leaf_nothing_to_verify`'s call site uses.
+        if matches!(mode, Mode::Printing) && matches!(sort_col, SortCol::EdhrecRank) {
+            let k = (params.page_offset as u32).saturating_add(params.limit as u32).min(result_total as u32);
+            feats.walked_hint = edhrec_walk_checkpoints_for(indexes, filter, descending).and_then(|cp| cp.walk_length_for(k));
+        }
         (feats, Prep::Range(CountSource::PrintingCompose))
     } else {
         let prep = prepare_candidates(ctx, params, filter, plane);
@@ -11790,7 +11996,10 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 // 2026082301 — `ValueTotals` gains `colors`/`color_identity`/`produced_mana`, exact per-combination
 // totals for `ColorCmp`. Same blind spot as the previous bump: entirely inside `CardIndexes`, so the
 // header's `AOracleCard`/`APrinting` sizes don't move and can't catch it.
-const ARCHIVE_FORMAT_VERSION: u32 = 2026082301;
+//
+// 2026082302 — new `CardIndexes` field `edhrec_walk_checkpoints` (`WalkCheckpoints` for subtypes/
+// keywords/oracle_tags against the EDHREC permutation). Same blind spot again.
+const ARCHIVE_FORMAT_VERSION: u32 = 2026082302;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -12335,6 +12544,11 @@ impl QueryEngine {
             &coll_vocab,
             usize::from(artwork_group_counts.iter().copied().max().unwrap_or(0)),
         );
+        // Out here (rather than inline in the struct literal, like `pair_totals`/`value_totals` above)
+        // because `edhrec_walk_checkpoints` needs its `edhrec_inv` before the literal moves `cards`.
+        let sort_perms = build_sort_permutations(&cards);
+        let edhrec_walk_checkpoints =
+            build_edhrec_walk_checkpoints(&cards, &offsets, &coll_vocab, &sort_perms.edhrec, &sort_perms.edhrec_inv);
         let value_totals = build_all_value_totals(
             &cards,
             &printings,
@@ -12388,7 +12602,8 @@ impl QueryEngine {
             price_eur_cards,
             price_tix_cards,
             collector_number_cards,
-            sort_perms:     build_sort_permutations(&cards),
+            sort_perms,
+            edhrec_walk_checkpoints,
             max_artwork_groups: artwork_group_counts.iter().copied().max().unwrap_or(0),
             artwork_groups: artwork_group_counts,
             // Columnar copy of each printing's assigned artwork_group_id, derived here — the single

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -12312,6 +12312,7 @@ fn acquire_facts_to_pydict<'py>(py: Python<'py>, f: &AcquireFacts) -> PyResult<B
         ("project_printings", g.project_printings),
         ("popcount_words", g.popcount_words),
         ("artwork_seen_cards", g.artwork_seen_cards),
+        ("artwork_seen_printings", g.artwork_seen_printings),
         ("compose_scan_printings", g.compose_scan_printings),
         ("gather_group_printings", g.gather_group_printings),
         // Derived inside plan_cost rather than stored, and exposed because the Perm/OrderbyWalk

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -7362,12 +7362,27 @@ struct ComposeEstimate {
     candidate: usize,
     broadcast: usize,
     scatter: usize,
+    /// Printings a CARD-SPACE collection leaf's build broadcasts (`ids_of` +
+    /// `broadcast_card_ids_to_printings`) -- kept apart from `scatter` because it is a different,
+    /// pricier operation (a card-cursor lookup per id, then a variable-width printing-range fill) than
+    /// a range's contiguous slice-scatter. Measured riding `scatter`'s rate on `otag:triggered-ability`
+    /// /`otag:cycle`/`otag:activated-ability`: 2.7-2.9x too cheap, consistently across all three (see
+    /// `COMPOSE_COLLECTION_BROADCAST_PER_PRINTING_NS`). Printing-space collection leaves (art_tags/
+    /// is_tags) still ride `scatter`: their build IS a contiguous `bits()` copy, the same shape a
+    /// range's is, and measured fine.
+    collection_broadcast: usize,
 }
 
 impl ComposeEstimate {
     /// A leaf: nothing to tighten, so both figures are the same count.
     fn leaf(k: usize, broadcast: usize, scatter: usize) -> Self {
-        Self { result: k, candidate: k, broadcast, scatter }
+        Self { result: k, candidate: k, broadcast, scatter, collection_broadcast: 0 }
+    }
+
+    /// A card-space collection leaf specifically -- see `collection_broadcast`'s doc for why this
+    /// isn't just `leaf(k, 0, k)`.
+    fn collection_leaf(k: usize) -> Self {
+        Self { result: k, candidate: k, broadcast: 0, scatter: 0, collection_broadcast: k }
     }
 }
 
@@ -7397,6 +7412,7 @@ fn compose_printing_estimate(
                     candidate: a.candidate.min(c.candidate),
                     broadcast: a.broadcast + c.broadcast,
                     scatter: a.scatter + c.scatter,
+                    collection_broadcast: a.collection_broadcast + c.collection_broadcast,
                 });
             // Tighten the `min` bound with every PAIR of children the table stores. `min` over singles
             // lets the most selective leaf decide alone, which is why `f:modern r:rare border:white`
@@ -7419,6 +7435,7 @@ fn compose_printing_estimate(
                     candidate: a.candidate + c.candidate,
                     broadcast: a.broadcast + c.broadcast,
                     scatter: a.scatter + c.scatter,
+                    collection_broadcast: a.collection_broadcast + c.collection_broadcast,
                 });
             ComposeEstimate {
                 result: summed.result.min(n_printings),
@@ -7454,17 +7471,20 @@ fn compose_printing_estimate(
         }
         // Collection containment leaf (`type:`/`kw:`/`otag:`/`art:`/`is:`, `Ge`): `k` = the exact
         // printing count the leaf matches (card-space sums the matching cards' printing ranges,
-        // printing-space is the postings length). The build scatters `k` printings → rides `scatter`,
-        // the cheap range-slice rate.
+        // printing-space is the postings length). Card-space fields build via `ids_of` +
+        // `broadcast_card_ids_to_printings` (a card-cursor lookup per id) -- `collection_broadcast`,
+        // not `scatter`. Printing-space fields build via a contiguous `bits()` copy, the same shape a
+        // range's scatter is, so they keep riding `scatter`'s rate.
         FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value, .. }
             if collection_compose_index(indexes, *field).is_some() =>
         {
             let src = collection_compose_index(indexes, *field).expect("guarded by the if");
             let k = collection_leaf_printing_count(&src, value.as_str(), offsets);
-            ComposeEstimate::leaf(k, 0, k)
+            if src.card_space { ComposeEstimate::collection_leaf(k) } else { ComposeEstimate::leaf(k, 0, k) }
         }
-        // Negated collection leaf: all printings minus the positive `k`; the scatter cost rides the
-        // (small) positive `k` cleared, not the (large) complement it produces — same shape as `-set:`.
+        // Negated collection leaf: all printings minus the positive `k`; the build cost rides the
+        // (small) positive `k` cleared, not the (large) complement it produces — same shape as `-set:`,
+        // and the same card-space-vs-printing-space split as the positive leaf above.
         FilterExpr::Not(inner)
             if matches!(inner.as_ref(), FilterExpr::CollectionCmp { field, op: CmpOp::Ge, .. } if collection_compose_index(indexes, *field).is_some()) =>
         {
@@ -7473,7 +7493,12 @@ fn compose_printing_estimate(
             };
             let src = collection_compose_index(indexes, *field).expect("guarded by the matches!");
             let k = collection_leaf_printing_count(&src, value.as_str(), offsets);
-            ComposeEstimate::leaf(n_printings.saturating_sub(k), 0, k)
+            let complement = n_printings.saturating_sub(k);
+            if src.card_space {
+                ComposeEstimate { result: complement, candidate: complement, broadcast: 0, scatter: 0, collection_broadcast: k }
+            } else {
+                ComposeEstimate::leaf(complement, 0, k)
+            }
         }
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op, rhs: NumExpr::Const(c) } => {
             ComposeEstimate::leaf(popcount(&rarity_cmp_leaf_bits(*op, *c, &indexes.rarity_printing, n_printings)), 0, 0)
@@ -10247,6 +10272,7 @@ fn mk_plan_feats(
         popcount_words: 0,     // PrintingCompose overrides this (result-space bitmap words)
         compose_paging: ComposePaging::Gather, // PrintingCompose overrides this (which paging strategy it'll actually use)
         walked_hint: None, // PrintingCompose's bare-collection-leaf-on-EDHREC branch overrides this
+        collection_broadcast_printings: 0, // PrintingCompose overrides this for a card-space collection leaf
         // `run_query_streamed`'s per-card artwork overhead applies to every candidate it visits, in
         // artwork mode only — so it rides `eval_domain` there and vanishes elsewhere. See
         // STREAM_ARTWORK_SEEN_PER_CARD_NS for the mechanism and the measurement.
@@ -10521,7 +10547,7 @@ fn acquire_plan_features(
         // execution have to agree on which representation this plan is being judged on.
         let composed = compose_source(filter, unsplit, plane);
         let est = compose_printing_estimate(composed, indexes, offsets, n_printings as usize);
-        let (printing_matches, broadcast, scatter) = (est.result, est.broadcast, est.scatter);
+        let (printing_matches, broadcast, scatter, collection_broadcast) = (est.result, est.broadcast, est.scatter, est.collection_broadcast);
         // Two build kinds, charged at different rates: `broadcast` = legality broadcast-down (linear
         // pass), `scatter` = range-slice scatter (cheap). `project` = the second pass (printing→
         // card/artwork), 0 for printing mode. Keeping all three separate is what lets a bare range's
@@ -10741,6 +10767,7 @@ fn acquire_plan_features(
         };
         feats.broadcast_printings = broadcast as u32;
         feats.scatter_printings = scatter as u32;
+        feats.collection_broadcast_printings = collection_broadcast as u32;
         feats.project_printings = project as u32;
         feats.popcount_words = popcount_words as u32;
         feats.compose_scan_printings = (printing_matches as f64 * COMPOSE_GATHER_SPAN_PER_MATCH) as u32;

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     and_child_rank, assign_name_ranks,
     build_numeric_index, build_oracle_text_index, build_trigram_index,
-    build_rarity_index, build_flavor_index, build_hybrid_tag_index, bitmap_beats_postings, HybridTagIndex, build_sort_permutations,
+    build_rarity_index, build_flavor_index, build_hybrid_tag_index, bitmap_beats_postings, HybridTagIndex, build_sort_permutations, EdhrecWalkCheckpoints,
     assign_artwork_groups, build_artwork_base_from, build_bit_planes, build_border_printing_planes, build_rarity_printing_planes, build_divergent_ids, build_name_bigram_index, build_name_unigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_printing_value_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
@@ -5157,7 +5157,7 @@ fn plan_cost_model_matches_gold() {
                     residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                     limit: limit as u32,
                     offset: offset as u32,
-                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
+                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
@@ -5399,7 +5399,7 @@ fn plan_cost_refit() {
                     residual_tier_ns100: if prep.all_match_known { 0 } else { verify_cost_tier(&res) },
                     residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                     limit: limit as u32, offset: offset as u32,
-                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
+                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
@@ -5604,7 +5604,7 @@ fn printing_range_route_probe() {
                 residual_tier_ns100,
                 residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                 limit: LIMIT as u32, offset: offset as u32,
-                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
@@ -5967,7 +5967,7 @@ fn plan_regret_report() {
                 residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                 limit: limit as u32,
                 offset: offset as u32,
-                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
@@ -6097,7 +6097,7 @@ fn plan_regret_fuzz() {
                 residual_tier_ns100: tier,
                 residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                 limit: limit as u32, offset: offset as u32,
-                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
@@ -6422,6 +6422,7 @@ fn bench_checked_vs_unchecked_access() {
         art_tags:       build_hybrid_tag_index(&printings, &vocab.strings, |p| &p.card_art_tags),
         is_tags:        build_hybrid_tag_index(&printings, &vocab.strings, |p| &p.card_is_tags),
         frame_data:     HybridTagIndex::default(),
+        edhrec_walk_checkpoints: EdhrecWalkCheckpoints::default(),
         artists:        ArtistIndex::default(),
         flavor:         build_flavor_index(&printings, &strings),
         set_codes:      HashMap::new(),

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -12,6 +12,7 @@ use super::{
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
     prepare_candidates, verify_cost_tier, scan_units, sort_col_bound, divergent_formats_of, Mode, QueryCtx, QueryParams, Prefer, SortBound,
+    push_card_matches,
     GatherSelect, select_page, GATHER_PRUNE_CHUNK, Match,
     archive_header, archive_payload, ARCHIVE_HEADER_LEN, Mmap,
     bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, split_planes,
@@ -5159,6 +5160,7 @@ fn plan_cost_model_matches_gold() {
                     offset: offset as u32,
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None, collection_broadcast_printings: 0,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
+                artwork_seen_printings: 0, // no artwork per-printing dedupe check in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
                 };
@@ -5401,6 +5403,7 @@ fn plan_cost_refit() {
                     limit: limit as u32, offset: offset as u32,
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None, collection_broadcast_printings: 0,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
+                artwork_seen_printings: 0, // no artwork per-printing dedupe check in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
                 };
@@ -5606,6 +5609,7 @@ fn printing_range_route_probe() {
                 limit: LIMIT as u32, offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None, collection_broadcast_printings: 0,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
+                artwork_seen_printings: 0, // no artwork per-printing dedupe check in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
             };
@@ -5969,6 +5973,7 @@ fn plan_regret_report() {
                 offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None, collection_broadcast_printings: 0,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
+                artwork_seen_printings: 0, // no artwork per-printing dedupe check in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
             };
@@ -6099,6 +6104,7 @@ fn plan_regret_fuzz() {
                 limit: limit as u32, offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None, collection_broadcast_printings: 0,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
+                artwork_seen_printings: 0, // no artwork per-printing dedupe check in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
             };
@@ -10982,6 +10988,91 @@ fn range_compose_kernel_costs() {
             "{hi:>8}  {set_prtg:>10}  {scatter_ns:>10}  {per_prtg:>11.3}  {proj_ns:>10}  {exists_cards:>10}  {walk_ns:>9}"
         );
     }
+}
+
+/// `GatheredScan`'s artwork-mode overhead: `push_card_matches`'s `Mode::Artwork` branch does a
+/// `group_best`/`touched` dedupe scan over every printing in `[start, end)` that `Mode::Printing`
+/// does not — see the doc on `STREAM_ARTWORK_SEEN_PER_CARD_NS` for `StreamedSelect`'s analogous
+/// (but differently-shaped: fixed per-CARD there, per-PRINTING here) overhead. `cost::plan_cost`'s
+/// `GatheredScan` arm charges no such term at all, unlike `StreamedSelect`'s.
+///
+/// Calls `push_card_matches` directly (not through a full query) with `all_match: true` so no
+/// residual evaluation cost pollutes the measurement -- isolating exactly the mode-dependent match-
+/// collection cost the two modes' loop bodies differ by, over the same real card/printing data. An
+/// end-to-end `explain_analyze` A/B (`unique=printing` vs `unique=artwork`, same filter) was tried
+/// first and was unusable: `matches_pushed` differs sharply between modes (printing pushes every
+/// printing, artwork only distinct groups), so `GATHER_PUSH_PER_MATCH_NS`'s much larger swing
+/// dominates the raw delta and even its SIGN. A pooled OLS regression over natural corpus queries
+/// (cards_visited/printing_span/matches_pushed as features, `is_artwork*printing_span` for the term
+/// of interest) came back with a negative coefficient and a negative per-match rate too --
+/// multicollinearity between those three features in real query data, not a real negative cost.
+///
+/// `cargo test --release gather_artwork_kernel_costs -- --ignored --nocapture`
+#[test]
+#[ignore = "gather-artwork kernel cost; needs real.store; cargo test --release gather_artwork_kernel_costs -- --ignored --nocapture"]
+fn gather_artwork_kernel_costs() {
+    use std::hint::black_box;
+    use std::time::Instant;
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    const WARMUP: usize = 15;
+    const ITERS: usize = 150;
+    // Enough cards that the printing span dwarfs per-call fixed overhead (Instant::now, branch
+    // mispredicts on the first card of a round), so the resulting rate is dominated by the loop body.
+    const N_CARDS: usize = 5000;
+
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch — rebuild");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let offsets = &archived.offsets;
+    let printings = &archived.printings;
+    let strings = &archived.strings;
+    let indexes = &archived.indexes;
+    let max_groups = usize::from(u16::from(indexes.max_artwork_groups));
+    let printing_span: u64 =
+        (0..N_CARDS).map(|cid| u64::from(u32::from(offsets[cid + 1])) - u64::from(u32::from(offsets[cid]))).sum();
+
+    let bench_mode = |mode: Mode| -> u128 {
+        let mut group_best: Vec<Option<(u32, f64)>> = vec![None; max_groups];
+        let mut touched: Vec<u16> = Vec::new();
+        let mut out: Vec<(u128, u32, u32)> = Vec::with_capacity(4096);
+        let mut best = u128::MAX;
+        for it in 0..(WARMUP + ITERS) {
+            out.clear();
+            let t0 = Instant::now();
+            for cid in 0..N_CARDS {
+                let card = &archived.cards[cid];
+                let start = u32::from(offsets[cid]) as usize;
+                let end = u32::from(offsets[cid + 1]) as usize;
+                black_box(push_card_matches(
+                    card, cid as u32, printings, &indexes.artwork_group_col, start, end, true, &[], false, mode,
+                    Prefer::Default, SortCol::EdhrecRank, false, strings, None, &mut out, &mut group_best, &mut touched,
+                ));
+            }
+            let dt = t0.elapsed().as_nanos();
+            if it >= WARMUP {
+                best = best.min(dt);
+            }
+        }
+        best
+    };
+
+    let printing_ns = bench_mode(Mode::Printing);
+    let artwork_ns = bench_mode(Mode::Artwork);
+    let delta = artwork_ns as i128 - printing_ns as i128;
+    println!("\ngather-artwork kernel costs ({N_CARDS} cards, {printing_span} printings)");
+    println!("  Printing: {printing_ns} ns total, {:.4} ns/printing", printing_ns as f64 / printing_span.max(1) as f64);
+    println!("  Artwork:  {artwork_ns} ns total, {:.4} ns/printing", artwork_ns as f64 / printing_span.max(1) as f64);
+    println!(
+        "  delta: {delta} ns / {printing_span} printings = {:.4} ns/printing (candidate GATHER_ARTWORK_PER_PRINTING_NS)",
+        delta as f64 / printing_span.max(1) as f64
+    );
 }
 
 /// #724 build-side correctness oracle: projecting a printing-space border plane up to card-existence

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     and_child_rank, assign_name_ranks,
     build_numeric_index, build_oracle_text_index, build_trigram_index,
-    build_rarity_index, build_flavor_index, build_hybrid_tag_index, bitmap_beats_postings, HybridTagIndex, build_sort_permutations, EdhrecWalkCheckpoints,
+    build_rarity_index, build_flavor_index, build_hybrid_tag_index, build_layout_hybrid_index, bitmap_beats_postings, HybridTagIndex, build_sort_permutations, EdhrecWalkCheckpoints,
     assign_artwork_groups, build_artwork_base_from, build_bit_planes, build_border_printing_planes, build_rarity_printing_planes, build_divergent_ids, build_name_bigram_index, build_name_unigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_printing_value_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
@@ -6425,6 +6425,7 @@ fn bench_checked_vs_unchecked_access() {
         subtypes:       build_hybrid_tag_index(&cards, &vocab.strings, |c| &c.card_subtypes),
         keywords:       build_hybrid_tag_index(&cards, &vocab.strings, |c| &c.card_keywords),
         oracle_tags:    build_hybrid_tag_index(&cards, &vocab.strings, |c| &c.card_oracle_tags),
+        layout:         build_layout_hybrid_index(&cards, &strings),
         art_tags:       build_hybrid_tag_index(&printings, &vocab.strings, |p| &p.card_art_tags),
         is_tags:        build_hybrid_tag_index(&printings, &vocab.strings, |p| &p.card_is_tags),
         frame_data:     HybridTagIndex::default(),

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -5145,7 +5145,7 @@ fn plan_cost_model_matches_gold() {
                 let eval_domain = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
                 // Tier reflects the residual AFTER memoize (what the walk pays).
                 let residual_tier_ns100 = if prep.all_match_known { 0 } else { verify_cost_tier(&res) };
-                let su = scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, eval_domain);
+                let su = scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, n_cards);
                 let feats = PlanFeatures {
                     n_cards, n_printings,
                     matches: total as u32,
@@ -5391,7 +5391,7 @@ fn plan_cost_refit() {
                 );
                 let prep = prepare_candidates(&QueryCtx::from(archived), &mode_only_params(mode_enum), &mut res, pe.as_ref());
                 let eval_domain = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
-                let su = scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, eval_domain);
+                let su = scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, n_cards);
                 let feats = PlanFeatures {
                     n_cards, n_printings, matches: total as u32, eval_domain,
                     scan_units: su,
@@ -5596,7 +5596,7 @@ fn printing_range_route_probe() {
             let prep = prepare_candidates(&QueryCtx::from(archived), &mode_only_params(Mode::Printing), &mut res, pe.as_ref());
             let eval_domain = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
             let residual_tier_ns100 = if prep.all_match_known { 0 } else { verify_cost_tier(&res) };
-            let su = scan_units(Mode::Printing, prep.candidate_cards.as_deref(), &archived.offsets, n_printings as u32, eval_domain);
+            let su = scan_units(Mode::Printing, prep.candidate_cards.as_deref(), &archived.offsets, n_printings as u32, n_cards);
             let feats = PlanFeatures {
                 n_cards, n_printings, matches: total as u32, eval_domain,
                 scan_units: su,

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -5157,7 +5157,7 @@ fn plan_cost_model_matches_gold() {
                     residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                     limit: limit as u32,
                     offset: offset as u32,
-                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None,
+                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None, collection_broadcast_printings: 0,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
@@ -5399,7 +5399,7 @@ fn plan_cost_refit() {
                     residual_tier_ns100: if prep.all_match_known { 0 } else { verify_cost_tier(&res) },
                     residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                     limit: limit as u32, offset: offset as u32,
-                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None,
+                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None, collection_broadcast_printings: 0,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
@@ -5604,7 +5604,7 @@ fn printing_range_route_probe() {
                 residual_tier_ns100,
                 residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                 limit: LIMIT as u32, offset: offset as u32,
-                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None, collection_broadcast_printings: 0,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
@@ -5967,7 +5967,7 @@ fn plan_regret_report() {
                 residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                 limit: limit as u32,
                 offset: offset as u32,
-                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None, collection_broadcast_printings: 0,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
@@ -6097,7 +6097,7 @@ fn plan_regret_fuzz() {
                 residual_tier_ns100: tier,
                 residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                 limit: limit as u32, offset: offset as u32,
-                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None, collection_broadcast_printings: 0,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,

--- a/docs/issues/local-engine-card-residual-pass-rate.md
+++ b/docs/issues/local-engine-card-residual-pass-rate.md
@@ -1,0 +1,94 @@
+# Card mode's `matches` estimate is bimodal, and a flat pass rate makes it worse, not better
+
+`candidate_feats`'s `Mode::Card` arm sets `matches = count` (the raw candidate-card count) with no
+discount at all, unlike `Mode::Printing`/`Mode::Artwork`, which apply a fitted `RESIDUAL_PASS_RATE_*`.
+That is provably wrong whenever a residual conjunct survives narrowing and is genuinely selective: real
+`matches_pushed` can run up to 132x lower than the `matches` estimate. It has real absolute cost at
+scale (tens of microseconds at large `eval_domain`), and no cheap fix was found. Documented so the next
+pass at this doesn't re-derive the same dead end.
+
+## Why this looked fixable
+
+`matches` only feeds one term in each plan's formula — `GATHER_PUSH_PER_MATCH_NS` (2.24 ns/match) and
+`STREAM_EMIT_PER_MATCH_NS` (0.12 ns/match) — so the natural fix looked like the same shape as the
+`scan_units` card-mode fix landed alongside this investigation: find the systematic bias, add a
+targeted correction.
+
+Concrete examples, all compound (multi-predicate) card-mode queries with a residual:
+
+| query | eval_domain | matches (est) | matches_pushed (real) | ratio |
+| --- | --: | --: | --: | --: |
+| `o:surveil frame:2003` | 215 | 215 | 1 | 215.0x |
+| `ft:shadow year<1995` | 226 | 226 | 3 | 75.3x |
+| `name:ja tix<0.02` | 272 | 272 | 5 | 54.4x |
+| `cn:141 o:nonlegendary` | 40 | 40 | 1 | 40.0x |
+
+The mechanism: `narrow_candidates_exact` narrows on whichever conjunct it can index (`frame:2003`,
+`tix<0.02`, `cn:141`, ...), leaving the *other* conjunct (`o:surveil`, `year<1995`, `o:nonlegendary`) as
+a per-candidate residual whose own selectivity `matches = count` does not account for at all.
+
+## Why the ratio looked bigger than the impact, at first
+
+The four examples above are all small (`eval_domain` 40-272) and their absolute measured times are
+0.75-5.6 µs. Decomposed: for `is:vanilla id:bw frame:etched` (eval_domain 132), the push-term overcharge
+is 293 ns against a 4,437 ns total prediction gap (measured 750 ns vs predicted 5,187 ns) — about 7% of
+the error. The other 93% is the already-known, already-deferred `GATHER_RESIDUAL_FLOOR_NS` overcharge
+(`eval_domain * max(tier, 18.89)` ≈ 132 × 21.89 ≈ 2,889 ns alone). At this scale the ratio is dramatic
+and the absolute damage is not.
+
+That stops being true at scale. Bucketing the real push-term overcharge (`(matches_est -
+matches_pushed) * 2.24 ns`) by `eval_domain`:
+
+| eval_domain bucket | n | median overcharge | p90 | p99 | max |
+| --- | --: | --: | --: | --: | --: |
+| [0, 100) | 13,278 | 0 ns | 27 ns | 134 ns | 215 ns |
+| [100, 1,000) | 3,820 | 0 ns | 488 ns | 1,214 ns | 2,038 ns |
+| [1,000, 10,000) | 2,860 | 651 ns | 5,773 ns | 12,768 ns | 21,517 ns |
+| [10,000, ∞) | 1,008 | 10,062 ns | 26,990 ns | 38,958 ns | 52,477 ns |
+
+Small queries hide it (as expected — everything hides in a query whose whole cost is under a
+microsecond); large ones don't.
+
+## Why no fix shipped
+
+The real pass rate (`matches_pushed / count`) is **bimodal**, not a population that a single constant
+discount can describe:
+
+| population | n | median | geomean | mean | p10 | p90 |
+| --- | --: | --: | --: | --: | --: | --: |
+| compound (multi-predicate) filters | 16,532 | **1.000** | 0.711 | 0.817 | 0.350 | **1.000** |
+| bare (single-predicate) residuals | 4,614 | 1.000 | 0.954 | 0.980 | 1.000 | 1.000 |
+
+Even restricted to compound filters, both the median *and* p90 real pass rate are 1.000 — the
+low-pass-rate tail dragging the geomean down to 0.711 is confined to well under 10% of compound
+queries. A flat `CARD_RESIDUAL_PASS_RATE` fitted to that geomean would under-predict the ~90% of
+compound queries that need no discount at all, while still not reaching the severe end (pass rates
+measured down to ~0.03 on the worst rows) — a bad trade in both directions.
+
+This is not a new failure mode for this codebase. `candidate_feats`'s own doc comment on the
+`Printing`/`Artwork` discount records the same experiment already run and rejected one mode over:
+`estimator::estimate_cardinality` (index-backed, independence-assumption over `And`) was tried
+specifically to do better than a flat rate there, and measured *worse* — "card mean |log| 1.31 against
+0.79, p90 33.38 against 9.91". Nothing here suggests a naive estimator would fare differently for card
+mode's version of the same problem, and the data above says a *flat rate* specifically loses on the
+majority case, which the printing/artwork rate does not (that population isn't bimodal the same way).
+
+## If someone wants to fix this properly
+
+The honest fix is a real per-query cardinality estimate for the *leftover, unnarrowed* residual
+conjunct — not a global rate. Candidates worth trying, none attempted here:
+
+- A conditional correction gated on a cheap, specific signal rather than "is the filter compound":
+  e.g., only apply a discount when the residual conjunct is itself index-backed (a second
+  `CollectionCmp`/range leaf that narrowing didn't pick), where an exact or near-exact count might be
+  cheaply available — the same shape as the `RangeCardCounts::distinct_cards` 9%-coverage path already
+  used elsewhere in this file, adapted to cover more of the compound population.
+- Keying off `proven_conjuncts`: an `And` where narrowing proved *all but one* conjunct is a
+  structurally different case from one where narrowing only partially covers a single unproven
+  conjunct's own selectivity — the current investigation treated "compound vs bare" as the whole
+  signal, but `proven_conjuncts`'s bit count is already computed and unused for this purpose.
+
+## Status
+
+Documented, not implemented. Land alongside `scan_units`'s card-mode fix (same investigation,
+different outcome) as the record of what was tried and why it didn't ship.

--- a/docs/issues/local-engine-compose-build-rates.md
+++ b/docs/issues/local-engine-compose-build-rates.md
@@ -125,3 +125,16 @@ Nothing shipped. The rate measurements are on the production corpus across 0.5x-
 justified by two instruments on two seeds. Not attempted: the joint refit, and the `Perm` per-card
 feature (which needs an estimator for `cards_visited`, plausibly `printings_walked / printings_per_card`,
 ungraded).
+
+**Still true, reconfirmed while joint-refitting `GatheredScan`/`StreamedSelect` in the same session
+that fixed `scan_units`'s card-mode overcharge.** `fit_cost_model.py`'s general fit still cannot
+separate `WALK_STEP` cleanly for the same reason: it fits against the ESTIMATED feature vector
+`plan_cost` reads today, which has no `cards_visited` column for `Perm` to fit against, so the
+question this doc's own hand-built design already answered (add the column, the rate resolves to
+0.31 against `OrderbyWalk`'s near-identical 0.31) never gets re-asked by the general harness — it
+just reports whatever number the wrong shape produces. `PrintingCompose` was excluded from that
+joint refit for exactly this reason: fitting a arm whose shape is known-wrong would ship coefficients
+that compensate for the missing column, which is the same mistake the original 1.07 popcount rate was
+already compensating for. The `GatheredScan`/`StreamedSelect` pair had no equivalent known gap, so it
+went ahead alone. Whoever picks this up next needs the `cards_visited` ESTIMATOR (not just the
+diagnostic column) built and graded before `PrintingCompose`'s rates are worth touching at all.

--- a/docs/issues/local-engine-p3-p4-joint-refit-vs-compose.md
+++ b/docs/issues/local-engine-p3-p4-joint-refit-vs-compose.md
@@ -1,0 +1,69 @@
+# A correct P3+P4 joint refit still regresses routing, because PrintingCompose didn't move
+
+After fixing a real feature bug (`scan_units`'s card-mode overcharge — see
+[local-engine-card-residual-pass-rate.md](local-engine-card-residual-pass-rate.md) for its unfixed
+sibling), `GatheredScan` and `StreamedSelect` were refit jointly on the corrected data — the exact
+prerequisite [bench_streamed_loop.rs](../../card_engine/src/bench_streamed_loop.rs)'s own conclusion
+asked for after its five earlier refit attempts all regressed. It still regressed, through a different
+mechanism than any of those five. Implemented, measured, reverted.
+
+## What was different this time
+
+The five prior attempts (`bench_streamed_loop.rs`'s module docs) all failed because of **P3-vs-P4
+compensating error**: the shipped rates were jointly tuned so that P4's over-estimate and P3's
+over-estimate cancelled in their comparison, and refitting one or both broke that cancellation without
+fixing what caused it. This attempt came after fixing the actual feature bug behind
+`GatheredScan`/`candidates`'s over-prediction, refit both arms' shape/per-unit-rate terms together
+(holding the two `*_FIXED_COST_NS` constants and two already-flagged noise-floor constants unchanged —
+see the commit for which and why), and the P3-vs-P4 relationship specifically improved:
+`plan_cost_model_matches_gold` went 97.7% → 98.9%.
+
+## What regressed instead
+
+Every plan that competes against `GatheredScan`/`StreamedSelect` in the same argmin, not just each
+other. `PrintingCompose` was deliberately left unrefit — its `Perm` arm is missing a `cards_visited`
+feature entirely (`local-engine-compose-build-rates.md`), so its rates cannot be safely refit until
+that's built. Making P3/P4 cheaper without touching `PrintingCompose` made them win against it wherever
+`PrintingCompose` was actually correct:
+
+| transition | before (n, miss%, share) | after (n, miss%, share) |
+| --- | --- | --- |
+| `PrintingCompose -> StreamedSelect` | minor cell | **309, 99%, 32%** |
+| `PrintingCompose -> GatheredScan` | minor cell | **93, 99%, 6%** |
+| `printing_compose` acquire branch, total share | ~47-58% | **72%** |
+| mean regret per query (uniform sample) | 0.50 µs | **0.56 µs** |
+
+The mechanism is exactly [local-engine-compose-build-rates.md](local-engine-compose-build-rates.md)'s
+finding in reverse: that doc made `PrintingCompose` cheaper in isolation and watched it over-win against
+`GatheredScan`/`StreamedSelect`; this made the other two cheaper in isolation and watched them over-win
+against `PrintingCompose`. Same failure, opposite direction, same root cause — refitting one side of an
+argmin without the other.
+
+## The generalization
+
+**A joint refit is only as joint as every plan that competes in the same decision, not just the two you
+happened to fix a feature for.** Fixing `GatheredScan`+`StreamedSelect`'s shared feature bug and
+refitting them together was necessary but not sufficient — `PrintingCompose` sits in the same argmin for
+every `printing_compose`-acquired query (a plurality of traffic; see its 47-72% share across every
+sweep this session), and any rate change to the plans it competes against needs it in the same
+refit-and-gate cycle. It cannot be, until its own feature gap closes first.
+
+## If someone wants to try this again
+
+1. Build the `cards_visited` estimator `local-engine-compose-build-rates.md` names as missing (it names
+   `printings_walked / printings_per_card` as one candidate, explicitly ungraded).
+2. Wire it into `PrintingCompose`'s `Perm` arm as a real `plan_cost` feature, not just a diagnostic
+   column.
+3. Grade it against the realized `cards_visited` counter the way `scan_units` is graded against
+   `printings_examined`.
+4. Only then refit `GatheredScan`, `StreamedSelect`, AND `PrintingCompose` together, gated on the full
+   regret-matrix transition breakdown (not just the aggregate total, and not just the pair you fixed a
+   feature for) — the aggregate total or a single pair's improvement is not sufficient evidence, as this
+   attempt's own `plan_cost_model_matches_gold` improvement (97.7% -> 98.9%) demonstrates: that metric
+   moved the right way while total routing regret got 12% worse.
+
+## Status
+
+Reverted. `card_engine/src/cost.rs` is unchanged from before this attempt. The fitted values (for
+whoever picks this up once `PrintingCompose` has its feature fix) are recorded in
+`bench_streamed_loop.rs`'s and `bench_gather_loop.rs`'s module docs' history tables, not repeated here.

--- a/scripts/bench_cost_model_agreement.py
+++ b/scripts/bench_cost_model_agreement.py
@@ -18,7 +18,19 @@ same properties and reached two of the three:
   not the *selectivity* — and selectivity is the axis a cost model varies along. The shared sampler
   also reaches `eur`/`tix` and two-sided bounds, neither of which the private table produced.
 
-Reports measured/predicted per (plan, acquire branch), plus the two phases no cost term describes:
+Reports `costbench.plan_self_ns` / predicted per (plan, acquire branch) -- NOT raw `min(trials_ns)`,
+which this collected until a routing-regret sweep found `GatheredScan`/`candidates` reading p90 32.9x
+"over-costed" and traced it here: a forced trial re-runs `prepare_candidates` from scratch, but the
+real routed path pays it once during acquire and dispatch just reuses the artifact (see
+`acquire_plan_features`/`run_query_routed`'s `Prep::Candidates` arm), so charging every forced trial
+for a rebuild the router never repeats inflated `candidates`/`plane` rows by however expensive that
+query's narrowing happened to be -- pure benchmark artifact, not a cost-model error.
+`costbench.plan_self_ns` already encoded the right rule (net it out for `candidates`/`plane`, add it
+back for `RANGE_ACQUIRES`, where dispatch really does rebuild); this module just was not using it yet.
+Netted, `GatheredScan`/`candidates` reads p90 1.05, median 0.69 -- a real, much smaller over-prediction
+worth its own investigation, not the crisis the raw number implied.
+
+Plus the two phases no cost term describes:
 `prepare_candidates` — 21-33% of a range-acquired query against 7-10% of a plane-acquired one — and
 the per-query scratch setup, which for `StreamedSelect` is an O(`n_cards`) counts zeroing that grows
 with the corpus rather than with the answer. Both shares are keyed by acquire branch as well as plan,
@@ -170,9 +182,9 @@ def main() -> None:
                 agr.declines[p["plan"], p["paging_taken"]].append(min(p["declined_ns"]))
                 continue
             predicted = costbench.predicted_ns(p)
-            if not p["trials_ns"] or predicted is None:
+            measured = costbench.plan_self_ns(p, acq)
+            if predicted is None or measured is None:
                 continue
-            measured = min(p["trials_ns"])
             agr.ratios[p["plan"], acq["count_source"]].append(measured / predicted)
             agr.by_unique[p["plan"], unique].append(measured / predicted)
             # Keyed by acquire branch as well as plan: the whole point of this row is that the
@@ -393,7 +405,7 @@ def report(agr: Agreement, seconds: float) -> None:
     if agr.skip_reasons:
         breakdown = ", ".join(f"{name} x{n:,}" for name, n in sorted(agr.skip_reasons.items(), key=lambda kv: -kv[1]))
         print(f"  skipped by reason: {breakdown}")
-    summarise("measured/predicted by acquire branch. 1.00 is agreement; >1 under-costed.", agr.ratios, "acquire")
+    summarise("measured (plan_self_ns) / predicted by acquire branch. 1.00 is agreement; >1 under-costed.", agr.ratios, "acquire")
     summarise("the same, split by distinct-on rather than acquire.", agr.by_unique, "unique")
 
     report_phase_share(agr.prep_frac, "prepare_candidates as a share of the plan's run — the term no cost arm carries.")

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -95,7 +95,10 @@ CURRENT: dict[str, list[float]] = {
     # `card_pass` call (3.00) on top of the floor (18.89), because the arm gates the call on
     # `tier_ns > 0` -- `all_match_known` skips it. The design matrix already had these as two
     # columns; only the arm and these labels changed.
-    "GatheredScan": [3.88, 2.06, 21.89, 2.24, 3.51, 9.79, 169.6],
+    # ..., artwork_seen_printings, fixed -- new (this session): `exec_gathered_scan`'s Mode::Artwork
+    # branch pays a per-printing group_best/touched dedupe check StreamedSelect's artwork_seen_cards
+    # column does not describe (that one is per-CARD; this is per-PRINTING, see cost.rs).
+    "GatheredScan": [3.88, 2.06, 21.89, 2.24, 3.51, 9.79, 0.50, 169.6],
     # eval_domain, scan_units, residual floor, matches, artwork_seen_cards, n_cards floor, corpus pass, fixed
     # Refit once `printings_examined` existed: this plan's fit was vetoed for as long as the only
     # available counter was the printing SPAN, which its all_match rows disagree with by ~3x over a
@@ -234,8 +237,13 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
     excess = eval_domain * max(tier_ns - floor, 0.0) if tier_ns > 0.0 else 0.0
 
     if plan == "GatheredScan":
+        # NOT `artwork_seen_cards`-if-nonzero: `exec_gathered_scan`'s per-printing dedupe loop runs
+        # unconditionally (no `all_match_known` shortcut like StreamedSelect's stored-group-count
+        # fast path), so `artwork_seen_cards` can read 0 (zeroed by all_match_known) on the same row
+        # where `artwork_seen_printings` is correctly nonzero -- read the real field directly.
+        artwork_seen_printings = float(acq.get("artwork_seen_printings", 0))
         return (
-            [eval_domain, scan_units, eval_domain * residual_on, matches, page_span, page_rows, 1.0],
+            [eval_domain, scan_units, eval_domain * residual_on, matches, page_span, page_rows, artwork_seen_printings, 1.0],
             [
                 "LOOP_PER_CARD",
                 "SCAN_PER_ROW",
@@ -243,6 +251,7 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
                 "PUSH_PER_MATCH",
                 "SELECT_PER_PAGE_SLOT",
                 "COLLECT_PER_PAGE_ROW",
+                "ARTWORK_PER_PRINTING",
                 "FIXED",
             ],
             excess,


### PR DESCRIPTION
Stacked on #1007. Five commits, found and fixed via a uniform-sampler routing-regret sweep (`scripts/bench_regret_matrix.py` / `scripts/bench_cost_model_agreement.py`) rather than a specific bug report -- each one closes a gap the sweep surfaced.

## Commits

**`Exact Walk-Length Checkpoints for otag:/keyword:/t: Ordered by EDHREC`** + **`Price a Card-Space Collection Leaf's Compose Build Separately From a Range's Scatter`** -- `PrintingCompose`'s Perm-branch walk-length estimate (`printings_walked`) is blind to EDHREC-order clumping for card-space collection leaves. Adds 5 exact sampled checkpoints (cumulative printings examined at card-permutation positions 1/100/200/400/800) per (value, direction), interpolated at query time, plus a second fix: the collection-leaf compose build was priced with a range's cheap scatter rate instead of the pricier card-broadcast rate its actual build operation (`ids_of` + `broadcast_card_ids_to_printings`) uses.

**`Fix scan_units Argument Swap in Cost-Model Gold/Refit/Probe Tests`** -- `scan_units()`'s last argument is the true total `n_cards` (matches the real router's call site), but three test harnesses (`plan_cost_model_matches_gold`, `plan_cost_refit`, `printing_range_route_probe`) passed `eval_domain` instead, wildly inflating the model's own self-check on narrow queries. `cmc>=15`/`o:annihilator`'s reported "120x misroutes" were entirely this bug -- confirmed the real router already routes them correctly via `explain_analyze` against the real corpus before touching anything else. `plan_cost_model_matches_gold`: 90.9% -> 98.9%.

**`Price GatheredScan's Artwork-Mode Dedupe Check`** -- the regret sweep's dominant misroute cluster among 100us+ queries was `StreamedSelect`<->`GatheredScan` confusion. Half of it: `exec_gathered_scan`'s `Mode::Artwork` branch runs the same `group_best`/`touched` dedupe work `StreamedSelect` charges via `artwork_seen_cards`, but `GatheredScan`'s cost formula charged nothing for it, so it read as a near-exact tie against `StreamedSelect` while measuring 10-16% slower in every observed case. Fixed by adding a new `artwork_seen_printings` feature and a `GATHER_ARTWORK_PER_PRINTING_NS` cost term to `GatheredScan`'s formula -- rate fit via a dedicated kernel test (`gather_artwork_kernel_costs`) rather than an end-to-end A/B or a pooled regression, since both of those proved unusable: the first dominated by the two plans' very different `matches_pushed`, the second by multicollinearity between `cards_visited`/`printing_span`/`matches_pushed` in natural query data. Verified against all three concrete misroutes the sweep found: all three now correctly route to `StreamedSelect`.

**`Narrow layout: (is:split/dfc/meld/...) Instead of Scanning Everything`** -- the other half of the misroute cluster, and the bigger find: `layout:` (what `is:split`/`is:dfc`/`is:meld`/... rewrite to) had no candidate-narrowing arm at all, unlike `border`/`set_code`/`watermark`, so any `layout:`-shaped query fell back to "assume ~everything matches" -- `is:split eur>0.07` estimated 31,724 of 31,724 candidate cards against a real 132. Gave `layout` the same `HybridTagIndex` treatment `subtypes`/`keywords`/`oracle_tags` already have. Bigger than a routing fix: these queries now actually narrow, so they run 30-60x faster end to end (`is:split eur>0.07` ~200us -> ~3-5us), not just route to the right plan.

**`Fix scan_units' Card-Mode Overcharge Under Default Prefer`** -- percentile breakdown of `scan_units/printings_examined` by (plan, unique, residual-present) surfaced a clean, constant 3.08x error across the ENTIRE distribution (flat p10-p90) for `GatheredScan`/card/all-match -- 3.08 is exactly `n_printings/n_cards`. `card_match_count`/`push_card_matches`'s `Mode::Card` arm under `Prefer::Default` breaks at the first printing whenever `all_match` is true, so `printings_examined` is always exactly 1 per card, never the corpus-average span `scan_units` estimated. `GatheredScan` reads `scan_units` unconditionally (no tier gate, unlike `StreamedSelect`'s own scan term), so the error rode straight into every such query. Verified: the ratio is now flat 1.00 for this population (was flat 3.00-3.08); median measured/predicted for the no-residual population moved 0.814 -> 0.864, within-25% 53% -> 63%.

Plus two small tooling fixes found and needed along the way (`bench_cost_model_agreement.py`'s missing `prepare_candidates` netting, `fit_cost_model.py`'s stale `artwork_seen_printings` mirror), and two documentation-only commits recording investigations that were tried and deliberately NOT shipped (a card-mode `matches` estimator bug with no cheap fix, and a P3+P4 joint refit that improved the gold test but regressed total routing regret 12% via `PrintingCompose` -- see `docs/issues/local-engine-card-residual-pass-rate.md` and `docs/issues/local-engine-p3-p4-joint-refit-vs-compose.md`). `card_engine/src/cost.rs`'s rate constants are unchanged from before those two investigations; only the `scan_units` feature fix above is a routing-relevant code change from them.

## Verification

- `cargo test --release`: 156 passed, 0 failed, at every commit in the stack
- `cargo clippy --release --all-targets`: clean (one pre-existing unrelated dead-code warning)
- `plan_cost_model_matches_gold` (rebuilt `real.store` after each archive-format bump): 90.9% -> 98.9% -> 97.7% (layout fix, one new unrelated-borderline miss) -> 98.9% (scan_units card-mode fix)
- Every fix verified against the real corpus via `explain_analyze` on the specific misrouted queries the regret sweep surfaced, not just the aggregate metrics
- The two reverted/unshipped investigations were verified NOT to help via the same regret-matrix instrument, and documented rather than silently dropped

## Test plan
- [x] `cargo test --release -p card_engine`
- [x] `cargo clippy --release --all-targets -p card_engine`
- [x] `plan_cost_model_matches_gold -- --ignored` against a freshly rebuilt `real.store`
- [x] Concrete misrouted queries re-verified against the real corpus after each fix
- [x] Full uniform-sampler regret-matrix sweep before and after, checked for cross-plan regressions, not just the targeted transition
