### PR TITLE
Engine: Split Compose's Walk-Cost Timing, and the Sigma Decision-Rule Bench Harness

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -11144,16 +11144,22 @@ pub(crate) struct PlanTrial {
     /// not as an invariant that should reach zero.
     ///
     /// Populated for the two materializing plans — `GatheredScan` (`exec_gathered_scan`) and
-    /// `StreamedSelect` (`run_query_streamed`, which publishes from all three of its return paths).
-    /// The four fast paths — `PrintingRangeScan`, `PrintingCompose`, `PlanePopcountOrder`,
-    /// `CardRangePopcount` — are NOT instrumented and report zeros, except `paging_taken`, which
-    /// the two printing-space fastpaths set on their own. `PlanePopcountOrder` and
-    /// `CardRangePopcount` write nothing at all and are the only plans for which a `NotEntered`
-    /// label is expected on a successful run.
+    /// `StreamedSelect` (`run_query_streamed`, which publishes from all three of its return paths) —
+    /// and, in narrower ways, for all four fast paths too: `PrintingCompose` reports real execution
+    /// counters (`cards_visited`/`printings_examined`/`matches_pushed`) plus a build/paging split
+    /// (`ComposePageWork::ns_build`/`ns_paging`, landing in `ns_setup`/`ns_loop`); `PlanePopcountOrder`
+    /// and `CardRangePopcount` (`publish_popcount_phases`, shared by both) report a real three-phase
+    /// `ns_setup`/`ns_loop`/`ns_finish` split but zero counters — a popcount walk visits no cards to
+    /// count; `PrintingRangeScan` reports one undivided `ns_loop` span (the shape `PrintingCompose`
+    /// used before its split) and zero counters. `paging_taken` is set independently by the two
+    /// printing-space fastpaths (`PrintingRangeScan`, `PrintingCompose`); `PlanePopcountOrder` and
+    /// `CardRangePopcount` never set it and are the only plans for which a `NotEntered` label is
+    /// expected on a successful run.
     ///
-    /// A consumer must not read all-zero counters as "this plan did no work": `explain_analyze`
-    /// fills `ns_round_total` for every round it records, so `ns_round_total > 0 && ns_loop == 0` is
-    /// the uninstrumented case, and `ns_round_total == 0` means the plan completed no round.
+    /// A consumer must not read all-zero counters as "this plan did no work": a plan that produced a
+    /// page always publishes SOME nonzero phase information (at minimum `ns_loop` or `ns_setup`), so
+    /// `ns_round_total > 0` with every phase and counter field still zero only means a decline (see
+    /// `declined_ns` below) or a plan that never entered at all — not a plan that ran uninstrumented.
     ///
     /// `ns_round_total == 0` has two sub-cases, and `declined_ns` is what separates them:
     ///

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -8048,20 +8048,22 @@ fn printing_compose_fastpath<'a>(
     // those same bits. Built once here and threaded through, instead of twice.
     let card_bits = matches!(mode, Mode::Card).then(|| printing_bits_to_card_bits(&pbits, offsets, cards.len()));
     let total = compose_total_for_mode(&pbits, mode, indexes, printings, card_bits.as_deref());
-    // Everything up to here (compose `pbits` + the card-space projection + the exact total) is the
-    // BUILD; timed on its own so a harness can tell "the filter was expensive to compose" apart from
-    // "the walk visited a lot of cards" -- see `ComposePageWork::ns_build`'s doc for why that split
-    // didn't exist before and what it cost to not have it.
-    let ns_build = t_start.elapsed().as_nanos() as u64;
     // Now the exact total exists, so make the real walk-vs-gather call on it. See
     // `orderby_walk_beats_gather` for why this is the total rather than the gather's own broad verdict.
     let walk_col = walk_possible && orderby_walk_beats_gather(mode, filter, total);
+    // Everything up to here (compose `pbits` + the card-space projection + the exact total + the
+    // walk-vs-gather decision) is the BUILD; timed on its own so a harness can tell "the filter was
+    // expensive to compose" apart from "the walk visited a lot of cards" -- see
+    // `ComposePageWork::ns_build`'s doc for why that split didn't exist before and what it cost to not
+    // have it. One read, two phases, same as `exec_gathered_scan`'s `t_loop`, so no cost between the
+    // two snapshots goes uncounted regardless of which branch runs below.
+    let t_paging_start = std::time::Instant::now();
+    let ns_build = (t_paging_start - t_start).as_nanos() as u64;
     if total == 0 || page_offset >= total {
         note_paging_taken(PagingTaken::EmptyPage);
         publish_compose_work(ComposePageWork { ns_build, ns_paging: 0, ..Default::default() });
         return Some((total, Vec::new()));
     }
-    let t_paging_start = std::time::Instant::now();
     let (page, mut work) = match perm {
         Some(perm) => {
             if total <= *STREAM_MIN_MATCHES {
@@ -9590,9 +9592,9 @@ fn note_pending_prepare_ns(ns: u64) {
 ///
 /// A 24-byte store into `COMPOSE_WORK`, not a write of the whole `PhaseStats` — see that slot's doc
 /// for the measurement that forced the split. `take_phase_stats` merges the two, so consumers see no
-/// seam, and the phase timings stay zero: compose's arm is not decomposed into setup/loop/finish, so
-/// there is nothing to check them against, and publishing an unvalidatable number is how
-/// `printing_span` became load-bearing in the first place.
+/// seam, and the phase timings are no longer zero: `ns_build`/`ns_paging` land in `ns_setup`/`ns_loop`
+/// the same as the other plans, checked against a real run by
+/// `plan_stats_never_leak_between_participants`'s `PrintingCompose` branch.
 fn publish_compose_work(work: ComposePageWork) {
     COMPOSE_WORK.with(|c| c.set(work));
 }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -7523,14 +7523,19 @@ struct ComposePageWork {
     /// Rows the branch pushed. For the gather this is every match (it visits every candidate); for
     /// the two walks it is bounded by the page, which is the whole point of their cost shape.
     matches_pushed: u64,
-    /// The whole fastpath's wall time, merged into `ns_loop` by `take_phase_stats`.
-    ///
-    /// One span, not three. Compose's arm is not decomposed into setup/loop/finish -- it is a build
-    /// plus one of three structurally different paging branches -- so there is nothing to attribute
-    /// between phases. What the harnesses need is that the phase sum equals the executor's own time,
-    /// and one span gives that. Carried here rather than written to `PHASE_STATS` separately so the
-    /// production compose path still pays ONE store; see this slot's doc for what that cost.
-    ns_total: u64,
+    /// Wall time of composing `pbits` (`compose_printing_bits` + the card-space projection + the
+    /// exact total) -- everything before the paging branch is chosen. Reported as `ns_setup` by
+    /// `take_phase_stats`, the same slot the other plans use for pre-loop work, so a harness reading
+    /// `plan_self_ns`'s `ns_setup + ns_loop + ns_finish` sees no change, but one that wants the build
+    /// separated from the walk (a natural-query harness cannot otherwise tell "the filter was
+    /// expensive to compose" from "the walk visited a lot of cards" -- see
+    /// `reference-engine-compose-perm-cards-visited-estimator.md`'s decision-rule work, which needed
+    /// exactly this split and initially had to fall back to a kernel-bench proxy without it) now can.
+    ns_build: u64,
+    /// Wall time of the paging branch alone (`walk_grouped_page` / `gather_composed_page` /
+    /// `walk_value_orderby_page`) -- reported as `ns_loop`, same reasoning as `ns_build` above.
+    /// Zero for the empty/past-the-end early return, which never reaches a paging branch at all.
+    ns_paging: u64,
 }
 
 /// The `prefer`-best MATCHING printing of the group `pid` belongs to.
@@ -7694,8 +7699,9 @@ fn walk_value_orderby_page<'a>(
             printings_examined: examined,
             // Page-bounded, which is what this counter's doc always claimed.
             matches_pushed: pushed,
-            // Filled by `printing_compose_fastpath`, which owns the span; this only reports work.
-            ns_total: 0,
+            // Filled by `printing_compose_fastpath`, which owns the spans; this only reports work.
+            ns_build: 0,
+            ns_paging: 0,
         },
     ))
 }
@@ -7999,7 +8005,7 @@ fn printing_compose_fastpath<'a>(
     params: &QueryParams,
     filter: &FilterExpr,
 ) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
-    // Ends at whichever exit produces a page; see `ComposePageWork::ns_total`. Declines return before
+    // Ends at whichever exit produces a page; see `ComposePageWork::ns_build`/`ns_paging`. Declines return before
     // any publish and so leave the slot as `take_phase_stats` cleared it.
     let t_start = std::time::Instant::now();
     let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
@@ -8042,14 +8048,20 @@ fn printing_compose_fastpath<'a>(
     // those same bits. Built once here and threaded through, instead of twice.
     let card_bits = matches!(mode, Mode::Card).then(|| printing_bits_to_card_bits(&pbits, offsets, cards.len()));
     let total = compose_total_for_mode(&pbits, mode, indexes, printings, card_bits.as_deref());
+    // Everything up to here (compose `pbits` + the card-space projection + the exact total) is the
+    // BUILD; timed on its own so a harness can tell "the filter was expensive to compose" apart from
+    // "the walk visited a lot of cards" -- see `ComposePageWork::ns_build`'s doc for why that split
+    // didn't exist before and what it cost to not have it.
+    let ns_build = t_start.elapsed().as_nanos() as u64;
     // Now the exact total exists, so make the real walk-vs-gather call on it. See
     // `orderby_walk_beats_gather` for why this is the total rather than the gather's own broad verdict.
     let walk_col = walk_possible && orderby_walk_beats_gather(mode, filter, total);
     if total == 0 || page_offset >= total {
         note_paging_taken(PagingTaken::EmptyPage);
-        publish_compose_work(ComposePageWork { ns_total: t_start.elapsed().as_nanos() as u64, ..Default::default() });
+        publish_compose_work(ComposePageWork { ns_build, ns_paging: 0, ..Default::default() });
         return Some((total, Vec::new()));
     }
+    let t_paging_start = std::time::Instant::now();
     let (page, mut work) = match perm {
         Some(perm) => {
             if total <= *STREAM_MIN_MATCHES {
@@ -8122,7 +8134,8 @@ fn printing_compose_fastpath<'a>(
             }
         }
     };
-    work.ns_total = t_start.elapsed().as_nanos() as u64;
+    work.ns_build = ns_build;
+    work.ns_paging = t_paging_start.elapsed().as_nanos() as u64;
     publish_compose_work(work);
     Some((total, page))
 }
@@ -9506,7 +9519,7 @@ thread_local! {
     /// participant runs, so a plan that does not publish here reads zeros rather than the last
     /// compose's numbers. Outside that window nothing reads it at all.
     static COMPOSE_WORK: std::cell::Cell<ComposePageWork> = const { std::cell::Cell::new(ComposePageWork {
-        cards_visited: 0, printings_examined: 0, matches_pushed: 0, ns_total: 0,
+        cards_visited: 0, printings_examined: 0, matches_pushed: 0, ns_build: 0, ns_paging: 0,
     }) };
 
     /// The routed path's disjoint phase split — see `RoutedPhases`. Its own slot for the same reason
@@ -9598,13 +9611,14 @@ fn take_phase_stats() -> PhaseStats {
     // `PHASE_STATS` and never `COMPOSE_WORK`, compose the reverse -- so this cannot double-count, and
     // taking both together is what stops either leaking into the next participant.
     let compose = COMPOSE_WORK.with(|c| c.replace(ComposePageWork::default()));
-    if compose.cards_visited | compose.printings_examined | compose.matches_pushed | compose.ns_total != 0 {
+    if compose.cards_visited | compose.printings_examined | compose.matches_pushed | compose.ns_build | compose.ns_paging != 0 {
         stats.cards_visited = compose.cards_visited;
         stats.printings_examined = compose.printings_examined;
         stats.matches_pushed = compose.matches_pushed;
-        // Compose reports one undivided span; `ns_loop` is where it belongs so the phase sum equals
-        // the executor's time. See `ComposePageWork::ns_total`.
-        stats.ns_loop = compose.ns_total;
+        // Same setup/loop split the other plans use: build (compose `pbits`) is pre-loop work, the
+        // paging branch is the loop. See `ComposePageWork::ns_build`/`ns_paging`.
+        stats.ns_setup = compose.ns_build;
+        stats.ns_loop = compose.ns_paging;
     }
     stats
 }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -7538,6 +7538,10 @@ struct ComposePageWork {
     ns_paging: u64,
 }
 
+// Production publishes this whole value on every successful compose run. Keep its footprint explicit:
+// three counters plus two phase timings, with no accidental padding or future silent growth.
+const _: [(); 5 * std::mem::size_of::<u64>()] = [(); std::mem::size_of::<ComposePageWork>()];
+
 /// The `prefer`-best MATCHING printing of the group `pid` belongs to.
 ///
 /// Byte-identical selection to `walk_grouped_page`'s grouping arm, and that is the whole requirement:
@@ -8051,19 +8055,21 @@ fn printing_compose_fastpath<'a>(
     // Now the exact total exists, so make the real walk-vs-gather call on it. See
     // `orderby_walk_beats_gather` for why this is the total rather than the gather's own broad verdict.
     let walk_col = walk_possible && orderby_walk_beats_gather(mode, filter, total);
+    // An empty page never enters a paging branch, so all work through the empty-page decision belongs
+    // to BUILD. Snapshot immediately before publishing so the decision and its label are not omitted.
+    if total == 0 || page_offset >= total {
+        note_paging_taken(PagingTaken::EmptyPage);
+        publish_compose_work(ComposePageWork { ns_build: t_start.elapsed().as_nanos() as u64, ns_paging: 0, ..Default::default() });
+        return Some((total, Vec::new()));
+    }
     // Everything up to here (compose `pbits` + the card-space projection + the exact total + the
-    // walk-vs-gather decision) is the BUILD; timed on its own so a harness can tell "the filter was
-    // expensive to compose" apart from "the walk visited a lot of cards" -- see
+    // walk-vs-gather and empty-page decisions) is the BUILD; timed on its own so a harness can tell
+    // "the filter was expensive to compose" apart from "the walk visited a lot of cards" -- see
     // `ComposePageWork::ns_build`'s doc for why that split didn't exist before and what it cost to not
     // have it. One read, two phases, same as `exec_gathered_scan`'s `t_loop`, so no cost between the
     // two snapshots goes uncounted regardless of which branch runs below.
     let t_paging_start = std::time::Instant::now();
     let ns_build = (t_paging_start - t_start).as_nanos() as u64;
-    if total == 0 || page_offset >= total {
-        note_paging_taken(PagingTaken::EmptyPage);
-        publish_compose_work(ComposePageWork { ns_build, ns_paging: 0, ..Default::default() });
-        return Some((total, Vec::new()));
-    }
     let (page, mut work) = match perm {
         Some(perm) => {
             if total <= *STREAM_MIN_MATCHES {
@@ -9507,9 +9513,9 @@ thread_local! {
     /// `take_phase_stats` reassembles the two into one `PhaseStats`, so consumers see no seam.
     static PAGING_TAKEN: std::cell::Cell<PagingTaken> = const { std::cell::Cell::new(PagingTaken::NotEntered) };
 
-    /// The compose fastpath's three counters, stored apart from `PHASE_STATS` for exactly the reason
-    /// `PAGING_TAKEN` is: this is the production compose path, and a whole-struct publish there is a
-    /// read-modify-write of ~80 bytes to report 24.
+    /// The compose fastpath's three counters and two phase timings, stored apart from `PHASE_STATS`
+    /// for exactly the reason `PAGING_TAKEN` is: this is the production compose path, and a
+    /// whole-struct publish there is a read-modify-write of ~80 bytes to report 40.
     ///
     /// Measured, because the first version did write the whole struct: a paired A/B against the same
     /// build without it read `+1.4 µs` and `+3.1 µs` on a 129 µs mean (slower on 619 and 863 queries
@@ -9590,7 +9596,7 @@ fn note_pending_prepare_ns(ns: u64) {
 /// Publish what a compose paging branch did, so `PrintingCompose` reports the same three quantities
 /// the two materializing plans do.
 ///
-/// A 24-byte store into `COMPOSE_WORK`, not a write of the whole `PhaseStats` — see that slot's doc
+/// A 40-byte store into `COMPOSE_WORK`, not a write of the whole `PhaseStats` — see that slot's doc
 /// for the measurement that forced the split. `take_phase_stats` merges the two, so consumers see no
 /// seam, and the phase timings are no longer zero: `ns_build`/`ns_paging` land in `ns_setup`/`ns_loop`
 /// the same as the other plans, checked against a real run by

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -10,7 +10,7 @@ use super::{
     EXACT_VALUE_TOTALS, RangeCardCounts, narrow_rec, ValueTotals, PairTotals, build_all_value_totals, build_pair_totals, build_range_card_counts, exact_result_total,
     PhysicalPlan, PlanScope, CandidatePlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingValueIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
-    walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
+    walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_compose_fastpath, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
     prepare_candidates, verify_cost_tier, scan_units, sort_col_bound, divergent_formats_of, Mode, QueryCtx, QueryParams, Prefer, SortBound,
     push_card_matches,
     GatherSelect, select_page, GATHER_PRUNE_CHUNK, Match,
@@ -4685,12 +4685,31 @@ fn plan_stats_never_leak_between_participants() {
                             p.ns_setup + p.ns_loop + p.ns_finish > 0,
                             "compose produced a page but published no phase timing, so it prices as zero: {case}",
                         );
+                        let phase_ns = p.ns_setup + p.ns_loop + p.ns_finish;
+                        assert!(
+                            phase_ns <= p.ns_round_total && phase_ns.saturating_mul(2) >= p.ns_round_total,
+                            "compose phases leave more than half the measured round unaccounted: \
+                             phases={phase_ns} round={} {case}",
+                            p.ns_round_total,
+                        );
                         compose_labelled += 1;
                     }
                 }
             }
         }
     }
+
+    // Empty pages have no paging branch, but the build still includes the exact-total calculation
+    // and the empty-page decision. Exercise that exit explicitly: the general coverage sweep uses
+    // offset 0, so it cannot prove the empty path reports build time and zero paging time.
+    let empty_params = kernel_params(Mode::Card, SortCol::EdhrecRank, false, 60, CORPUS_SIZE * 2);
+    let empty_filter = fuzz_bound_filter(specs.last().expect("specs is non-empty"), archived);
+    take_phase_stats();
+    printing_compose_fastpath(&ctx, &empty_params, &empty_filter).expect("PrintingCompose must serve the explicit empty-page case");
+    let empty_phases = take_phase_stats();
+    assert_eq!(empty_phases.paging_taken, PagingTaken::EmptyPage);
+    assert!(empty_phases.ns_setup > 0, "empty compose page omitted its build timing");
+    assert_eq!(empty_phases.ns_loop, 0, "empty compose page reported paging work it never ran");
 
     println!(
         "stat isolation: {silent_checked} uninstrumented-plan runs ({range_labelled} range-labelled), \

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -4676,6 +4676,15 @@ fn plan_stats_never_leak_between_participants() {
                             p.paging_taken, PagingTaken::NotEntered,
                             "compose ran but recorded no paging branch, so leak 2 has no source: {case}",
                         );
+                        // Same statement `SILENT_PLANS` gets above: `plan_self_ns` reads dispatch
+                        // time from `ns_setup + ns_loop + ns_finish`, so a compose run that published
+                        // nothing here would price as zero. Unlike `SILENT_PLANS`, compose's split is
+                        // two fields (`ns_build`/`ns_paging`, landing in `ns_setup`/`ns_loop`), not
+                        // three, but the sum still has to be positive on every real run.
+                        assert!(
+                            p.ns_setup + p.ns_loop + p.ns_finish > 0,
+                            "compose produced a page but published no phase timing, so it prices as zero: {case}",
+                        );
                         compose_labelled += 1;
                     }
                 }

--- a/scripts/bench_compose_card_visited_safety_bound.py
+++ b/scripts/bench_compose_card_visited_safety_bound.py
@@ -30,7 +30,9 @@ shape, since it never reads WHERE matches sit in the permutation, only how many 
 explicit deep-offset sweep (real traffic is offset~0-heavy by design, `costbench.OFFSETS`, so it can't
 supply the tail this bound exists for).
 
-    .venv/bin/python scripts/bench_compose_card_visited_safety_bound.py --n-queries 400
+    .venv/bin/python scripts/bench_compose_card_visited_safety_bound.py --n-queries 400 \
+        --three-phase-rate-ns-per-match 5.3444 --three-phase-fixed-ns -4809 \
+        --three-phase-floor-ns 5000
 
 """
 
@@ -42,31 +44,34 @@ import math
 import pathlib
 import random
 import sys
+from dataclasses import dataclass
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
-from client.query_sampler import QuerySampler, Shape  # noqa: E402
+from client.query_sampler import QuerySampler  # noqa: E402
 from scripts import costbench  # noqa: E402
 from scripts.costbench import load_engine  # noqa: E402
 
 percentile = costbench.percentile
 
-# Three-phase (`walk_card_page_via_popcount_skip`) is a `#[cfg(test)]` Rust prototype with no Python
-# binding, so there's no per-row REAL measurement of it for the general uniform-query population (only
-# two named-tag queries were ever benched against it directly, in `tests.rs`). Modeled instead, from
-# THIS session's own real measurement: `compose_popcount_skip_kernel_costs`'s fit of the scatter rate
-# against `matching_cards`, `card_engine/src/tests.rs`. Approximate, not measured-per-row -- good enough
-# for a DIRECTIONAL choice-frequency/latency simulation, not for pricing an individual query.
-THREE_PHASE_RATE_NS_PER_MATCH = 5.3444
-THREE_PHASE_FIXED_NS = -4809.0
-THREE_PHASE_FLOOR_NS = 5_000.0  # the fit goes negative below ~900 matches; floor at the smallest real dispatch cost seen this session
+@dataclass(frozen=True)
+class ThreePhaseModel:
+    """Explicit calibration for the modeled three-phase fallback.
 
+    The fallback has no Python binding, so the harness cannot measure it per row. Requiring these
+    coefficients on the command line keeps a machine-specific calibration out of source and makes
+    every reported result reproducible from its invocation.
+    """
 
-def three_phase_ns_model(matches: int) -> float:
-    """Modeled `walk_card_page_via_popcount_skip` cost -- see the module-level note on its provenance."""
-    return max(THREE_PHASE_RATE_NS_PER_MATCH * matches + THREE_PHASE_FIXED_NS, THREE_PHASE_FLOOR_NS)
+    rate_ns_per_match: float
+    fixed_ns: float
+    floor_ns: float
+
+    def estimate(self, matches: int) -> float:
+        """Estimate `walk_card_page_via_popcount_skip` latency."""
+        return max(self.rate_ns_per_match * matches + self.fixed_ns, self.floor_ns)
 
 
 # The PRODUCTION cost model's own `PhysicalPlan::PrintingCompose` / `ComposePaging::Perm` formula
@@ -114,9 +119,11 @@ ORDERBYS = ("edhrec", "cubecobra", "cmc", "power", "toughness", "name")
 # that distribution can't exercise the deep tail this bound exists for, so sweep it explicitly instead.
 OFFSET_SWEEP = (0, 50, 200, 500, 1_000, 2_000, 4_000, 8_000, 15_000, 25_000)
 LIMIT = 20
-NUM_WARMUPS = 1
-NUM_TRIALS = 2
+NUM_WARMUPS = costbench.NUM_WARMUPS
+NUM_TRIALS = costbench.NUM_TRIALS
 MIN_REALIZED = 5  # below this, `cards_visited` is too noisy/trivial to grade a bound against
+POLICY_SPLIT_SEED = 730_1009
+MIN_POLICY_GROUPS = 2
 
 
 # ─── The two closed-form anchors ───────────────────────────────────────────────
@@ -124,11 +131,17 @@ MIN_REALIZED = 5  # below this, `cards_visited` is too noisy/trivial to grade a 
 
 def worst_case_bound(n_cards: int, matches: int, k: int) -> float:
     """Every non-matching card clumped before the k-th match -- an exact, unconditional ceiling."""
+    if k > matches:
+        # A partial final page never fills, so `walk_grouped_page` exhausts the permutation rather
+        # than stopping at the last match.
+        return float(n_cards)
     return max(n_cards - matches, 0) + k
 
 
 def uniform_mean(n_cards: int, matches: int, k: int) -> float:
     """Expected position of the k-th match if `matches` cards were scattered with NO clumping -- the order-statistic mean of a uniformly random `matches`-subset of `n_cards` slots."""
+    if k > matches:
+        return float(n_cards)
     return k * (n_cards + 1) / (matches + 1)
 
 
@@ -165,27 +178,6 @@ def sigma_bound(n_cards: int, matches: int, k: int, knob: float) -> float:
     """`knob` = how many std devs above the no-clumping mean, same random-placement model as `blend_bound`'s low anchor -- just a different (distribution-shaped, not linear) margin."""
     mean = uniform_mean(n_cards, matches, k)
     return mean + knob * math.sqrt(nhg_variance(n_cards, matches, k))
-
-
-def abort_budget_ns(walk_ns: float, matches: int, safety_factor: float, ceiling_ns: float) -> tuple[float, bool]:
-    """Cost under a RUNTIME circuit breaker instead of an a-priori decision: let the walk run, and only abort into three-phase once the walk's OWN elapsed cost crosses `budget = safety_factor * three_phase_ns_model(matches)` -- a budget anchored to the alternative's own (offset-independent) cost, not to `k`. A `k`-scaled budget was tried first and does not work: `k = offset + limit` already includes the offset, so at a deep offset the budget outgrows `n_cards` and the abort can never trip at all -- exactly the population (deep, expensive walks) this exists to catch. Tracking elapsed cost is free in the real executor (`work.cards_visited += 1` already runs every iteration); this models "compare it against a threshold every so often," not new instrumentation.
-
-    Naively, an abort caps the total at `(safety_factor + 1) * three_phase_ns_model(matches)` -- but
-    that cap ITSELF grows with `matches` (three-phase costs more for a high-selectivity query), and a
-    high `safety_factor` on top of an already-large baseline let the capped outcome exceed what a
-    plain walk would have cost -- measured: `abort at 3x` had a WORSE max than `always_walk` on this
-    dataset. `ceiling_ns` is the fix: an absolute cap independent of `matches` entirely (the caller
-    passes `walk_rate * n_cards` -- no real walk, however clumped, can cost more than visiting the
-    whole corpus once). A row that finishes within budget still pays EXACTLY its own real `walk_ns`.
-
-    Returns:
-        `(ns, aborted)` -- `aborted` is whether the breaker tripped, returned alongside the cost
-        instead of recomputed by the caller from the same `budget`.
-    """
-    budget = safety_factor * three_phase_ns_model(matches)
-    if walk_ns <= budget:
-        return walk_ns, False
-    return min(budget + three_phase_ns_model(matches), ceiling_ns), True
 
 
 METHODS = {
@@ -262,7 +254,7 @@ def evaluate(engine: object, query: str, orderby: str, direction: str, offset: i
         return None
     matches = compose["result_total"]
     realized = compose["cards_visited"]
-    if matches <= 0 or k >= matches or matches >= n_cards or realized < MIN_REALIZED:
+    if matches <= 0 or offset >= matches or matches >= n_cards or realized < MIN_REALIZED:
         return None
     # `ns_loop` is now the paging branch ALONE -- `card_engine/src/lib.rs`'s `ComposePageWork` split
     # (this session) separated it from `ns_setup` (the compose-build cost that used to be bundled in
@@ -468,42 +460,82 @@ def report(rows: list[dict]) -> None:
     _report_worst_outliers(rows)
 
 
-def _walk_rate_and_ceiling(rows: list[dict]) -> tuple[float, float]:
-    """Fit `walk_rate` from real (`walk_ns`, `realized`) pairs and derive the abort ceiling from it, printing both."""
-    walk_rate = percentile(sorted(r["walk_ns"] / r["realized"] for r in rows), 50)
-    print(f"\nwalk_grouped_page rate fit from real (walk_ns, realized) pairs: {walk_rate:.3f} ns/card visited (median)\n")
-    # No real walk, however clumped, visits more cards than the whole corpus once -- an absolute
-    # backstop independent of `matches`, unlike the naive `(safety_factor + 1) * three_phase` cap.
-    ceiling_ns = walk_rate * max(r["n_cards"] for r in rows)
-    print(f"abort ceiling: {ceiling_ns:.0f} ns (walk_rate * n_cards -- a full-corpus walk, absolute worst case)\n")
-    return walk_rate, ceiling_ns
+@dataclass(frozen=True)
+class WalkCostModel:
+    """Non-negative two-term fit for the native walk's measured work."""
+
+    ns_per_card: float
+    ns_per_printing: float
+
+    def estimate(self, cards_visited: float, printings_examined: float) -> float:
+        """Estimate walk latency from both operations the loop reports."""
+        return self.ns_per_card * cards_visited + self.ns_per_printing * printings_examined
 
 
-def _build_policies(walk_rate: float, ceiling_ns: float) -> dict[str, object]:
+def _fit_walk_cost_model(rows: list[dict]) -> WalkCostModel:
+    """Fit non-negative least squares for cards visited plus printings examined."""
+    cc = sum(r["realized"] ** 2 for r in rows)
+    cp = sum(r["realized"] * r["printings_examined"] for r in rows)
+    pp = sum(r["printings_examined"] ** 2 for r in rows)
+    cy = sum(r["realized"] * r["walk_ns"] for r in rows)
+    py = sum(r["printings_examined"] * r["walk_ns"] for r in rows)
+    candidates = [
+        WalkCostModel(cy / cc if cc else 0.0, 0.0),
+        WalkCostModel(0.0, py / pp if pp else 0.0),
+    ]
+    determinant = cc * pp - cp * cp
+    if determinant > 0:
+        both = WalkCostModel((cy * pp - py * cp) / determinant, (py * cc - cy * cp) / determinant)
+        if both.ns_per_card >= 0 and both.ns_per_printing >= 0:
+            candidates.append(both)
+
+    def squared_error(model: WalkCostModel) -> float:
+        return sum((model.estimate(r["realized"], r["printings_examined"]) - r["walk_ns"]) ** 2 for r in rows)
+
+    return min(candidates, key=squared_error)
+
+
+def _split_policy_rows(rows: list[dict]) -> tuple[list[dict], list[dict]]:
+    """Split by query shape so no offset sibling appears in both calibration and evaluation."""
+    keys = sorted({(r["query"], r["orderby"], r["direction"]) for r in rows})
+    if len(keys) < MIN_POLICY_GROUPS:
+        msg = "policy simulation needs at least two distinct query/orderby/direction groups"
+        raise ValueError(msg)
+    random.Random(POLICY_SPLIT_SEED).shuffle(keys)
+    calibration_keys = set(keys[: len(keys) // 2])
+    calibration = [r for r in rows if (r["query"], r["orderby"], r["direction"]) in calibration_keys]
+    evaluation = [r for r in rows if (r["query"], r["orderby"], r["direction"]) not in calibration_keys]
+    return calibration, evaluation
+
+
+def _predicted_printings_for_bound(r: dict, bound_cards: float) -> float:
+    """Scale acquire's printing-walk estimate from the uniform card depth to the candidate bound."""
+    uniform_cards = uniform_mean(r["n_cards"], r["matches"], r["k"])
+    return r["printings_walked_pred"] * bound_cards / uniform_cards
+
+
+def _build_policies(walk_model: WalkCostModel, three_phase: ThreePhaseModel) -> dict[str, object]:
     """The named decision policies `simulate_policies` grades against each other, keyed by display name."""
 
     def gated(gate: int, bound_fn) -> object:  # noqa: ANN001 - bound_fn is one of the module's *_bound callables
         def cost(r: dict) -> tuple[float, bool]:
             if r["offset"] < gate:
                 return r["walk_ns"], False
-            predicted_walk_ns = walk_rate * bound_fn(r["n_cards"], r["matches"], r["k"])
-            if predicted_walk_ns <= three_phase_ns_model(r["matches"]):
+            bound_cards = bound_fn(r["n_cards"], r["matches"], r["k"])
+            predicted_walk_ns = walk_model.estimate(bound_cards, _predicted_printings_for_bound(r, bound_cards))
+            if predicted_walk_ns <= three_phase.estimate(r["matches"]):
                 return r["walk_ns"], False
-            return three_phase_ns_model(r["matches"]), True
-
-        return cost
-
-    def abort_at(safety_factor: float) -> object:
-        def cost(r: dict) -> tuple[float, bool]:
-            return abort_budget_ns(r["walk_ns"], r["matches"], safety_factor, ceiling_ns)
+            return three_phase.estimate(r["matches"]), True
 
         return cost
 
     return {
         "always_walk (today)": lambda r: (r["walk_ns"], False),
-        "always_three_phase": lambda r: (three_phase_ns_model(r["matches"]), True),
+        "always_three_phase": lambda r: (three_phase.estimate(r["matches"]), True),
         "oracle (best possible)": lambda r: (
-            (r["walk_ns"], False) if r["walk_ns"] <= three_phase_ns_model(r["matches"]) else (three_phase_ns_model(r["matches"]), True)
+            (r["walk_ns"], False)
+            if r["walk_ns"] <= three_phase.estimate(r["matches"])
+            else (three_phase.estimate(r["matches"]), True)
         ),
         "no gate, worst_case": gated(0, worst_case_bound),
         "no gate, blend(0.6)": gated(0, lambda n, m, k: blend_bound(n, m, k, 0.6)),
@@ -517,15 +549,33 @@ def _build_policies(walk_rate: float, ceiling_ns: float) -> dict[str, object]:
         "gate=4000, worst_case": gated(4_000, worst_case_bound),
         "gate=2000, blend(0.6)": gated(2_000, lambda n, m, k: blend_bound(n, m, k, 0.6)),
         "gate=4000, blend(0.6)": gated(4_000, lambda n, m, k: blend_bound(n, m, k, 0.6)),
-        "abort at 2x 3phase": abort_at(2.0),
-        "abort at 3x 3phase": abort_at(3.0),
-        "abort at 5x 3phase": abort_at(5.0),
-        "abort at 10x 3phase": abort_at(10.0),
-        "abort at 20x 3phase": abort_at(20.0),
     }
 
 
-def _print_pooled_latency_table(rows: list[dict], policies: dict) -> dict[str, list[float]]:
+def _weighted_percentile(sorted_weighted: list[tuple[float, float]], pct: float) -> float:
+    """Nearest-rank percentile where each row carries an explicit weight."""
+    if not sorted_weighted:
+        return float("nan")
+    if pct <= 0:
+        return sorted_weighted[0][0]
+    target = pct / 100 * sum(weight for _, weight in sorted_weighted)
+    cumulative = 0.0
+    for value, weight in sorted_weighted:
+        cumulative += weight
+        if cumulative >= target:
+            return value
+    return sorted_weighted[-1][0]
+
+
+def _offset_weighted_rows(rows: list[dict]) -> list[tuple[dict, float]]:
+    """Give every represented offset the same total weight."""
+    counts: dict[int, int] = {}
+    for r in rows:
+        counts[r["offset"]] = counts.get(r["offset"], 0) + 1
+    return [(r, 1 / counts[r["offset"]]) for r in rows]
+
+
+def _print_pooled_latency_table(rows: list[dict], policies: dict) -> dict[str, list[tuple[float, float]]]:
     """% diverted and latency percentiles for every policy, pooled across the whole offset sweep."""
     print(f"{'policy':<26} {'%diverted':>10} {'p50':>10} {'p90':>10} {'p99':>10} {'max':>10}")
     print("(pooled across OFFSET_SWEEP, which weights shallow and deep offsets EQUALLY -- nothing like")
@@ -533,27 +583,28 @@ def _print_pooled_latency_table(rows: list[dict], policies: dict) -> dict[str, l
     print(" deliberately offset-heavy stress grid, not a production latency estimate; see the by-offset")
     print(" breakdown below for the number that matters -- reweight it by your own traffic's real offset")
     print(" distribution instead of trusting a blended average here. 'diverted' means routed to")
-    print(" three-phase outright for the a-priori policies, or actually ABORTED past budget for the")
-    print(" abort policies -- not the same event, so don't compare the percentages across the two kinds.)")
-    latencies_by_policy: dict[str, list[float]] = {}
+    print(" three-phase instead of running the native walk.)")
+    weighted_rows = _offset_weighted_rows(rows)
+    total_weight = sum(weight for _, weight in weighted_rows)
+    latencies_by_policy: dict[str, list[tuple[float, float]]] = {}
     for name, cost_fn in policies.items():
         latencies = []
-        diverted_count = 0
-        for r in rows:
+        diverted_weight = 0.0
+        for r, weight in weighted_rows:
             ns, diverted = cost_fn(r)
-            latencies.append(ns)
-            diverted_count += diverted
+            latencies.append((ns, weight))
+            diverted_weight += weight * diverted
         latencies.sort()
         latencies_by_policy[name] = latencies
         print(
-            f"{name:<26} {100 * diverted_count / len(rows):>9.1f}% "
-            f"{fmt_ns(percentile(latencies, 50)):>10} {fmt_ns(percentile(latencies, 90)):>10} "
-            f"{fmt_ns(percentile(latencies, 99)):>10} {fmt_ns(latencies[-1]):>10}"
+            f"{name:<26} {100 * diverted_weight / total_weight:>9.1f}% "
+            f"{fmt_ns(_weighted_percentile(latencies, 50)):>10} {fmt_ns(_weighted_percentile(latencies, 90)):>10} "
+            f"{fmt_ns(_weighted_percentile(latencies, 99)):>10} {fmt_ns(latencies[-1][0]):>10}"
         )
     return latencies_by_policy
 
 
-def _print_worst_surviving_rows(rows: list[dict], policies: dict) -> None:
+def _print_worst_surviving_rows(rows: list[dict], policies: dict, three_phase: ThreePhaseModel) -> None:
     """Worst SURVIVING (non-diverted) row for a shortlist of policies -- does a bound's own worst case walk a row that should have been diverted?"""
     print("\nworst SURVIVING (non-diverted) row for each policy -- oracle's max is capped by construction")
     print("at always_three_phase's own max (see the earlier discussion); does sigma's/blend's own worst")
@@ -567,15 +618,14 @@ def _print_worst_surviving_rows(rows: list[dict], policies: dict) -> None:
         "no gate, sigma(4.0)",
         "no gate, sigma(6.0)",
         "no gate, sigma(8.0)",
-        "abort at 2x 3phase",
     ):
         cost_fn = policies[name]
         results = [(*cost_fn(r), r) for r in rows]
-        walked = [(ns, r) for ns, aborted, r in results if not aborted]
+        walked = [(ns, r) for ns, diverted, r in results if not diverted]
         if not walked:
             continue
         worst_ns, r = max(walked, key=lambda t: t[0])
-        tp = three_phase_ns_model(r["matches"])
+        tp = three_phase.estimate(r["matches"])
         print(
             f"  {name:<24} worst_walked={fmt_ns(worst_ns):>10}  offset={r['offset']:<6} matches={r['matches']:<6} "
             f"n_cards={r['n_cards']}  three_phase_would_be={fmt_ns(tp):>10}  clumping_factor={r['clumping_factor']:.2f}"
@@ -583,7 +633,7 @@ def _print_worst_surviving_rows(rows: list[dict], policies: dict) -> None:
 
 
 def _print_headline_percentiles(
-    latencies_by_policy: dict[str, list[float]], headline: list[str], chart_path: pathlib.Path | None
+    latencies_by_policy: dict[str, list[tuple[float, float]]], headline: list[str], chart_path: pathlib.Path | None
 ) -> None:
     """5%-granularity percentile-vs-latency table for the headline policies, plus the tail-concentrated chart export."""
     print(f"\npercentile vs latency (ns), 5% granularity, for the {len(headline)} headline policies:")
@@ -593,16 +643,16 @@ def _print_headline_percentiles(
     # Chart export uses a TAIL-CONCENTRATED grid, not the flat 5% steps printed above: the policies
     # only visibly separate past p90 (pooling-heavy shallow offsets dominate the bulk of the range),
     # and a flat step size leaves only 2-3 points there -- not enough to see curve shape once a chart
-    # zooms in. 1% steps 0-89, 0.5% steps 90-100 (n=2705 real rows underlies each, so 0.5% steps
-    # average ~14 rows/bucket in the tail -- real resolution, not pure sampling noise).
+    # zooms in. Use 1% steps 0-89 and 0.5% steps 90-100; the policy-split line above reports the
+    # evaluation population that underlies each point.
     pcts = [float(p) for p in range(90)] + [90 + 0.5 * i for i in range(21)]
     chart_data = {"pcts": pcts, "series": {}}
     for name in headline:
-        chart_data["series"][name] = [percentile(latencies_by_policy[name], p) for p in pcts]
+        chart_data["series"][name] = [_weighted_percentile(latencies_by_policy[name], p) for p in pcts]
     for p in pcts_print:
         line = f"{p:<5}"
         for name in headline:
-            line += f"{percentile(latencies_by_policy[name], p):>24.0f}"
+            line += f"{_weighted_percentile(latencies_by_policy[name], p):>24.0f}"
         print(line)
 
     if chart_path is not None:
@@ -619,15 +669,15 @@ def _print_by_offset_tables(rows: list[dict], policies: dict) -> None:
         "always_walk": policies["always_walk (today)"],
         "always_three_phase": policies["always_three_phase"],
         "no gate, blend(0.6)": policies["no gate, blend(0.6)"],
-        "abort at 3x 3phase": policies["abort at 3x 3phase"],
-        "abort at 5x 3phase": policies["abort at 5x 3phase"],
-        "abort at 10x 3phase": policies["abort at 10x 3phase"],
+        "no gate, sigma(2.0)": policies["no gate, sigma(2.0)"],
+        "no gate, sigma(3.0)": policies["no gate, sigma(3.0)"],
+        "no gate, sigma(4.0)": policies["no gate, sigma(4.0)"],
     }
     by_offset_rows: dict[int, list[dict]] = {}
     for r in rows:
         by_offset_rows.setdefault(r["offset"], []).append(r)
 
-    print("\n% diverted (routed/aborted), BY OFFSET:")
+    print("\n% diverted (routed to three-phase), BY OFFSET:")
     header = f"{'offset':<8}" + "".join(f"{name:>24}" for name in shortlist)
     print(header)
     for off, off_rows in sorted(by_offset_rows.items()):
@@ -647,24 +697,28 @@ def _print_by_offset_tables(rows: list[dict], policies: dict) -> None:
         print(line)
 
 
-def simulate_policies(rows: list[dict], chart_path: pathlib.Path | None) -> None:
+def simulate_policies(rows: list[dict], chart_path: pathlib.Path | None, three_phase: ThreePhaseModel) -> None:
     """For each decision POLICY, what fraction of real traffic gets routed to the three-phase fallback, and what does that do to the resulting latency distribution?
 
     The walk side uses each row's REAL `walk_ns` (see `evaluate()`) whenever a policy picks it,
     including `oracle` (the reference point: the best any policy COULD do, using the row's real
     `walk_ns` directly -- unknowable in advance, but it bounds how much more there is to gain over a
     real decision rule, which only ever gets `matches`/`n_cards`/`k`, never the outcome). The
-    bound-based policies still have to PREDICT a hypothetical walk cost from a card estimate before
-    running anything, so they convert it via `walk_rate` -- fit from this same dataset's real
-    (`walk_ns`, `realized`) pairs now that `walk_ns` is a clean, confound-free measurement, not an
-    externally recalled or kernel-modeled constant. The three-phase side has no per-row real
-    measurement at all (not wired into dispatch -- see the module docstring), so it stays modeled via
-    `three_phase_ns_model`.
+    bound-based policies still have to PREDICT a hypothetical walk cost before running anything, so
+    they convert bound cards and acquire's corresponding printing-walk estimate through a two-term
+    model fit on a disjoint calibration half. The three-phase side has no per-row real
+    measurement at all (not wired into dispatch -- see the module docstring), so it stays modeled by
+    the explicit `ThreePhaseModel` calibration supplied for this run.
     """
-    walk_rate, ceiling_ns = _walk_rate_and_ceiling(rows)
-    policies = _build_policies(walk_rate, ceiling_ns)
-    latencies_by_policy = _print_pooled_latency_table(rows, policies)
-    _print_worst_surviving_rows(rows, policies)
+    calibration_rows, evaluation_rows = _split_policy_rows(rows)
+    walk_model = _fit_walk_cost_model(calibration_rows)
+    print(
+        f"\npolicy split: calibration={len(calibration_rows)} rows, evaluation={len(evaluation_rows)} rows; "
+        f"walk fit={walk_model.ns_per_card:.3f} ns/card + {walk_model.ns_per_printing:.3f} ns/printing\n"
+    )
+    policies = _build_policies(walk_model, three_phase)
+    latencies_by_policy = _print_pooled_latency_table(evaluation_rows, policies)
+    _print_worst_surviving_rows(evaluation_rows, policies, three_phase)
     headline = [
         "always_walk (today)",
         "always_three_phase",
@@ -677,7 +731,7 @@ def simulate_policies(rows: list[dict], chart_path: pathlib.Path | None) -> None
         "no gate, sigma(8.0)",
     ]
     _print_headline_percentiles(latencies_by_policy, headline, chart_path)
-    _print_by_offset_tables(rows, policies)
+    _print_by_offset_tables(evaluation_rows, policies)
 
 
 def main() -> None:
@@ -688,10 +742,25 @@ def main() -> None:
     parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
     parser.add_argument("--shm-path", type=pathlib.Path, default=None)
     parser.add_argument("--chart-path", type=pathlib.Path, default=None, help="write chart series JSON here")
+    parser.add_argument("--three-phase-rate-ns-per-match", type=float, required=True)
+    parser.add_argument("--three-phase-fixed-ns", type=float, required=True)
+    parser.add_argument("--three-phase-floor-ns", type=float, required=True)
     args = parser.parse_args()
+    if args.n_queries <= 0:
+        parser.error("--n-queries must be greater than zero")
 
     rng = random.Random(args.seed)
     selfcheck_nhg_moments(rng)
+    three_phase = ThreePhaseModel(
+        rate_ns_per_match=args.three_phase_rate_ns_per_match,
+        fixed_ns=args.three_phase_fixed_ns,
+        floor_ns=args.three_phase_floor_ns,
+    )
+    print(
+        "three-phase model: "
+        f"rate={three_phase.rate_ns_per_match:g} ns/match "
+        f"fixed={three_phase.fixed_ns:g} ns floor={three_phase.floor_ns:g} ns"
+    )
 
     engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".cardvisitedbound.store"))
     sampler = QuerySampler(args.corpus, "uniform")
@@ -699,14 +768,10 @@ def main() -> None:
     rows: list[dict] = []
     considered = 0
     for _ in range(args.n_queries):
-        # Pinned to ONE predicate: this used to be required because `PrintingCompose` reported one
-        # undivided `ns_total` span, so a multi-predicate AND's compose cost could dwarf the walk
-        # itself and swamp any attempt to fit a per-card WALK rate from `ns`. `ComposePageWork`'s
-        # `ns_build`/`ns_paging` split (this same session, `card_engine/src/lib.rs`) fixed that at the
-        # source -- `ns_loop` is now the paging branch alone regardless of predicate count. Kept anyway
-        # as the simpler default: single-predicate is still the case this bound targets, and narrowing
-        # the sampler to it costs nothing here.
-        query = sampler.query(rng, shape=Shape(predicates=1))
+        # Exercise the sampler's normal predicate counts and connective structures. The
+        # `ns_build`/`ns_paging` split keeps multi-predicate compose work out of the measured walk, so
+        # there is no longer a measurement reason to narrow this to one flat predicate.
+        query = sampler.structured_query(rng)["query"]
         orderby = rng.choice(ORDERBYS)
         direction = rng.choice(("asc", "desc"))
         for offset in OFFSET_SWEEP:
@@ -717,7 +782,9 @@ def main() -> None:
 
     print(f"\n{considered} (query, orderby, direction, offset) points considered, {len(rows)} landed on Card-mode Perm both ways.")
     report(rows)
-    simulate_policies(rows, args.chart_path)
+    if not rows:
+        return
+    simulate_policies(rows, args.chart_path, three_phase)
 
 
 if __name__ == "__main__":

--- a/scripts/bench_compose_card_visited_safety_bound.py
+++ b/scripts/bench_compose_card_visited_safety_bound.py
@@ -1,7 +1,4 @@
-"""Two candidate SAFETY BOUNDS on `walk_grouped_page`'s (`Mode::Card`) worst-case `cards_visited`,
-built from the one thing EDHREC clumping cannot corrupt: the exact matching-card count `matches`
-(`M`), already computed before the `Perm` branch runs (`compose_paging_with_total`/the fastpath's own
-`compose_total_for_mode`) -- never a position estimate, which is exactly what clumping defeats.
+"""Two candidate SAFETY BOUNDS on `walk_grouped_page`'s (`Mode::Card`) worst-case `cards_visited`, built from the one thing EDHREC clumping cannot corrupt: the exact matching-card count `matches` (`M`), already computed before the `Perm` branch runs (`compose_paging_with_total`/the fastpath's own `compose_total_for_mode`) -- never a position estimate, which is exactly what clumping defeats.
 
 Two closed-form anchors, no calibration needed for either:
 
@@ -83,16 +80,21 @@ PROD_COMPOSE_WALK_EMIT_PER_ROW_NS = 2.19
 
 
 def prod_cost_model_ns(printings_walked_pred: float, limit: int) -> float:
+    """The PRODUCTION cost model's own prediction (`cost::plan_cost`'s `PrintingCompose`/`Perm` arm), for grading against real `walk_ns`."""
     return printings_walked_pred * PROD_COMPOSE_WALK_STEP_NS + limit * PROD_COMPOSE_WALK_EMIT_PER_ROW_NS
+
+
+NS_PER_US = 1_000
+NS_PER_MS = 1_000_000
 
 
 def fmt_ns(ns: float) -> str:
     """Human units, fixed width -- raw nanosecond counts (`606542`) are hard to eyeball at a glance."""
-    if ns < 1_000:
+    if ns < NS_PER_US:
         return f"{ns:.0f} ns"
-    if ns < 1_000_000:
-        return f"{ns / 1_000:.1f} us"
-    return f"{ns / 1_000_000:.2f} ms"
+    if ns < NS_PER_MS:
+        return f"{ns / NS_PER_US:.1f} us"
+    return f"{ns / NS_PER_MS:.2f} ms"
 
 
 # `walk_grouped_page`'s own real cost, unlike three-phase's, IS directly observable now: `explain_
@@ -126,8 +128,7 @@ def worst_case_bound(n_cards: int, matches: int, k: int) -> float:
 
 
 def uniform_mean(n_cards: int, matches: int, k: int) -> float:
-    """Expected position of the k-th match if `matches` cards were scattered with NO clumping --
-    the order-statistic mean of a uniformly random `matches`-subset of `n_cards` slots."""
+    """Expected position of the k-th match if `matches` cards were scattered with NO clumping -- the order-statistic mean of a uniformly random `matches`-subset of `n_cards` slots."""
     return k * (n_cards + 1) / (matches + 1)
 
 
@@ -161,21 +162,13 @@ def blend_bound(n_cards: int, matches: int, k: int, knob: float) -> float:
 
 
 def sigma_bound(n_cards: int, matches: int, k: int, knob: float) -> float:
-    """`knob` = how many std devs above the no-clumping mean, same random-placement model as
-    `blend_bound`'s low anchor -- just a different (distribution-shaped, not linear) margin."""
+    """`knob` = how many std devs above the no-clumping mean, same random-placement model as `blend_bound`'s low anchor -- just a different (distribution-shaped, not linear) margin."""
     mean = uniform_mean(n_cards, matches, k)
     return mean + knob * math.sqrt(nhg_variance(n_cards, matches, k))
 
 
-def abort_budget_ns(walk_ns: float, matches: int, safety_factor: float, ceiling_ns: float) -> float:
-    """Cost under a RUNTIME circuit breaker instead of an a-priori decision: let the walk run, and
-    only abort into three-phase once the walk's OWN elapsed cost crosses `budget = safety_factor *
-    three_phase_ns_model(matches)` -- a budget anchored to the alternative's own (offset-independent)
-    cost, not to `k`. A `k`-scaled budget was tried first and does not work: `k = offset + limit`
-    already includes the offset, so at a deep offset the budget outgrows `n_cards` and the abort can
-    never trip at all -- exactly the population (deep, expensive walks) this exists to catch. Tracking
-    elapsed cost is free in the real executor (`work.cards_visited += 1` already runs every
-    iteration); this models "compare it against a threshold every so often," not new instrumentation.
+def abort_budget_ns(walk_ns: float, matches: int, safety_factor: float, ceiling_ns: float) -> tuple[float, bool]:
+    """Cost under a RUNTIME circuit breaker instead of an a-priori decision: let the walk run, and only abort into three-phase once the walk's OWN elapsed cost crosses `budget = safety_factor * three_phase_ns_model(matches)` -- a budget anchored to the alternative's own (offset-independent) cost, not to `k`. A `k`-scaled budget was tried first and does not work: `k = offset + limit` already includes the offset, so at a deep offset the budget outgrows `n_cards` and the abort can never trip at all -- exactly the population (deep, expensive walks) this exists to catch. Tracking elapsed cost is free in the real executor (`work.cards_visited += 1` already runs every iteration); this models "compare it against a threshold every so often," not new instrumentation.
 
     Naively, an abort caps the total at `(safety_factor + 1) * three_phase_ns_model(matches)` -- but
     that cap ITSELF grows with `matches` (three-phase costs more for a high-selectivity query), and a
@@ -184,11 +177,15 @@ def abort_budget_ns(walk_ns: float, matches: int, safety_factor: float, ceiling_
     dataset. `ceiling_ns` is the fix: an absolute cap independent of `matches` entirely (the caller
     passes `walk_rate * n_cards` -- no real walk, however clumped, can cost more than visiting the
     whole corpus once). A row that finishes within budget still pays EXACTLY its own real `walk_ns`.
+
+    Returns:
+        `(ns, aborted)` -- `aborted` is whether the breaker tripped, returned alongside the cost
+        instead of recomputed by the caller from the same `budget`.
     """
     budget = safety_factor * three_phase_ns_model(matches)
     if walk_ns <= budget:
-        return walk_ns
-    return min(budget + three_phase_ns_model(matches), ceiling_ns)
+        return walk_ns, False
+    return min(budget + three_phase_ns_model(matches), ceiling_ns), True
 
 
 METHODS = {
@@ -198,9 +195,7 @@ METHODS = {
 
 
 def selfcheck_nhg_moments(rng: random.Random) -> None:
-    """Monte Carlo check of `uniform_mean`/`nhg_variance` against simulated random placements --
-    quoting a variance formula from memory is exactly the kind of thing this repo's conventions say
-    to verify, not assume."""
+    """Monte Carlo check of `uniform_mean`/`nhg_variance` against simulated random placements -- quoting a variance formula from memory is exactly the kind of thing this repo's conventions say to verify, not assume."""
     trials = 20_000
     cases = [(500, 50, 10), (5_000, 200, 80), (2_000, 1_800, 500)]
     print("selfcheck: analytic vs Monte Carlo (negative hypergeometric position of the k-th match)")
@@ -261,6 +256,7 @@ def evaluate(engine: object, query: str, orderby: str, direction: str, offset: i
         num_warmups=NUM_WARMUPS,
         num_trials=NUM_TRIALS,
     )
+    costbench.require_schema(full)
     compose = next((p for p in full["plans"] if p["plan"] == "PrintingCompose"), None)
     if compose is None or not compose["trials_ns"] or compose.get("paging_taken") != "Perm":
         return None
@@ -292,17 +288,13 @@ def evaluate(engine: object, query: str, orderby: str, direction: str, offset: i
     }
 
 
-def report(rows: list[dict]) -> None:
-    """Per-(method, knob) violation rate and bound tightness, so a knob can be picked by matching
-    violation rates across methods and comparing which gives the smaller (tighter) bound there."""
-    if not rows:
-        print("Nothing landed on Card-mode Perm for both explain() and explain_analyze() -- nothing to grade.")
-        return
-    print(f"\nn={len(rows)} (query, orderby, direction, offset) points graded\n")
-    prod_ratio = sorted(prod_cost_model_ns(r["printings_walked_pred"], LIMIT) / r["walk_ns"] for r in rows)
+def _report_prod_cost_model(rows: list[dict]) -> None:
+    """PRODUCTION cost model (`cost::plan_cost`) vs real `walk_ns`, pooled and by offset."""
+    prod_ratios_by_row = [(prod_cost_model_ns(r["printings_walked_pred"], LIMIT) / r["walk_ns"], r) for r in rows]
+    prod_ratio = sorted(ratio for ratio, _ in prod_ratios_by_row)
     print(
-        f"PRODUCTION cost model (cost::plan_cost, PrintingCompose/Perm) vs real walk_ns, "
-        f"ratio = predicted/realized (>1 over-costs, <1 under-costs):"
+        "PRODUCTION cost model (cost::plan_cost, PrintingCompose/Perm) vs real walk_ns, "
+        "ratio = predicted/realized (>1 over-costs, <1 under-costs):"
     )
     for p in (0, 5, 10, 25, 50, 75, 90, 95, 100):
         print(f"  p{p:<3} {percentile(prod_ratio, p):.3f}")
@@ -310,17 +302,25 @@ def report(rows: list[dict]) -> None:
     print("traffic rarely reaches -- i.e. is the model actually fine for the shallow case it was likely")
     print("tuned against, and only broken for the population this whole investigation is about?):")
     by_offset_prod: dict[int, list[float]] = {}
-    for r in rows:
-        by_offset_prod.setdefault(r["offset"], []).append(prod_cost_model_ns(r["printings_walked_pred"], LIMIT) / r["walk_ns"])
+    for ratio, r in prod_ratios_by_row:
+        by_offset_prod.setdefault(r["offset"], []).append(ratio)
     for off, vals in sorted(by_offset_prod.items()):
         vals.sort()
         print(f"  offset={off:<8} n={len(vals):<4} p50={percentile(vals, 50):>7.3f}  p90={percentile(vals, 90):>7.3f}")
+
+
+def _report_acquire_estimate_error(rows: list[dict]) -> None:
+    """Acquire-time estimate of `matches` vs the exact count -- the second-order error `evaluate()` keeps separate from the bound's own grading."""
     print()
     est_ratio = sorted(r["est_matches"] / r["matches"] for r in rows)
     print(
         f"acquire-estimate matches / exact matches (>1 over-estimates M, shrinks worst_case's margin): "
         f"p10={percentile(est_ratio, 10):.2f}  p50={percentile(est_ratio, 50):.2f}  p90={percentile(est_ratio, 90):.2f}"
     )
+
+
+def _report_worst_case_bound(rows: list[dict]) -> None:
+    """`worst_case_bound` alone: violation count and slack, pooled and by offset."""
     wc_slack = [worst_case_bound(r["n_cards"], r["matches"], r["k"]) / r["realized"] for r in rows]
     print(f"worst_case_bound alone: 0 violations by construction; slack (bound/realized) p50={percentile(sorted(wc_slack), 50):.2f}")
     print("\nworst_case_bound slack BY OFFSET (does the bound stay huge even at shallow offset, where\n"
@@ -332,6 +332,10 @@ def report(rows: list[dict]) -> None:
     for off, vals in sorted(by_offset.items()):
         vals.sort()
         print(f"  offset={off:<8} n={len(vals):<4} p50 slack={percentile(vals, 50):>8.1f}  p90 slack={percentile(vals, 90):>8.1f}")
+
+
+def _report_blend_bound_by_offset(rows: list[dict]) -> None:
+    """`blend_bound(knob=0.6)` slack by offset, for comparison against `worst_case_bound`'s table."""
     print("\nblend_bound(knob=0.6) slack BY OFFSET, for comparison against worst_case's table above --")
     print("does the better-behaved knob still stay tight at shallow offset (where it matters for keeping")
     print("walk_grouped_page in play), not just safe at deep offset?")
@@ -341,12 +345,20 @@ def report(rows: list[dict]) -> None:
     for off, vals in sorted(by_offset_blend.items()):
         vals.sort()
         print(f"  offset={off:<8} n={len(vals):<4} p50 slack={percentile(vals, 50):>8.2f}  p90 slack={percentile(vals, 90):>8.2f}")
+
+
+def _dump_worst_case_violations(rows: list[dict]) -> None:
+    """Dump any row where `worst_case_bound` undershot `realized` -- should never fire; diagnostic only."""
     wc_violations = [r for r in rows if worst_case_bound(r["n_cards"], r["matches"], r["k"]) < r["realized"]]
     if wc_violations:
         print(f"  !! {len(wc_violations)} worst_case_bound violations (should be impossible) -- dumping for diagnosis:")
         for r in wc_violations:
             wc = worst_case_bound(r["n_cards"], r["matches"], r["k"])
             print(f"     n_cards={r['n_cards']} matches={r['matches']} k={r['k']} offset={r['offset']} realized={r['realized']} worst_case={wc}")
+
+
+def _report_method_knob_table(rows: list[dict]) -> None:
+    """Per-(method, knob) violation rate and slack percentiles -- the table a knob gets picked from."""
     print(f"{'method':<8} {'knob':>6} {'violations':>11} {'viol%':>8} {'p50 slack':>10} {'p90 slack':>10} {'p99 slack':>10}")
     for name, (fn, knobs) in METHODS.items():
         for knob in knobs:
@@ -367,8 +379,13 @@ def report(rows: list[dict]) -> None:
                 f"{p50:>10.2f} {p90:>10.2f} {p99:>10.2f}"
             )
 
-    # ─── How bad are violations, not just how many? A "95% safe" bound is only useful if the 5% that ─
-    # miss don't reintroduce the exact unbounded tail this whole effort exists to remove.
+
+def _report_overshoot_among_violations(rows: list[dict]) -> None:
+    """Overshoot (realized/bound) among violations only, every knob -- how bad a miss is, not just how often.
+
+    A "95% safe" bound is only useful if the 5% that miss don't reintroduce the exact unbounded tail
+    this whole effort exists to remove.
+    """
     print("\novershoot (realized/bound) AMONG VIOLATIONS ONLY, EVERY knob -- if this stays near 1.0, a")
     print("violation is a near-miss; if it's large/growing, relaxing the violation-rate target doesn't cap")
     print("the pathological case, it just makes it rarer:")
@@ -387,7 +404,12 @@ def report(rows: list[dict]) -> None:
                 f"p50={percentile(overshoots, 50):.2f}  p90={percentile(overshoots, 90):.2f}  max={overshoots[-1]:.2f}"
             )
 
-    # ─── Does clumping severity correlate with anything cheap to know a priori? ─────────────────────
+
+def _report_clumping_by_selectivity(rows: list[dict]) -> None:
+    """`clumping_factor` by selectivity decile -- does a low- or high-selectivity query clump worse?
+
+    Does clumping severity correlate with anything cheap to know a priori?
+    """
     print("\nclumping_factor (realized/uniform_mean) BY SELECTIVITY DECILE (does a low-M/n_cards query")
     print("clump worse than a high-selectivity one, or is it roughly uniform across selectivity?):")
     by_sel: list[tuple[float, dict]] = sorted(((r["matches"] / r["n_cards"], r) for r in rows), key=lambda t: t[0])
@@ -403,6 +425,9 @@ def report(rows: list[dict]) -> None:
             f"p50={percentile(cfs, 50):>8.2f}  p90={percentile(cfs, 90):>8.2f}  max={cfs[-1]:>8.2f}"
         )
 
+
+def _report_clumping_by_orderby(rows: list[dict]) -> None:
+    """`clumping_factor` by orderby column -- does a semantically-loaded sort column clump worse than an arbitrary one?"""
     print("\nclumping_factor BY ORDERBY COLUMN (does a real, semantically-loaded sort column like edhrec")
     print("clump worse than an arbitrary one like name?):")
     by_orderby: dict[str, list[float]] = {}
@@ -412,6 +437,9 @@ def report(rows: list[dict]) -> None:
         cfs.sort()
         print(f"  {col:<12} n={len(cfs):<5} p50={percentile(cfs, 50):>8.2f}  p90={percentile(cfs, 90):>8.2f}  max={cfs[-1]:>8.2f}")
 
+
+def _report_worst_outliers(rows: list[dict]) -> None:
+    """The 10 rows with the highest `clumping_factor`, for manual inspection."""
     print("\nworst 10 outliers by clumping_factor (manual-inspection candidates):")
     worst = sorted(rows, key=lambda r: -r["clumping_factor"])[:10]
     for r in worst:
@@ -422,23 +450,37 @@ def report(rows: list[dict]) -> None:
         )
 
 
-def simulate_policies(rows: list[dict]) -> None:
-    """For each decision POLICY, what fraction of real traffic gets routed to the three-phase
-    fallback, and what does that do to the resulting latency distribution?
+def report(rows: list[dict]) -> None:
+    """Per-(method, knob) violation rate and bound tightness, so a knob can be picked by matching violation rates across methods and comparing which gives the smaller (tighter) bound there."""
+    if not rows:
+        print("Nothing landed on Card-mode Perm for both explain() and explain_analyze() -- nothing to grade.")
+        return
+    print(f"\nn={len(rows)} (query, orderby, direction, offset) points graded\n")
+    _report_prod_cost_model(rows)
+    _report_acquire_estimate_error(rows)
+    _report_worst_case_bound(rows)
+    _report_blend_bound_by_offset(rows)
+    _dump_worst_case_violations(rows)
+    _report_method_knob_table(rows)
+    _report_overshoot_among_violations(rows)
+    _report_clumping_by_selectivity(rows)
+    _report_clumping_by_orderby(rows)
+    _report_worst_outliers(rows)
 
-    The walk side uses each row's REAL `walk_ns` (see `evaluate()`) whenever a policy picks it,
-    including `oracle` (the reference point: the best any policy COULD do, using the row's real
-    `walk_ns` directly -- unknowable in advance, but it bounds how much more there is to gain over a
-    real decision rule, which only ever gets `matches`/`n_cards`/`k`, never the outcome). The
-    bound-based policies still have to PREDICT a hypothetical walk cost from a card estimate before
-    running anything, so they convert it via `walk_rate` -- fit from this same dataset's real
-    (`walk_ns`, `realized`) pairs now that `walk_ns` is a clean, confound-free measurement, not an
-    externally recalled or kernel-modeled constant. The three-phase side has no per-row real
-    measurement at all (not wired into dispatch -- see the module docstring), so it stays modeled via
-    `three_phase_ns_model`.
-    """
+
+def _walk_rate_and_ceiling(rows: list[dict]) -> tuple[float, float]:
+    """Fit `walk_rate` from real (`walk_ns`, `realized`) pairs and derive the abort ceiling from it, printing both."""
     walk_rate = percentile(sorted(r["walk_ns"] / r["realized"] for r in rows), 50)
     print(f"\nwalk_grouped_page rate fit from real (walk_ns, realized) pairs: {walk_rate:.3f} ns/card visited (median)\n")
+    # No real walk, however clumped, visits more cards than the whole corpus once -- an absolute
+    # backstop independent of `matches`, unlike the naive `(safety_factor + 1) * three_phase` cap.
+    ceiling_ns = walk_rate * max(r["n_cards"] for r in rows)
+    print(f"abort ceiling: {ceiling_ns:.0f} ns (walk_rate * n_cards -- a full-corpus walk, absolute worst case)\n")
+    return walk_rate, ceiling_ns
+
+
+def _build_policies(walk_rate: float, ceiling_ns: float) -> dict[str, object]:
+    """The named decision policies `simulate_policies` grades against each other, keyed by display name."""
 
     def gated(gate: int, bound_fn) -> object:  # noqa: ANN001 - bound_fn is one of the module's *_bound callables
         def cost(r: dict) -> tuple[float, bool]:
@@ -451,20 +493,13 @@ def simulate_policies(rows: list[dict]) -> None:
 
         return cost
 
-    # No real walk, however clumped, visits more cards than the whole corpus once -- an absolute
-    # backstop independent of `matches`, unlike the naive `(safety_factor + 1) * three_phase` cap.
-    ceiling_ns = walk_rate * max(r["n_cards"] for r in rows)
-    print(f"abort ceiling: {ceiling_ns:.0f} ns (walk_rate * n_cards -- a full-corpus walk, absolute worst case)\n")
-
     def abort_at(safety_factor: float) -> object:
         def cost(r: dict) -> tuple[float, bool]:
-            budget = safety_factor * three_phase_ns_model(r["matches"])
-            ns = abort_budget_ns(r["walk_ns"], r["matches"], safety_factor, ceiling_ns)
-            return ns, r["walk_ns"] > budget
+            return abort_budget_ns(r["walk_ns"], r["matches"], safety_factor, ceiling_ns)
 
         return cost
 
-    policies = {
+    return {
         "always_walk (today)": lambda r: (r["walk_ns"], False),
         "always_three_phase": lambda r: (three_phase_ns_model(r["matches"]), True),
         "oracle (best possible)": lambda r: (
@@ -489,6 +524,9 @@ def simulate_policies(rows: list[dict]) -> None:
         "abort at 20x 3phase": abort_at(20.0),
     }
 
+
+def _print_pooled_latency_table(rows: list[dict], policies: dict) -> dict[str, list[float]]:
+    """% diverted and latency percentiles for every policy, pooled across the whole offset sweep."""
     print(f"{'policy':<26} {'%diverted':>10} {'p50':>10} {'p90':>10} {'p99':>10} {'max':>10}")
     print("(pooled across OFFSET_SWEEP, which weights shallow and deep offsets EQUALLY -- nothing like")
     print(" real traffic's offset~0-heavy mix, so this table is a policy-vs-policy comparison on a")
@@ -512,7 +550,11 @@ def simulate_policies(rows: list[dict]) -> None:
             f"{fmt_ns(percentile(latencies, 50)):>10} {fmt_ns(percentile(latencies, 90)):>10} "
             f"{fmt_ns(percentile(latencies, 99)):>10} {fmt_ns(latencies[-1]):>10}"
         )
+    return latencies_by_policy
 
+
+def _print_worst_surviving_rows(rows: list[dict], policies: dict) -> None:
+    """Worst SURVIVING (non-diverted) row for a shortlist of policies -- does a bound's own worst case walk a row that should have been diverted?"""
     print("\nworst SURVIVING (non-diverted) row for each policy -- oracle's max is capped by construction")
     print("at always_three_phase's own max (see the earlier discussion); does sigma's/blend's own worst")
     print("case walk a row that should have been diverted, and by how much does it miss?")
@@ -528,7 +570,8 @@ def simulate_policies(rows: list[dict]) -> None:
         "abort at 2x 3phase",
     ):
         cost_fn = policies[name]
-        walked = [(cost_fn(r)[0], r) for r in rows if not cost_fn(r)[1]]
+        results = [(*cost_fn(r), r) for r in rows]
+        walked = [(ns, r) for ns, aborted, r in results if not aborted]
         if not walked:
             continue
         worst_ns, r = max(walked, key=lambda t: t[0])
@@ -538,17 +581,11 @@ def simulate_policies(rows: list[dict]) -> None:
             f"n_cards={r['n_cards']}  three_phase_would_be={fmt_ns(tp):>10}  clumping_factor={r['clumping_factor']:.2f}"
         )
 
-    headline = [
-        "always_walk (today)",
-        "always_three_phase",
-        "oracle (best possible)",
-        "no gate, sigma(1.0)",
-        "no gate, sigma(2.0)",
-        "no gate, sigma(3.0)",
-        "no gate, sigma(4.0)",
-        "no gate, sigma(6.0)",
-        "no gate, sigma(8.0)",
-    ]
+
+def _print_headline_percentiles(
+    latencies_by_policy: dict[str, list[float]], headline: list[str], chart_path: pathlib.Path | None
+) -> None:
+    """5%-granularity percentile-vs-latency table for the headline policies, plus the tail-concentrated chart export."""
     print(f"\npercentile vs latency (ns), 5% granularity, for the {len(headline)} headline policies:")
     pcts_print = list(range(0, 101, 5))
     header2 = f"{'pct':<5}" + "".join(f"{name:>24}" for name in headline)
@@ -558,7 +595,7 @@ def simulate_policies(rows: list[dict]) -> None:
     # and a flat step size leaves only 2-3 points there -- not enough to see curve shape once a chart
     # zooms in. 1% steps 0-89, 0.5% steps 90-100 (n=2705 real rows underlies each, so 0.5% steps
     # average ~14 rows/bucket in the tail -- real resolution, not pure sampling noise).
-    pcts = [float(p) for p in range(0, 90)] + [90 + 0.5 * i for i in range(21)]
+    pcts = [float(p) for p in range(90)] + [90 + 0.5 * i for i in range(21)]
     chart_data = {"pcts": pcts, "series": {}}
     for name in headline:
         chart_data["series"][name] = [percentile(latencies_by_policy[name], p) for p in pcts]
@@ -568,14 +605,14 @@ def simulate_policies(rows: list[dict]) -> None:
             line += f"{percentile(latencies_by_policy[name], p):>24.0f}"
         print(line)
 
-    chart_path = pathlib.Path(
-        "/private/tmp/claude-502/-Users-joseph-bylund-scratch-sylvan-librarian/"
-        "06741293-793d-446c-823a-cac4758bff9c/scratchpad/policy_latency_percentiles.json"
-    )
-    chart_path.write_text(json.dumps(chart_data))
-    print(f"\nchart data written to {chart_path}")
+    if chart_path is not None:
+        chart_path.write_text(json.dumps(chart_data))
+        print(f"\nchart data written to {chart_path}")
 
-    # ─── By offset instead of pooled: this is the view to actually trust, since it doesn't require ──
+
+def _print_by_offset_tables(rows: list[dict], policies: dict) -> None:
+    """% diverted and median latency, BY OFFSET, for a policy shortlist -- the view to trust over the pooled tables above."""
+    # By offset instead of pooled: this is the view to actually trust, since it doesn't require
     # guessing how real traffic distributes across offsets -- read it against YOUR OWN traffic's depth
     # distribution instead of a blended average that bakes in an arbitrary sweep weighting.
     shortlist = {
@@ -610,6 +647,39 @@ def simulate_policies(rows: list[dict]) -> None:
         print(line)
 
 
+def simulate_policies(rows: list[dict], chart_path: pathlib.Path | None) -> None:
+    """For each decision POLICY, what fraction of real traffic gets routed to the three-phase fallback, and what does that do to the resulting latency distribution?
+
+    The walk side uses each row's REAL `walk_ns` (see `evaluate()`) whenever a policy picks it,
+    including `oracle` (the reference point: the best any policy COULD do, using the row's real
+    `walk_ns` directly -- unknowable in advance, but it bounds how much more there is to gain over a
+    real decision rule, which only ever gets `matches`/`n_cards`/`k`, never the outcome). The
+    bound-based policies still have to PREDICT a hypothetical walk cost from a card estimate before
+    running anything, so they convert it via `walk_rate` -- fit from this same dataset's real
+    (`walk_ns`, `realized`) pairs now that `walk_ns` is a clean, confound-free measurement, not an
+    externally recalled or kernel-modeled constant. The three-phase side has no per-row real
+    measurement at all (not wired into dispatch -- see the module docstring), so it stays modeled via
+    `three_phase_ns_model`.
+    """
+    walk_rate, ceiling_ns = _walk_rate_and_ceiling(rows)
+    policies = _build_policies(walk_rate, ceiling_ns)
+    latencies_by_policy = _print_pooled_latency_table(rows, policies)
+    _print_worst_surviving_rows(rows, policies)
+    headline = [
+        "always_walk (today)",
+        "always_three_phase",
+        "oracle (best possible)",
+        "no gate, sigma(1.0)",
+        "no gate, sigma(2.0)",
+        "no gate, sigma(3.0)",
+        "no gate, sigma(4.0)",
+        "no gate, sigma(6.0)",
+        "no gate, sigma(8.0)",
+    ]
+    _print_headline_percentiles(latencies_by_policy, headline, chart_path)
+    _print_by_offset_tables(rows, policies)
+
+
 def main() -> None:
     """Sample uniform real queries, sweep deep offsets explicitly, grade both bound candidates."""
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
@@ -617,6 +687,7 @@ def main() -> None:
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
     parser.add_argument("--shm-path", type=pathlib.Path, default=None)
+    parser.add_argument("--chart-path", type=pathlib.Path, default=None, help="write chart series JSON here")
     args = parser.parse_args()
 
     rng = random.Random(args.seed)
@@ -628,13 +699,13 @@ def main() -> None:
     rows: list[dict] = []
     considered = 0
     for _ in range(args.n_queries):
-        # Pinned to ONE predicate: `PrintingCompose`'s own phase reporting doesn't split "build pbits
-        # from the filter" out from "page it" (`ComposePageWork`'s doc: "Compose's arm is not
-        # decomposed into setup/loop/finish... there is nothing to attribute between phases" -- both
-        # land in `ns_loop` as one undivided span). A multi-predicate AND's compose cost can dwarf the
-        # walk itself and swamp any attempt to fit a per-card WALK rate from `ns`. A single predicate
-        # makes that shared cost small and roughly constant instead, so it acts like the intercept in
-        # `WALK_RATE`'s fit rather than dominating its slope.
+        # Pinned to ONE predicate: this used to be required because `PrintingCompose` reported one
+        # undivided `ns_total` span, so a multi-predicate AND's compose cost could dwarf the walk
+        # itself and swamp any attempt to fit a per-card WALK rate from `ns`. `ComposePageWork`'s
+        # `ns_build`/`ns_paging` split (this same session, `card_engine/src/lib.rs`) fixed that at the
+        # source -- `ns_loop` is now the paging branch alone regardless of predicate count. Kept anyway
+        # as the simpler default: single-predicate is still the case this bound targets, and narrowing
+        # the sampler to it costs nothing here.
         query = sampler.query(rng, shape=Shape(predicates=1))
         orderby = rng.choice(ORDERBYS)
         direction = rng.choice(("asc", "desc"))
@@ -646,7 +717,7 @@ def main() -> None:
 
     print(f"\n{considered} (query, orderby, direction, offset) points considered, {len(rows)} landed on Card-mode Perm both ways.")
     report(rows)
-    simulate_policies(rows)
+    simulate_policies(rows, args.chart_path)
 
 
 if __name__ == "__main__":

--- a/scripts/bench_compose_card_visited_safety_bound.py
+++ b/scripts/bench_compose_card_visited_safety_bound.py
@@ -1,0 +1,653 @@
+"""Two candidate SAFETY BOUNDS on `walk_grouped_page`'s (`Mode::Card`) worst-case `cards_visited`,
+built from the one thing EDHREC clumping cannot corrupt: the exact matching-card count `matches`
+(`M`), already computed before the `Perm` branch runs (`compose_paging_with_total`/the fastpath's own
+`compose_total_for_mode`) -- never a position estimate, which is exactly what clumping defeats.
+
+Two closed-form anchors, no calibration needed for either:
+
+    worst_case(N, M, k)     = (N - M) + k       -- every non-match clumped before the k-th match.
+    uniform_mean(N, M, k)   = k*(N+1)/(M+1)     -- expected position if M matches were scattered with
+                                                    NO clumping at all (order statistic of a random
+                                                    M-subset of N slots).
+
+The user's ask, in `reference-engine-compose-popcount-skip-topk-select.md`'s decision-rule discussion: a
+pure worst-case bound is safe but leaves a lot of `walk_grouped_page` traffic needlessly routed to the
+(slower, but bounded) three-phase fallback; a pure mean estimate is exactly the thing clumping already
+broke (`reference-engine-compose-perm-cards-visited-estimator.md`). So: build BOTH of the following
+candidates, sharing one signature `(n_cards, matches, k, knob) -> float`, and let real uniform-sampled
+traffic pick between them:
+
+    blend_bound(n_cards, matches, k, knob)  -- knob in [0,1]: linear interpolation between the two
+                                                anchors above. knob=0 is the mean, knob=1 is worst case.
+    sigma_bound(n_cards, matches, k, knob)  -- knob = how many std devs above the mean, under the SAME
+                                                no-clumping random-placement model (closed-form negative
+                                                hypergeometric variance, no simulation, no corpus fit).
+
+Both are safety bounds: bigger is "more conservative" (routes more `Perm` queries to the fallback,
+never wrong to do so), smaller is "tighter" (more `Perm` traffic gets to run its native walk). The
+question this harness answers is not "which model is more ACCURATE on average" -- it's "at a matched
+violation rate (the bound undershoots the REAL executed `cards_visited`), which knob/method gives the
+smaller bound," using real queries from `QuerySampler("uniform")` (not the checkpoint-eligible/EDHREC
+population `bench_compose_perm_cards_visited.py` targets -- this bound is meant to work for ANY filter
+shape, since it never reads WHERE matches sit in the permutation, only how many there are) with an
+explicit deep-offset sweep (real traffic is offset~0-heavy by design, `costbench.OFFSETS`, so it can't
+supply the tail this bound exists for).
+
+    .venv/bin/python scripts/bench_compose_card_visited_safety_bound.py --n-queries 400
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import pathlib
+import random
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from client.query_sampler import QuerySampler, Shape  # noqa: E402
+from scripts import costbench  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
+
+percentile = costbench.percentile
+
+# Three-phase (`walk_card_page_via_popcount_skip`) is a `#[cfg(test)]` Rust prototype with no Python
+# binding, so there's no per-row REAL measurement of it for the general uniform-query population (only
+# two named-tag queries were ever benched against it directly, in `tests.rs`). Modeled instead, from
+# THIS session's own real measurement: `compose_popcount_skip_kernel_costs`'s fit of the scatter rate
+# against `matching_cards`, `card_engine/src/tests.rs`. Approximate, not measured-per-row -- good enough
+# for a DIRECTIONAL choice-frequency/latency simulation, not for pricing an individual query.
+THREE_PHASE_RATE_NS_PER_MATCH = 5.3444
+THREE_PHASE_FIXED_NS = -4809.0
+THREE_PHASE_FLOOR_NS = 5_000.0  # the fit goes negative below ~900 matches; floor at the smallest real dispatch cost seen this session
+
+
+def three_phase_ns_model(matches: int) -> float:
+    """Modeled `walk_card_page_via_popcount_skip` cost -- see the module-level note on its provenance."""
+    return max(THREE_PHASE_RATE_NS_PER_MATCH * matches + THREE_PHASE_FIXED_NS, THREE_PHASE_FLOOR_NS)
+
+
+# The PRODUCTION cost model's own `PhysicalPlan::PrintingCompose` / `ComposePaging::Perm` formula
+# (`card_engine/src/cost.rs`): `printings_walked * COMPOSE_WALK_STEP_NS + limit * COMPOSE_WALK_EMIT_
+# PER_ROW_NS`. Copied here, not imported -- there's no Python binding for `cost::plan_cost` itself, but
+# `printings_walked` (its main input) is already exposed via `acquire["printings_walked"]`, so the
+# model's OWN prediction can be graded against real `walk_ns` directly, using the ACQUIRE-time value
+# the router actually sees (not a recomputation with hindsight).
+PROD_COMPOSE_WALK_STEP_NS = 0.58
+PROD_COMPOSE_WALK_EMIT_PER_ROW_NS = 2.19
+
+
+def prod_cost_model_ns(printings_walked_pred: float, limit: int) -> float:
+    return printings_walked_pred * PROD_COMPOSE_WALK_STEP_NS + limit * PROD_COMPOSE_WALK_EMIT_PER_ROW_NS
+
+
+def fmt_ns(ns: float) -> str:
+    """Human units, fixed width -- raw nanosecond counts (`606542`) are hard to eyeball at a glance."""
+    if ns < 1_000:
+        return f"{ns:.0f} ns"
+    if ns < 1_000_000:
+        return f"{ns / 1_000:.1f} us"
+    return f"{ns / 1_000_000:.2f} ms"
+
+
+# `walk_grouped_page`'s own real cost, unlike three-phase's, IS directly observable now: `explain_
+# analyze`'s `ns_loop` for `PrintingCompose` used to bundle compose-build time in with it (confirmed by
+# reading `card_engine/src/lib.rs` -- `t_start` started before `compose_printing_bits` ran, and
+# `ComposePageWork` published them as one undivided span), which is what produced a nonsensical
+# ~85-170us reading at offset=0 even for single-predicate queries in an earlier version of this
+# analysis. Fixed at the source (this session, `card_engine/src/lib.rs`): `ComposePageWork` now splits
+# `ns_build` (compose) from `ns_paging` (the walk alone), landing in `ns_setup`/`ns_loop` respectively
+# -- see the doc on `ComposePageWork::ns_build`. `evaluate()` below reads `compose["ns_loop"]` as the
+# real, per-row `walk_ns`, no modeling needed on this side at all anymore.
+
+# Permutation-backed sort columns only (`SortCol`'s six, minus `Rarity`/`PriceUsd` which have no
+# permutation and never reach `Perm`) -- this bound is specifically about the `Perm` branch's risk.
+ORDERBYS = ("edhrec", "cubecobra", "cmc", "power", "toughness", "name")
+# Real `Perm`-paging traffic is offset~0-heavy (`costbench.OFFSETS` is `(0, 0, 0, 100)`) by design --
+# that distribution can't exercise the deep tail this bound exists for, so sweep it explicitly instead.
+OFFSET_SWEEP = (0, 50, 200, 500, 1_000, 2_000, 4_000, 8_000, 15_000, 25_000)
+LIMIT = 20
+NUM_WARMUPS = 1
+NUM_TRIALS = 2
+MIN_REALIZED = 5  # below this, `cards_visited` is too noisy/trivial to grade a bound against
+
+
+# ─── The two closed-form anchors ───────────────────────────────────────────────
+
+
+def worst_case_bound(n_cards: int, matches: int, k: int) -> float:
+    """Every non-matching card clumped before the k-th match -- an exact, unconditional ceiling."""
+    return max(n_cards - matches, 0) + k
+
+
+def uniform_mean(n_cards: int, matches: int, k: int) -> float:
+    """Expected position of the k-th match if `matches` cards were scattered with NO clumping --
+    the order-statistic mean of a uniformly random `matches`-subset of `n_cards` slots."""
+    return k * (n_cards + 1) / (matches + 1)
+
+
+def nhg_variance(n_cards: int, matches: int, k: int) -> float:
+    """Variance of that same no-clumping position (negative hypergeometric, closed form).
+
+    Zero at the edges by construction: `matches == n_cards` (nothing to scatter, position is exactly
+    `k`) and `k == 0`. Verified against Monte Carlo in `selfcheck_nhg_moments` below, not just quoted.
+    """
+    n, m = n_cards, matches
+    if m <= 0 or k <= 0 or k > m or m >= n:
+        return 0.0
+    return k * (n + 1) * (n - m) * (m - k + 1) / ((m + 1) ** 2 * (m + 2))
+
+
+# ─── The two candidates, identical signature ───────────────────────────────────
+
+
+def blend_bound(n_cards: int, matches: int, k: int, knob: float) -> float:
+    """`knob` in [0, 1]: 0 is the pure no-clumping mean, 1 is the pure adversarial worst case.
+
+    `knob == 1.0` returns `worst_case_bound` exactly rather than `lo + 1.0*(hi-lo)` -- that
+    algebraically equals `hi`, but subtractive cancellation between two close floats can drift it a
+    hair below `hi`, which matters here: a real query landing exactly ON the worst-case bound would
+    then spuriously register as a "violation" of a bound that is, by construction, never violated.
+    """
+    if knob >= 1.0:
+        return worst_case_bound(n_cards, matches, k)
+    lo, hi = uniform_mean(n_cards, matches, k), worst_case_bound(n_cards, matches, k)
+    return lo + knob * (hi - lo)
+
+
+def sigma_bound(n_cards: int, matches: int, k: int, knob: float) -> float:
+    """`knob` = how many std devs above the no-clumping mean, same random-placement model as
+    `blend_bound`'s low anchor -- just a different (distribution-shaped, not linear) margin."""
+    mean = uniform_mean(n_cards, matches, k)
+    return mean + knob * math.sqrt(nhg_variance(n_cards, matches, k))
+
+
+def abort_budget_ns(walk_ns: float, matches: int, safety_factor: float, ceiling_ns: float) -> float:
+    """Cost under a RUNTIME circuit breaker instead of an a-priori decision: let the walk run, and
+    only abort into three-phase once the walk's OWN elapsed cost crosses `budget = safety_factor *
+    three_phase_ns_model(matches)` -- a budget anchored to the alternative's own (offset-independent)
+    cost, not to `k`. A `k`-scaled budget was tried first and does not work: `k = offset + limit`
+    already includes the offset, so at a deep offset the budget outgrows `n_cards` and the abort can
+    never trip at all -- exactly the population (deep, expensive walks) this exists to catch. Tracking
+    elapsed cost is free in the real executor (`work.cards_visited += 1` already runs every
+    iteration); this models "compare it against a threshold every so often," not new instrumentation.
+
+    Naively, an abort caps the total at `(safety_factor + 1) * three_phase_ns_model(matches)` -- but
+    that cap ITSELF grows with `matches` (three-phase costs more for a high-selectivity query), and a
+    high `safety_factor` on top of an already-large baseline let the capped outcome exceed what a
+    plain walk would have cost -- measured: `abort at 3x` had a WORSE max than `always_walk` on this
+    dataset. `ceiling_ns` is the fix: an absolute cap independent of `matches` entirely (the caller
+    passes `walk_rate * n_cards` -- no real walk, however clumped, can cost more than visiting the
+    whole corpus once). A row that finishes within budget still pays EXACTLY its own real `walk_ns`.
+    """
+    budget = safety_factor * three_phase_ns_model(matches)
+    if walk_ns <= budget:
+        return walk_ns
+    return min(budget + three_phase_ns_model(matches), ceiling_ns)
+
+
+METHODS = {
+    "blend": (blend_bound, [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.8, 1.0]),
+    "sigma": (sigma_bound, [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, 8.0]),
+}
+
+
+def selfcheck_nhg_moments(rng: random.Random) -> None:
+    """Monte Carlo check of `uniform_mean`/`nhg_variance` against simulated random placements --
+    quoting a variance formula from memory is exactly the kind of thing this repo's conventions say
+    to verify, not assume."""
+    trials = 20_000
+    cases = [(500, 50, 10), (5_000, 200, 80), (2_000, 1_800, 500)]
+    print("selfcheck: analytic vs Monte Carlo (negative hypergeometric position of the k-th match)")
+    for n, m, k in cases:
+        positions = []
+        for _ in range(trials):
+            chosen = rng.sample(range(n), m)
+            chosen.sort()
+            positions.append(chosen[k - 1] + 1)  # 1-indexed position of the k-th match
+        sim_mean = sum(positions) / trials
+        sim_var = sum((p - sim_mean) ** 2 for p in positions) / (trials - 1)
+        an_mean, an_var = uniform_mean(n, m, k), nhg_variance(n, m, k)
+        print(
+            f"  N={n:<6} M={m:<5} k={k:<4} mean: sim={sim_mean:9.2f} analytic={an_mean:9.2f}   "
+            f"var: sim={sim_var:11.1f} analytic={an_var:11.1f}"
+        )
+
+
+def evaluate(engine: object, query: str, orderby: str, direction: str, offset: int) -> dict | None:
+    """One (query, orderby, direction, offset) point's features + realized `cards_visited`.
+
+    Grades against `compose["result_total"]`, the EXECUTED plan's exact match count ("ground truth
+    for this run", `card_engine/src/lib.rs`'s own doc on `PlanTrial::result_total`) -- not `explain()`'s
+    acquire-time `matches`, which can be a `calibrated_balls_into_bins` ESTIMATE rather than an exact
+    count when `exact_result_total` declines the filter's shape (`compose_paging_with_total`'s own
+    doc on `result_total`: "the acquire-time ESTIMATE where the fastpath has the exact count"). A
+    first pass graded against the acquire estimate and found the SUPPOSEDLY-IMPOSSIBLE-TO-VIOLATE
+    `worst_case_bound` violated on real queries -- not a flaw in the bound's math (re-verified by
+    hand), but the acquire estimate over-stating `M` for those queries, which shrinks `(n_cards - M)`
+    below the true value. Grading the bound formula itself needs the exact `M` it was proven against;
+    the acquire-time estimate's own error is a separate, second-order question (`est_matches` is kept
+    on the row for that comparison) -- and the one that matters operationally, since a WIRED-IN
+    version of this bound would run inside the fastpath using the exact count it already computes
+    before choosing `Perm` (`compose_total_for_mode`, paid for regardless), not the acquire estimate.
+
+    `None` if this point doesn't land on `Mode::Card` `Perm` paging for both the plan estimate and the
+    actual execution, or is too degenerate (page past the total, or a match count `>= n_cards`, where
+    clumping cannot exist at all) to be an interesting test of a CLUMPING bound.
+    """
+    try:
+        filters = parse_scryfall_query(query)
+    except Exception:  # noqa: BLE001 - a handful of vocab strings don't round-trip through the grammar
+        return None
+    quick = engine.explain(filters=filters, unique="card", orderby=orderby, direction=direction, limit=LIMIT, offset=offset)
+    acq = quick["acquire"]
+    if acq["compose_paging"] != "Perm":
+        return None
+    n_cards, est_matches = acq["n_cards"], acq["matches"]
+    printings_walked_pred = acq["printings_walked"]  # cost::printings_walked(f) -- the router's OWN input, acquire-time
+    k = offset + LIMIT
+    full = engine.explain_analyze(
+        filters=filters,
+        unique="card",
+        orderby=orderby,
+        direction=direction,
+        limit=LIMIT,
+        offset=offset,
+        num_warmups=NUM_WARMUPS,
+        num_trials=NUM_TRIALS,
+    )
+    compose = next((p for p in full["plans"] if p["plan"] == "PrintingCompose"), None)
+    if compose is None or not compose["trials_ns"] or compose.get("paging_taken") != "Perm":
+        return None
+    matches = compose["result_total"]
+    realized = compose["cards_visited"]
+    if matches <= 0 or k >= matches or matches >= n_cards or realized < MIN_REALIZED:
+        return None
+    # `ns_loop` is now the paging branch ALONE -- `card_engine/src/lib.rs`'s `ComposePageWork` split
+    # (this session) separated it from `ns_setup` (the compose-build cost that used to be bundled in
+    # with it, `plan_self_ns`'s old total). This is the REAL per-row walk cost, not a kernel-modeled
+    # stand-in -- exactly what the full code path can now report directly.
+    walk_ns = compose["ns_loop"]
+    if walk_ns <= 0:
+        return None
+    return {
+        "n_cards": n_cards,
+        "matches": matches,
+        "est_matches": est_matches,
+        "k": k,
+        "offset": offset,
+        "realized": realized,
+        "printings_examined": compose["printings_examined"],
+        "orderby": orderby,
+        "direction": direction,
+        "query": query,
+        "clumping_factor": realized / uniform_mean(n_cards, matches, k),
+        "walk_ns": walk_ns,
+        "printings_walked_pred": printings_walked_pred,
+    }
+
+
+def report(rows: list[dict]) -> None:
+    """Per-(method, knob) violation rate and bound tightness, so a knob can be picked by matching
+    violation rates across methods and comparing which gives the smaller (tighter) bound there."""
+    if not rows:
+        print("Nothing landed on Card-mode Perm for both explain() and explain_analyze() -- nothing to grade.")
+        return
+    print(f"\nn={len(rows)} (query, orderby, direction, offset) points graded\n")
+    prod_ratio = sorted(prod_cost_model_ns(r["printings_walked_pred"], LIMIT) / r["walk_ns"] for r in rows)
+    print(
+        f"PRODUCTION cost model (cost::plan_cost, PrintingCompose/Perm) vs real walk_ns, "
+        f"ratio = predicted/realized (>1 over-costs, <1 under-costs):"
+    )
+    for p in (0, 5, 10, 25, 50, 75, 90, 95, 100):
+        print(f"  p{p:<3} {percentile(prod_ratio, p):.3f}")
+    print("\nSAME ratio, BY OFFSET (is the under-cost uniform, or concentrated at the deep offsets real")
+    print("traffic rarely reaches -- i.e. is the model actually fine for the shallow case it was likely")
+    print("tuned against, and only broken for the population this whole investigation is about?):")
+    by_offset_prod: dict[int, list[float]] = {}
+    for r in rows:
+        by_offset_prod.setdefault(r["offset"], []).append(prod_cost_model_ns(r["printings_walked_pred"], LIMIT) / r["walk_ns"])
+    for off, vals in sorted(by_offset_prod.items()):
+        vals.sort()
+        print(f"  offset={off:<8} n={len(vals):<4} p50={percentile(vals, 50):>7.3f}  p90={percentile(vals, 90):>7.3f}")
+    print()
+    est_ratio = sorted(r["est_matches"] / r["matches"] for r in rows)
+    print(
+        f"acquire-estimate matches / exact matches (>1 over-estimates M, shrinks worst_case's margin): "
+        f"p10={percentile(est_ratio, 10):.2f}  p50={percentile(est_ratio, 50):.2f}  p90={percentile(est_ratio, 90):.2f}"
+    )
+    wc_slack = [worst_case_bound(r["n_cards"], r["matches"], r["k"]) / r["realized"] for r in rows]
+    print(f"worst_case_bound alone: 0 violations by construction; slack (bound/realized) p50={percentile(sorted(wc_slack), 50):.2f}")
+    print("\nworst_case_bound slack BY OFFSET (does the bound stay huge even at shallow offset, where\n"
+          "walk_grouped_page's real cost is tiny? -- if so, comparing its COST estimate against three-\n"
+          "phase's would reject walk_grouped_page there too, not just on the deep pages it's meant to catch):")
+    by_offset: dict[int, list[float]] = {}
+    for r in rows:
+        by_offset.setdefault(r["offset"], []).append(worst_case_bound(r["n_cards"], r["matches"], r["k"]) / r["realized"])
+    for off, vals in sorted(by_offset.items()):
+        vals.sort()
+        print(f"  offset={off:<8} n={len(vals):<4} p50 slack={percentile(vals, 50):>8.1f}  p90 slack={percentile(vals, 90):>8.1f}")
+    print("\nblend_bound(knob=0.6) slack BY OFFSET, for comparison against worst_case's table above --")
+    print("does the better-behaved knob still stay tight at shallow offset (where it matters for keeping")
+    print("walk_grouped_page in play), not just safe at deep offset?")
+    by_offset_blend: dict[int, list[float]] = {}
+    for r in rows:
+        by_offset_blend.setdefault(r["offset"], []).append(blend_bound(r["n_cards"], r["matches"], r["k"], 0.6) / r["realized"])
+    for off, vals in sorted(by_offset_blend.items()):
+        vals.sort()
+        print(f"  offset={off:<8} n={len(vals):<4} p50 slack={percentile(vals, 50):>8.2f}  p90 slack={percentile(vals, 90):>8.2f}")
+    wc_violations = [r for r in rows if worst_case_bound(r["n_cards"], r["matches"], r["k"]) < r["realized"]]
+    if wc_violations:
+        print(f"  !! {len(wc_violations)} worst_case_bound violations (should be impossible) -- dumping for diagnosis:")
+        for r in wc_violations:
+            wc = worst_case_bound(r["n_cards"], r["matches"], r["k"])
+            print(f"     n_cards={r['n_cards']} matches={r['matches']} k={r['k']} offset={r['offset']} realized={r['realized']} worst_case={wc}")
+    print(f"{'method':<8} {'knob':>6} {'violations':>11} {'viol%':>8} {'p50 slack':>10} {'p90 slack':>10} {'p99 slack':>10}")
+    for name, (fn, knobs) in METHODS.items():
+        for knob in knobs:
+            slacks = []
+            violations = 0
+            for r in rows:
+                bound = fn(r["n_cards"], r["matches"], r["k"], knob)
+                if bound < r["realized"]:
+                    violations += 1
+                else:
+                    slacks.append(bound / r["realized"])
+            slacks.sort()
+            p50 = percentile(slacks, 50) if slacks else float("nan")
+            p90 = percentile(slacks, 90) if slacks else float("nan")
+            p99 = percentile(slacks, 99) if slacks else float("nan")
+            print(
+                f"{name:<8} {knob:>6.2f} {violations:>11} {100 * violations / len(rows):>7.2f}% "
+                f"{p50:>10.2f} {p90:>10.2f} {p99:>10.2f}"
+            )
+
+    # ─── How bad are violations, not just how many? A "95% safe" bound is only useful if the 5% that ─
+    # miss don't reintroduce the exact unbounded tail this whole effort exists to remove.
+    print("\novershoot (realized/bound) AMONG VIOLATIONS ONLY, EVERY knob -- if this stays near 1.0, a")
+    print("violation is a near-miss; if it's large/growing, relaxing the violation-rate target doesn't cap")
+    print("the pathological case, it just makes it rarer:")
+    for name, (fn, knobs) in METHODS.items():
+        for knob in knobs:
+            overshoots = sorted(
+                r["realized"] / fn(r["n_cards"], r["matches"], r["k"], knob)
+                for r in rows
+                if fn(r["n_cards"], r["matches"], r["k"], knob) < r["realized"]
+            )
+            if not overshoots:
+                print(f"  {name} knob={knob:<5.2f}: 0 violations")
+                continue
+            print(
+                f"  {name} knob={knob:<5.2f} n_violations={len(overshoots):<5} "
+                f"p50={percentile(overshoots, 50):.2f}  p90={percentile(overshoots, 90):.2f}  max={overshoots[-1]:.2f}"
+            )
+
+    # ─── Does clumping severity correlate with anything cheap to know a priori? ─────────────────────
+    print("\nclumping_factor (realized/uniform_mean) BY SELECTIVITY DECILE (does a low-M/n_cards query")
+    print("clump worse than a high-selectivity one, or is it roughly uniform across selectivity?):")
+    by_sel: list[tuple[float, dict]] = sorted(((r["matches"] / r["n_cards"], r) for r in rows), key=lambda t: t[0])
+    decile_size = max(len(by_sel) // 10, 1)
+    for d in range(0, len(by_sel), decile_size):
+        chunk = by_sel[d : d + decile_size]
+        if not chunk:
+            continue
+        sel_lo, sel_hi = chunk[0][0], chunk[-1][0]
+        cfs = sorted(r["clumping_factor"] for _, r in chunk)
+        print(
+            f"  selectivity [{sel_lo:.4f}, {sel_hi:.4f}]  n={len(chunk):<4} "
+            f"p50={percentile(cfs, 50):>8.2f}  p90={percentile(cfs, 90):>8.2f}  max={cfs[-1]:>8.2f}"
+        )
+
+    print("\nclumping_factor BY ORDERBY COLUMN (does a real, semantically-loaded sort column like edhrec")
+    print("clump worse than an arbitrary one like name?):")
+    by_orderby: dict[str, list[float]] = {}
+    for r in rows:
+        by_orderby.setdefault(r["orderby"], []).append(r["clumping_factor"])
+    for col, cfs in sorted(by_orderby.items()):
+        cfs.sort()
+        print(f"  {col:<12} n={len(cfs):<5} p50={percentile(cfs, 50):>8.2f}  p90={percentile(cfs, 90):>8.2f}  max={cfs[-1]:>8.2f}")
+
+    print("\nworst 10 outliers by clumping_factor (manual-inspection candidates):")
+    worst = sorted(rows, key=lambda r: -r["clumping_factor"])[:10]
+    for r in worst:
+        print(
+            f"  cf={r['clumping_factor']:>7.2f}  orderby={r['orderby']:<10} dir={r['direction']:<5} "
+            f"offset={r['offset']:<6} n_cards={r['n_cards']} matches={r['matches']} realized={r['realized']:<7} "
+            f"query={r['query']!r}"
+        )
+
+
+def simulate_policies(rows: list[dict]) -> None:
+    """For each decision POLICY, what fraction of real traffic gets routed to the three-phase
+    fallback, and what does that do to the resulting latency distribution?
+
+    The walk side uses each row's REAL `walk_ns` (see `evaluate()`) whenever a policy picks it,
+    including `oracle` (the reference point: the best any policy COULD do, using the row's real
+    `walk_ns` directly -- unknowable in advance, but it bounds how much more there is to gain over a
+    real decision rule, which only ever gets `matches`/`n_cards`/`k`, never the outcome). The
+    bound-based policies still have to PREDICT a hypothetical walk cost from a card estimate before
+    running anything, so they convert it via `walk_rate` -- fit from this same dataset's real
+    (`walk_ns`, `realized`) pairs now that `walk_ns` is a clean, confound-free measurement, not an
+    externally recalled or kernel-modeled constant. The three-phase side has no per-row real
+    measurement at all (not wired into dispatch -- see the module docstring), so it stays modeled via
+    `three_phase_ns_model`.
+    """
+    walk_rate = percentile(sorted(r["walk_ns"] / r["realized"] for r in rows), 50)
+    print(f"\nwalk_grouped_page rate fit from real (walk_ns, realized) pairs: {walk_rate:.3f} ns/card visited (median)\n")
+
+    def gated(gate: int, bound_fn) -> object:  # noqa: ANN001 - bound_fn is one of the module's *_bound callables
+        def cost(r: dict) -> tuple[float, bool]:
+            if r["offset"] < gate:
+                return r["walk_ns"], False
+            predicted_walk_ns = walk_rate * bound_fn(r["n_cards"], r["matches"], r["k"])
+            if predicted_walk_ns <= three_phase_ns_model(r["matches"]):
+                return r["walk_ns"], False
+            return three_phase_ns_model(r["matches"]), True
+
+        return cost
+
+    # No real walk, however clumped, visits more cards than the whole corpus once -- an absolute
+    # backstop independent of `matches`, unlike the naive `(safety_factor + 1) * three_phase` cap.
+    ceiling_ns = walk_rate * max(r["n_cards"] for r in rows)
+    print(f"abort ceiling: {ceiling_ns:.0f} ns (walk_rate * n_cards -- a full-corpus walk, absolute worst case)\n")
+
+    def abort_at(safety_factor: float) -> object:
+        def cost(r: dict) -> tuple[float, bool]:
+            budget = safety_factor * three_phase_ns_model(r["matches"])
+            ns = abort_budget_ns(r["walk_ns"], r["matches"], safety_factor, ceiling_ns)
+            return ns, r["walk_ns"] > budget
+
+        return cost
+
+    policies = {
+        "always_walk (today)": lambda r: (r["walk_ns"], False),
+        "always_three_phase": lambda r: (three_phase_ns_model(r["matches"]), True),
+        "oracle (best possible)": lambda r: (
+            (r["walk_ns"], False) if r["walk_ns"] <= three_phase_ns_model(r["matches"]) else (three_phase_ns_model(r["matches"]), True)
+        ),
+        "no gate, worst_case": gated(0, worst_case_bound),
+        "no gate, blend(0.6)": gated(0, lambda n, m, k: blend_bound(n, m, k, 0.6)),
+        "no gate, sigma(1.0)": gated(0, lambda n, m, k: sigma_bound(n, m, k, 1.0)),
+        "no gate, sigma(2.0)": gated(0, lambda n, m, k: sigma_bound(n, m, k, 2.0)),
+        "no gate, sigma(3.0)": gated(0, lambda n, m, k: sigma_bound(n, m, k, 3.0)),
+        "no gate, sigma(4.0)": gated(0, lambda n, m, k: sigma_bound(n, m, k, 4.0)),
+        "no gate, sigma(6.0)": gated(0, lambda n, m, k: sigma_bound(n, m, k, 6.0)),
+        "no gate, sigma(8.0)": gated(0, lambda n, m, k: sigma_bound(n, m, k, 8.0)),
+        "gate=2000, worst_case": gated(2_000, worst_case_bound),
+        "gate=4000, worst_case": gated(4_000, worst_case_bound),
+        "gate=2000, blend(0.6)": gated(2_000, lambda n, m, k: blend_bound(n, m, k, 0.6)),
+        "gate=4000, blend(0.6)": gated(4_000, lambda n, m, k: blend_bound(n, m, k, 0.6)),
+        "abort at 2x 3phase": abort_at(2.0),
+        "abort at 3x 3phase": abort_at(3.0),
+        "abort at 5x 3phase": abort_at(5.0),
+        "abort at 10x 3phase": abort_at(10.0),
+        "abort at 20x 3phase": abort_at(20.0),
+    }
+
+    print(f"{'policy':<26} {'%diverted':>10} {'p50':>10} {'p90':>10} {'p99':>10} {'max':>10}")
+    print("(pooled across OFFSET_SWEEP, which weights shallow and deep offsets EQUALLY -- nothing like")
+    print(" real traffic's offset~0-heavy mix, so this table is a policy-vs-policy comparison on a")
+    print(" deliberately offset-heavy stress grid, not a production latency estimate; see the by-offset")
+    print(" breakdown below for the number that matters -- reweight it by your own traffic's real offset")
+    print(" distribution instead of trusting a blended average here. 'diverted' means routed to")
+    print(" three-phase outright for the a-priori policies, or actually ABORTED past budget for the")
+    print(" abort policies -- not the same event, so don't compare the percentages across the two kinds.)")
+    latencies_by_policy: dict[str, list[float]] = {}
+    for name, cost_fn in policies.items():
+        latencies = []
+        diverted_count = 0
+        for r in rows:
+            ns, diverted = cost_fn(r)
+            latencies.append(ns)
+            diverted_count += diverted
+        latencies.sort()
+        latencies_by_policy[name] = latencies
+        print(
+            f"{name:<26} {100 * diverted_count / len(rows):>9.1f}% "
+            f"{fmt_ns(percentile(latencies, 50)):>10} {fmt_ns(percentile(latencies, 90)):>10} "
+            f"{fmt_ns(percentile(latencies, 99)):>10} {fmt_ns(latencies[-1]):>10}"
+        )
+
+    print("\nworst SURVIVING (non-diverted) row for each policy -- oracle's max is capped by construction")
+    print("at always_three_phase's own max (see the earlier discussion); does sigma's/blend's own worst")
+    print("case walk a row that should have been diverted, and by how much does it miss?")
+    for name in (
+        "oracle (best possible)",
+        "no gate, blend(0.6)",
+        "no gate, sigma(1.0)",
+        "no gate, sigma(2.0)",
+        "no gate, sigma(3.0)",
+        "no gate, sigma(4.0)",
+        "no gate, sigma(6.0)",
+        "no gate, sigma(8.0)",
+        "abort at 2x 3phase",
+    ):
+        cost_fn = policies[name]
+        walked = [(cost_fn(r)[0], r) for r in rows if not cost_fn(r)[1]]
+        if not walked:
+            continue
+        worst_ns, r = max(walked, key=lambda t: t[0])
+        tp = three_phase_ns_model(r["matches"])
+        print(
+            f"  {name:<24} worst_walked={fmt_ns(worst_ns):>10}  offset={r['offset']:<6} matches={r['matches']:<6} "
+            f"n_cards={r['n_cards']}  three_phase_would_be={fmt_ns(tp):>10}  clumping_factor={r['clumping_factor']:.2f}"
+        )
+
+    headline = [
+        "always_walk (today)",
+        "always_three_phase",
+        "oracle (best possible)",
+        "no gate, sigma(1.0)",
+        "no gate, sigma(2.0)",
+        "no gate, sigma(3.0)",
+        "no gate, sigma(4.0)",
+        "no gate, sigma(6.0)",
+        "no gate, sigma(8.0)",
+    ]
+    print(f"\npercentile vs latency (ns), 5% granularity, for the {len(headline)} headline policies:")
+    pcts_print = list(range(0, 101, 5))
+    header2 = f"{'pct':<5}" + "".join(f"{name:>24}" for name in headline)
+    print(header2)
+    # Chart export uses a TAIL-CONCENTRATED grid, not the flat 5% steps printed above: the policies
+    # only visibly separate past p90 (pooling-heavy shallow offsets dominate the bulk of the range),
+    # and a flat step size leaves only 2-3 points there -- not enough to see curve shape once a chart
+    # zooms in. 1% steps 0-89, 0.5% steps 90-100 (n=2705 real rows underlies each, so 0.5% steps
+    # average ~14 rows/bucket in the tail -- real resolution, not pure sampling noise).
+    pcts = [float(p) for p in range(0, 90)] + [90 + 0.5 * i for i in range(21)]
+    chart_data = {"pcts": pcts, "series": {}}
+    for name in headline:
+        chart_data["series"][name] = [percentile(latencies_by_policy[name], p) for p in pcts]
+    for p in pcts_print:
+        line = f"{p:<5}"
+        for name in headline:
+            line += f"{percentile(latencies_by_policy[name], p):>24.0f}"
+        print(line)
+
+    chart_path = pathlib.Path(
+        "/private/tmp/claude-502/-Users-joseph-bylund-scratch-sylvan-librarian/"
+        "06741293-793d-446c-823a-cac4758bff9c/scratchpad/policy_latency_percentiles.json"
+    )
+    chart_path.write_text(json.dumps(chart_data))
+    print(f"\nchart data written to {chart_path}")
+
+    # ─── By offset instead of pooled: this is the view to actually trust, since it doesn't require ──
+    # guessing how real traffic distributes across offsets -- read it against YOUR OWN traffic's depth
+    # distribution instead of a blended average that bakes in an arbitrary sweep weighting.
+    shortlist = {
+        "always_walk": policies["always_walk (today)"],
+        "always_three_phase": policies["always_three_phase"],
+        "no gate, blend(0.6)": policies["no gate, blend(0.6)"],
+        "abort at 3x 3phase": policies["abort at 3x 3phase"],
+        "abort at 5x 3phase": policies["abort at 5x 3phase"],
+        "abort at 10x 3phase": policies["abort at 10x 3phase"],
+    }
+    by_offset_rows: dict[int, list[dict]] = {}
+    for r in rows:
+        by_offset_rows.setdefault(r["offset"], []).append(r)
+
+    print("\n% diverted (routed/aborted), BY OFFSET:")
+    header = f"{'offset':<8}" + "".join(f"{name:>24}" for name in shortlist)
+    print(header)
+    for off, off_rows in sorted(by_offset_rows.items()):
+        line = f"{off:<8}"
+        for cost_fn in shortlist.values():
+            frac = sum(1 for r in off_rows if cost_fn(r)[1]) / len(off_rows)
+            line += f"{100 * frac:>23.1f}%"
+        print(line)
+
+    print("\nmedian realized latency (ns), BY OFFSET:")
+    print(header)
+    for off, off_rows in sorted(by_offset_rows.items()):
+        line = f"{off:<8}"
+        for cost_fn in shortlist.values():
+            lat = sorted(cost_fn(r)[0] for r in off_rows)
+            line += f"{percentile(lat, 50):>24.0f}"
+        print(line)
+
+
+def main() -> None:
+    """Sample uniform real queries, sweep deep offsets explicitly, grade both bound candidates."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--n-queries", type=int, default=400)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None)
+    args = parser.parse_args()
+
+    rng = random.Random(args.seed)
+    selfcheck_nhg_moments(rng)
+
+    engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".cardvisitedbound.store"))
+    sampler = QuerySampler(args.corpus, "uniform")
+
+    rows: list[dict] = []
+    considered = 0
+    for _ in range(args.n_queries):
+        # Pinned to ONE predicate: `PrintingCompose`'s own phase reporting doesn't split "build pbits
+        # from the filter" out from "page it" (`ComposePageWork`'s doc: "Compose's arm is not
+        # decomposed into setup/loop/finish... there is nothing to attribute between phases" -- both
+        # land in `ns_loop` as one undivided span). A multi-predicate AND's compose cost can dwarf the
+        # walk itself and swamp any attempt to fit a per-card WALK rate from `ns`. A single predicate
+        # makes that shared cost small and roughly constant instead, so it acts like the intercept in
+        # `WALK_RATE`'s fit rather than dominating its slope.
+        query = sampler.query(rng, shape=Shape(predicates=1))
+        orderby = rng.choice(ORDERBYS)
+        direction = rng.choice(("asc", "desc"))
+        for offset in OFFSET_SWEEP:
+            considered += 1
+            row = evaluate(engine, query, orderby, direction, offset)
+            if row is not None:
+                rows.append(row)
+
+    print(f"\n{considered} (query, orderby, direction, offset) points considered, {len(rows)} landed on Card-mode Perm both ways.")
+    report(rows)
+    simulate_policies(rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_compose_card_visited_safety_bound.py
+++ b/scripts/bench_compose_card_visited_safety_bound.py
@@ -121,7 +121,6 @@ OFFSET_SWEEP = (0, 50, 200, 500, 1_000, 2_000, 4_000, 8_000, 15_000, 25_000)
 LIMIT = 20
 NUM_WARMUPS = costbench.NUM_WARMUPS
 NUM_TRIALS = costbench.NUM_TRIALS
-MIN_REALIZED = 5  # below this, `cards_visited` is too noisy/trivial to grade a bound against
 POLICY_SPLIT_SEED = 730_1009
 MIN_POLICY_GROUPS = 2
 
@@ -177,7 +176,8 @@ def blend_bound(n_cards: int, matches: int, k: int, knob: float) -> float:
 def sigma_bound(n_cards: int, matches: int, k: int, knob: float) -> float:
     """`knob` = how many std devs above the no-clumping mean, same random-placement model as `blend_bound`'s low anchor -- just a different (distribution-shaped, not linear) margin."""
     mean = uniform_mean(n_cards, matches, k)
-    return mean + knob * math.sqrt(nhg_variance(n_cards, matches, k))
+    # A statistical margin is never usefully more conservative than the exact unconditional ceiling.
+    return min(worst_case_bound(n_cards, matches, k), mean + knob * math.sqrt(nhg_variance(n_cards, matches, k)))
 
 
 METHODS = {
@@ -235,7 +235,7 @@ def evaluate(engine: object, query: str, orderby: str, direction: str, offset: i
     acq = quick["acquire"]
     if acq["compose_paging"] != "Perm":
         return None
-    n_cards, est_matches = acq["n_cards"], acq["matches"]
+    n_cards, n_printings, est_matches = acq["n_cards"], acq["n_printings"], acq["matches"]
     printings_walked_pred = acq["printings_walked"]  # cost::printings_walked(f) -- the router's OWN input, acquire-time
     k = offset + LIMIT
     full = engine.explain_analyze(
@@ -254,7 +254,7 @@ def evaluate(engine: object, query: str, orderby: str, direction: str, offset: i
         return None
     matches = compose["result_total"]
     realized = compose["cards_visited"]
-    if matches <= 0 or offset >= matches or matches >= n_cards or realized < MIN_REALIZED:
+    if matches <= 0 or offset >= matches or matches >= n_cards:
         return None
     # `ns_loop` is now the paging branch ALONE -- `card_engine/src/lib.rs`'s `ComposePageWork` split
     # (this session) separated it from `ns_setup` (the compose-build cost that used to be bundled in
@@ -265,6 +265,7 @@ def evaluate(engine: object, query: str, orderby: str, direction: str, offset: i
         return None
     return {
         "n_cards": n_cards,
+        "n_printings": n_printings,
         "matches": matches,
         "est_matches": est_matches,
         "k": k,
@@ -509,9 +510,14 @@ def _split_policy_rows(rows: list[dict]) -> tuple[list[dict], list[dict]]:
 
 
 def _predicted_printings_for_bound(r: dict, bound_cards: float) -> float:
-    """Scale acquire's printing-walk estimate from the uniform card depth to the candidate bound."""
-    uniform_cards = uniform_mean(r["n_cards"], r["matches"], r["k"])
-    return r["printings_walked_pred"] * bound_cards / uniform_cards
+    """Convert a card-visit bound to printing probes at the corpus's exact average span.
+
+    Do not reuse acquire's `printings_walked_pred`: it was computed from estimated matches and
+    already carries production's clumping bias. The candidate bound uses exact matches and supplies
+    its own clumping margin, so scaling that acquire estimate would mix populations and count the
+    margin twice.
+    """
+    return bound_cards * r["n_printings"] / r["n_cards"]
 
 
 def _build_policies(walk_model: WalkCostModel, three_phase: ThreePhaseModel) -> dict[str, object]:
@@ -576,11 +582,12 @@ def _offset_weighted_rows(rows: list[dict]) -> list[tuple[dict, float]]:
 
 
 def _print_pooled_latency_table(rows: list[dict], policies: dict) -> dict[str, list[tuple[float, float]]]:
-    """% diverted and latency percentiles for every policy, pooled across the whole offset sweep."""
+    """% diverted and paging-branch latency percentiles, pooled across the whole offset sweep."""
     print(f"{'policy':<26} {'%diverted':>10} {'p50':>10} {'p90':>10} {'p99':>10} {'max':>10}")
     print("(pooled across OFFSET_SWEEP, which weights shallow and deep offsets EQUALLY -- nothing like")
     print(" real traffic's offset~0-heavy mix, so this table is a policy-vs-policy comparison on a")
-    print(" deliberately offset-heavy stress grid, not a production latency estimate; see the by-offset")
+    print(" deliberately offset-heavy stress grid, not a production latency estimate. Latencies are")
+    print(" PAGING-BRANCH ONLY: every policy has already paid the same compose build. See the by-offset")
     print(" breakdown below for the number that matters -- reweight it by your own traffic's real offset")
     print(" distribution instead of trusting a blended average here. 'diverted' means routed to")
     print(" three-phase instead of running the native walk.)")
@@ -635,8 +642,8 @@ def _print_worst_surviving_rows(rows: list[dict], policies: dict, three_phase: T
 def _print_headline_percentiles(
     latencies_by_policy: dict[str, list[tuple[float, float]]], headline: list[str], chart_path: pathlib.Path | None
 ) -> None:
-    """5%-granularity percentile-vs-latency table for the headline policies, plus the tail-concentrated chart export."""
-    print(f"\npercentile vs latency (ns), 5% granularity, for the {len(headline)} headline policies:")
+    """5%-granularity percentile-vs-paging-latency table, plus the tail-concentrated chart export."""
+    print(f"\npercentile vs PAGING-BRANCH latency (ns), 5% granularity, for the {len(headline)} headline policies:")
     pcts_print = list(range(0, 101, 5))
     header2 = f"{'pct':<5}" + "".join(f"{name:>24}" for name in headline)
     print(header2)
@@ -661,7 +668,7 @@ def _print_headline_percentiles(
 
 
 def _print_by_offset_tables(rows: list[dict], policies: dict) -> None:
-    """% diverted and median latency, BY OFFSET, for a policy shortlist -- the view to trust over the pooled tables above."""
+    """% diverted and median paging-branch latency, BY OFFSET, for a policy shortlist."""
     # By offset instead of pooled: this is the view to actually trust, since it doesn't require
     # guessing how real traffic distributes across offsets -- read it against YOUR OWN traffic's depth
     # distribution instead of a blended average that bakes in an arbitrary sweep weighting.
@@ -687,7 +694,7 @@ def _print_by_offset_tables(rows: list[dict], policies: dict) -> None:
             line += f"{100 * frac:>23.1f}%"
         print(line)
 
-    print("\nmedian realized latency (ns), BY OFFSET:")
+    print("\nmedian realized PAGING-BRANCH latency (ns), BY OFFSET:")
     print(header)
     for off, off_rows in sorted(by_offset_rows.items()):
         line = f"{off:<8}"
@@ -698,15 +705,15 @@ def _print_by_offset_tables(rows: list[dict], policies: dict) -> None:
 
 
 def simulate_policies(rows: list[dict], chart_path: pathlib.Path | None, three_phase: ThreePhaseModel) -> None:
-    """For each decision POLICY, what fraction of real traffic gets routed to the three-phase fallback, and what does that do to the resulting latency distribution?
+    """For each policy, what fraction of traffic is diverted, and what happens to paging latency?
 
     The walk side uses each row's REAL `walk_ns` (see `evaluate()`) whenever a policy picks it,
     including `oracle` (the reference point: the best any policy COULD do, using the row's real
     `walk_ns` directly -- unknowable in advance, but it bounds how much more there is to gain over a
     real decision rule, which only ever gets `matches`/`n_cards`/`k`, never the outcome). The
     bound-based policies still have to PREDICT a hypothetical walk cost before running anything, so
-    they convert bound cards and acquire's corresponding printing-walk estimate through a two-term
-    model fit on a disjoint calibration half. The three-phase side has no per-row real
+    they convert bound cards and the corpus's exact average printing span through a two-term model
+    fit on a disjoint calibration half. The three-phase side has no per-row real
     measurement at all (not wired into dispatch -- see the module docstring), so it stays modeled by
     the explicit `ThreePhaseModel` calibration supplied for this run.
     """

--- a/scripts/bench_compose_card_visited_safety_bound.py
+++ b/scripts/bench_compose_card_visited_safety_bound.py
@@ -520,6 +520,14 @@ def _predicted_printings_for_bound(r: dict, bound_cards: float) -> float:
     return bound_cards * r["n_printings"] / r["n_cards"]
 
 
+# The two rejected offset-gate thresholds (see the module's `Dead ends` doc elsewhere in this repo:
+# gating protects the wrong population, since clumping outliers sit at shallow offsets too). Kept as
+# comparison rows for `worst_case`/`blend` only -- named so the label can never drift from the value
+# it names, which a bare literal duplicated into a separate f-string label cannot guarantee.
+GATE_OFFSET_LOW = 2_000
+GATE_OFFSET_HIGH = 4_000
+
+
 def _build_policies(walk_model: WalkCostModel, three_phase: ThreePhaseModel) -> dict[str, object]:
     """The named decision policies `simulate_policies` grades against each other, keyed by display name."""
 
@@ -551,10 +559,10 @@ def _build_policies(walk_model: WalkCostModel, three_phase: ThreePhaseModel) -> 
         "no gate, sigma(4.0)": gated(0, lambda n, m, k: sigma_bound(n, m, k, 4.0)),
         "no gate, sigma(6.0)": gated(0, lambda n, m, k: sigma_bound(n, m, k, 6.0)),
         "no gate, sigma(8.0)": gated(0, lambda n, m, k: sigma_bound(n, m, k, 8.0)),
-        "gate=2000, worst_case": gated(2_000, worst_case_bound),
-        "gate=4000, worst_case": gated(4_000, worst_case_bound),
-        "gate=2000, blend(0.6)": gated(2_000, lambda n, m, k: blend_bound(n, m, k, 0.6)),
-        "gate=4000, blend(0.6)": gated(4_000, lambda n, m, k: blend_bound(n, m, k, 0.6)),
+        f"gate={GATE_OFFSET_LOW}, worst_case": gated(GATE_OFFSET_LOW, worst_case_bound),
+        f"gate={GATE_OFFSET_HIGH}, worst_case": gated(GATE_OFFSET_HIGH, worst_case_bound),
+        f"gate={GATE_OFFSET_LOW}, blend(0.6)": gated(GATE_OFFSET_LOW, lambda n, m, k: blend_bound(n, m, k, 0.6)),
+        f"gate={GATE_OFFSET_HIGH}, blend(0.6)": gated(GATE_OFFSET_HIGH, lambda n, m, k: blend_bound(n, m, k, 0.6)),
     }
 
 

--- a/scripts/costbench.py
+++ b/scripts/costbench.py
@@ -351,11 +351,11 @@ def plan_self_ns(plan: dict, acquire: dict) -> float | None:
 # ── statistics and tables ─────────────────────────────────────────────────────────────────────
 
 
-def percentile(sorted_vals: list[float], pct: int) -> float:
+def percentile(sorted_vals: list[float], pct: float) -> float:
     """Nearest-rank percentile; no interpolation, so every printed number is a real observation."""
     if not sorted_vals:
         return float("nan")
-    idx = min(round(pct / 100.0 * len(sorted_vals) + 0.5) - 1, len(sorted_vals) - 1)
+    idx = min(math.ceil(pct / 100.0 * len(sorted_vals)) - 1, len(sorted_vals) - 1)
     return sorted_vals[max(idx, 0)]
 
 

--- a/scripts/costbench.py
+++ b/scripts/costbench.py
@@ -316,10 +316,11 @@ def plan_self_ns(plan: dict, acquire: dict) -> float | None:
 
     **The executor**, from `ns_setup + ns_loop + ns_finish`. Contiguous by construction, so the sum IS
     the executor -- exact, with nothing to overshoot. Every plan publishes these; the two materializing
-    ones split them three ways, and the four others report one undivided span in `ns_loop` because they
-    have no three phases to attribute between. Verified against the old netted figure on 45k paired
-    rows before the switch: median ratio 0.998 (GatheredScan) and 0.997 (StreamedSelect), 0.08us of the
-    round unaccounted.
+    ones split them three ways, `PrintingCompose` splits them two ways (`ns_setup` for the build,
+    `ns_loop` for the paging branch, no `ns_finish`), and the three remaining plans report one
+    undivided span in `ns_loop` because they have no phases to attribute between at all. Verified
+    against the old netted figure on 45k paired rows before the switch: median ratio 0.998
+    (GatheredScan) and 0.997 (StreamedSelect), 0.08us of the round unaccounted.
 
     **Plus any shared artifact DISPATCH pays for**, which depends on the acquire and not on the plan:
 


### PR DESCRIPTION
## Summary

Rebased and trimmed to the pieces that do not have another home. Everything else from the original branch has either landed as a doc elsewhere, has its own open PR, or was a dead end the later work deliberately routed around — see the branch history below for the full lineage.

What ships in this PR, in 7 commits:

1. **Split `PrintingCompose`'s `ns_build`/`ns_paging`** — separates the walk's own cost from compose-build cost in `explain_analyze`, for the first time. This is the enabling change behind two already-merged docs: `docs/issues/01025-engine-compose-walk-cost-miscalibrated.md` and `docs/issues/local-engine-compose-perm-sigma-decision-rule.md`.
2. **Bench: Sigma-Bound Safety Rule Harness** — `bench_compose_card_visited_safety_bound.py`, the harness that produced the sigma decision-rule doc's numbers. Depends only on commit 1's real `walk_ns`, nothing else from the original branch.
3-5. **Three review-fixup passes** (`#1032`, `#1033`, `#1034`, already squashed into this branch's history) — removes a hardcoded scratch path, closes a phase-accounting gap where the walk-vs-gather decision cost landed in neither `ns_build` nor `ns_paging`, adds a phase-sum assertion, and strengthens the harness methodology (final-page tails, explicit three-phase calibration, equal offset weighting, structured filter shapes, corrected empty-result/percentile edge cases).
6. **Fix a stale `PlanTrial::phases` doc comment** — it claimed all four fast paths report all-zero phases, which was already inaccurate before this branch (`PrintingRangeScan`'s `ns_loop`, `PlanePopcountOrder`/`CardRangePopcount`'s three-phase split, and `PrintingCompose`'s own counters all predate it) and the new split makes actively wrong (`PrintingCompose`'s `EmptyPage` exit now produces exactly the pattern the doc called "uninstrumented"). Rewritten to describe what each of the four actually reports.
7. **Name the safety-bound script's gate thresholds** — `2_000`/`4_000` were bare literals duplicated as separate string labels; named as constants so a future edit can't silently desync the label from the value.

**Nothing in this PR wires the sigma rule into `plan_cost` or the fastpath**, and `card_engine/src/cost.rs` is untouched — no production routing behavior changes.

## Hot-path overhead, measured

The split adds a second `Instant::now()` call and grows the per-run `ComposePageWork` publish from 24 to 40 bytes, on a path this codebase documents as carrying ~75% of routing regret — worth isolating rather than assuming free. Built the pre-split and post-split commits as two isolated wheels and ran `bench_plan_execution_ab.py` with the same corpus/seed/mode on both:

```
PrintingCompose:  B - A = +0.28us on a 37.7us median, 95% CI [-1.48, +2.11] -- NO DETECTABLE DIFFERENCE
ROUTED (end-to-end): B - A = -0.04us, CI [-0.96, +0.77] -- NO DETECTABLE DIFFERENCE
routing: unchanged on every paired query
```

## Known, not fixed here

- `scripts/costbench.py`'s shared `percentile()` tie-break formula changed from round-half-up to nearest-rank ceiling (commit 4) — a real correctness fix (the old formula was off-by-one at exact percentile boundaries), but it's shared infra used by 4 scripts total (`bench_feature_accuracy.py`, `bench_regret_matrix.py`, `bench_cost_error_percentiles.py`, and this PR's own script), so any historical baseline recorded with the old formula is off by one rank at round sample sizes compared to a fresh run.
- `tests.rs`'s new `phase_ns.saturating_mul(2) >= p.ns_round_total` assertion is tighter than `PlanTrial`'s own documented guarantee that the round/phase shortfall is real, sizeable, unmodelled work rather than a bounded invariant. Stress-tested 8 standalone runs plus 3 full-suite concurrent debug runs with no failure, so not observed flakiness today, but worth watching if it ever flakes in CI.
- The safety-bound script's `--three-phase-rate-ns-per-match`/`--three-phase-fixed-ns`/`--three-phase-floor-ns` CLI args have no sign/sanity validation, unlike `--n-queries` next to them. Offline analysis script only — a bad value produces a nonsense printed report, not a production issue.

## Relationship to the 7-part sigma decision-rule plan

This PR completes only the enabling half of step 1 (`docs/issues/local-engine-compose-perm-sigma-decision-rule.md`) — the `ns_build`/`ns_paging` split. The live refit of `COMPOSE_WALK_STEP_NS`/`COMPOSE_WALK_EMIT_PER_ROW_NS` turned out not to be a standalone follow-up: it's gated on the same `cards_visited` feature-estimation gap blocking `docs/issues/local-engine-p3-p4-joint-refit-vs-compose.md`'s joint refit (see that doc and `docs/issues/reference-engine-compose-perm-cards-visited-estimator.md`). Next up after this lands is step 2: promoting the three-phase popcount-skip walk out of `#[cfg(test)]` (`#1030`).

## Test plan

- [x] `cargo test --release` (card_engine): 160 passed, 0 failed, 43 ignored
- [x] `cargo clippy --release --all-targets`: clean (one pre-existing unrelated dead-code warning, predates this branch)
- [x] `ruff check` on both touched Python files: clean
- [x] Paired A/B isolating this PR's hot-path addition (see above): no detectable difference
