### PR TITLE
Fix: is:hybrid Counts Four Symbol Families, and is:phyrexian Reads the Card and Not Just the Cost

### DIFF
--- a/api/admin_resource.py
+++ b/api/admin_resource.py
@@ -118,7 +118,20 @@ BOOLEAN_IS_TAGS: dict[str, str] = {
     "gameday": "cards.raw_card_blob->'promo_types' @> '\"gameday\"'",
     "giftbox": "cards.raw_card_blob->'promo_types' @> '\"giftbox\"'",
     "glossy": "cards.raw_card_blob->'promo_types' @> '\"glossy\"'",
-    "hybrid": r"cards.mana_cost_text ~ '\{[WUBRG]/[WUBRG]\}'",
+    # EVERY hybrid symbol, not just the ten two-colour ones. Scryfall counts four families and
+    # measuring it settles the width rather than reasoning about it (api.scryfall.com, 2026-08-23,
+    # unique=cards): `is:hybrid` is 603, and the ten `{W/U}`-style symbols reach 579 of them. The
+    # other 24 are the twobrid `{2/W}` cycle (19 cards), colourless-hybrid `{C/W}` (1) and
+    # Phyrexian-hybrid `{W/U/P}` (4).
+    #
+    # All four are one SHAPE -- an optional generic-or-colourless left side, and an optional `/P`
+    # tail -- which is the argument for a regex over the enumerated rewrite 00713 rejected: the
+    # alternation covers a family Wizards has not printed yet without another entry here.
+    #
+    # `{C/P}` is deliberately NOT in it. Colourless Phyrexian is not a hybrid symbol and Scryfall
+    # agrees: `is:hybrid o:"{c/p}"` is empty. The `[WUBRGC]` on the RIGHT of the slash is what
+    # excludes it, since `P` is not in that class.
+    "hybrid": r"cards.mana_cost_text ~ '\{([0-9]+|[WUBRGC])/[WUBRGC](/P)?\}'",
     "instore": "cards.raw_card_blob->'promo_types' @> '\"instore\"'",
     "intro_pack": "cards.raw_card_blob->'promo_types' @> '\"intropack\"'",
     "judge_gift": "cards.raw_card_blob->'promo_types' @> '\"judgegift\"'",
@@ -128,7 +141,29 @@ BOOLEAN_IS_TAGS: dict[str, str] = {
     # "Partner with <name>" cards carry a plain "Partner" keyword alongside it (verified
     # against the corpus), so checking for "Partner" alone already covers both.
     "partner": "cards.raw_card_blob->'keywords' @> '\"Partner\"'",
-    "phyrexian": r"cards.mana_cost_text ~ '\{[WUBRG]/P\}'",
+    # Phyrexian is ANYWHERE ON THE CARD, and the cost is the SMALLER half: `is:phyrexian` is 73
+    # and the cost -- even counting the Phyrexian-hybrid `{W/U/P}` symbols this also widens to --
+    # reaches only 37. The other 36 carry the symbol in rules text and nowhere else: Spellskite,
+    # the Souleaters, every `{2}{B/P}: transform` back face. Reading `mana_cost_text` alone answers
+    # 33 of the 73.
+    #
+    # Case-insensitive on the text side only: costs are stored upper-case, rules text quotes the
+    # symbol lower-case.
+    #
+    # `card_faces` is not walked, and could not be: preprocess_card explodes a multi-face printing
+    # into one row per face and strips the key from `raw_card_blob`, then the unique index on
+    # `scryfall_id` keeps ONE of those rows -- the last face. So a symbol that appears only on the
+    # FRONT face of a two-sided card is not in this table at all, under either column. That is a
+    # pre-existing limit of the row model rather than of this expression, it is unchanged by this
+    # commit, and merging the faces is what would lift it.
+    #
+    # `{C/P}` IS in this class, unlike in `hybrid`: it exists on cards even though #909's
+    # mana-symbol validator rejects it as a QUERY term, which is exactly the case a stored tag can
+    # answer and an enumerated `m:` rewrite structurally cannot.
+    "phyrexian": (
+        r"cards.mana_cost_text ~ '\{([WUBRGC]/)?[WUBRGC]/P\}' "
+        r"OR cards.oracle_text ~* '\{([wubrgc]/)?[wubrgc]/p\}'"
+    ),
     "planeswalker_deck": "cards.raw_card_blob->'promo_types' @> '\"planeswalkerdeck\"'",
     "player_rewards": "cards.raw_card_blob->'promo_types' @> '\"playerrewards\"'",
     "release": "cards.raw_card_blob->'promo_types' @> '\"release\"'",

--- a/api/tests/test_upsert_cards.py
+++ b/api/tests/test_upsert_cards.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import logging
 import multiprocessing
 import uuid
-from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import psycopg
+import pytest
 
 from api.admin_resource import AdminResource
 from api.api_resource import APIResource
@@ -17,9 +17,6 @@ from api.db.bulk_upsert import bulk_upsert
 from api.scryfall_bulk_data_fetcher import BulkDataKey
 from api.tests.helpers import make_raw_card
 from api.tests.support import mock_app_context
-
-if TYPE_CHECKING:
-    import pytest
 
 # ---------------------------------------------------------------------------
 # Status-code tests
@@ -134,18 +131,36 @@ class TestBooleanIsTags:
         api_resource.admin._upsert_cards([card])
         assert _is_tags_for(api_resource, card["id"]).get("spotlight") is True
 
-    def test_hybrid_mana_symbol_lands_as_is_tag(self, api_resource: APIResource) -> None:
-        """hybrid/phyrexian read mana_cost_text, not raw_card_blob.
+    @pytest.mark.parametrize(
+        "mana_cost",
+        [
+            "{R/G}",  # the ten two-colour symbols
+            "{2/W}",  # the twobrid cycle -- 19 of Scryfall's is:hybrid cards have only these
+            "{C/U}",  # colourless-hybrid -- 1 card
+            "{G/W/P}",  # Phyrexian-hybrid -- 4 cards
+        ],
+    )
+    def test_every_hybrid_family_lands_as_is_tag(self, api_resource: APIResource, mana_cost: str) -> None:
+        """Hybrid reads the front face's cost, and counts all FOUR hybrid families.
 
-        A regex, not a rewrite, per docs/issues/done/00713-is-tag-recovery.md (an open,
-        growing symbol set makes an enumerated rewrite brittle).
+        A regex, not a rewrite, per docs/issues/done/00713-is-tag-recovery.md (an open, growing
+        symbol set makes an enumerated rewrite brittle) -- but the regex has to be as wide as the
+        set it stands in for. Reading only `{W/U}`-style symbols answered 569 of Scryfall's 603.
         """
-        card = make_raw_card(name="Hybrid Mana Import Test")
-        card["mana_cost"] = "{R/G}"
+        card = make_raw_card(name=f"Hybrid Mana Import Test {mana_cost}")
+        card["mana_cost"] = mana_cost
         api_resource.admin._upsert_cards([card])
         tags = _is_tags_for(api_resource, card["id"])
         assert tags.get("hybrid") is True
-        assert "phyrexian" not in tags
+
+    def test_colourless_phyrexian_is_not_hybrid(self, api_resource: APIResource) -> None:
+        """`{C/P}` is Phyrexian, not hybrid, and Scryfall agrees: `is:hybrid o:"{c/p}"` is empty."""
+        card = make_raw_card(name="Colourless Phyrexian Import Test")
+        card["mana_cost"] = "{C/P}"
+        api_resource.admin._upsert_cards([card])
+        tags = _is_tags_for(api_resource, card["id"])
+        assert "hybrid" not in tags
+        assert tags.get("phyrexian") is True
 
     def test_phyrexian_mana_symbol_lands_as_is_tag(self, api_resource: APIResource) -> None:
         card = make_raw_card(name="Phyrexian Mana Import Test")
@@ -155,13 +170,17 @@ class TestBooleanIsTags:
         assert tags.get("phyrexian") is True
         assert "hybrid" not in tags
 
-    def test_plain_mana_cost_does_not_set_hybrid_or_phyrexian(self, api_resource: APIResource) -> None:
-        card = make_raw_card(name="Plain Mana Import Test")
-        card["mana_cost"] = "{2}{W}{W}"
+    def test_phyrexian_is_anywhere_on_the_card_not_only_the_cost(self, api_resource: APIResource) -> None:
+        """The cost is the SMALLER half: 36 of Scryfall's 73 carry the symbol in rules text only.
+
+        Reading `mana_cost_text` alone answers 33 of the 73 -- Spellskite, the Souleaters and every
+        `{2}{B/P}: transform` back face put the symbol in rules text and nowhere else.
+        """
+        card = make_raw_card(name="Phyrexian In Rules Text")
+        card["mana_cost"] = "{2}{U}"
+        card["oracle_text"] = "{W/P}: Draw a card."
         api_resource.admin._upsert_cards([card])
-        tags = _is_tags_for(api_resource, card["id"])
-        assert "hybrid" not in tags
-        assert "phyrexian" not in tags
+        assert _is_tags_for(api_resource, card["id"]).get("phyrexian") is True
 
     def test_promo_types_membership_lands_as_is_tag(self, api_resource: APIResource) -> None:
         card = make_raw_card(name="FNM Import Test")


### PR DESCRIPTION
## Summary

#1001 put `hybrid` and `phyrexian` in `BOOLEAN_IS_TAGS`, which I think is the right home for them — the DSL only does exact-symbol containment, so an enumerated rewrite over an open symbol set is brittle, exactly as `00713` argued. But the two regexes are narrower than the sets they stand in for, and both under-match on live data today.

I measured each candidate rule by simulating it over the cards Scryfall itself returns (api.scryfall.com, 2026-08-23, `unique=cards`):

| `is:hybrid` (603 cards) | matched |
|---|---|
| `\{[WUBRG]/[WUBRG]\}` — what main has now | **569 / 603** |
| all four hybrid families | **603 / 603** |

| `is:phyrexian` (73 cards) | matched |
|---|---|
| `\{[WUBRG]/P\}` in `mana_cost_text` — what main has now | **33 / 73** |
| the full Phyrexian class in `mana_cost_text` | 37 / 73 |
| ...plus `oracle_text` | **73 / 73** |

## Hybrid is four families, not one

Scryfall counts the ten `{W/U}` symbols, the twobrid `{2/W}` cycle, colourless-hybrid `{C/W}`, and Phyrexian-hybrid `{W/U/P}`. The 24 cards the current regex misses break down as 19 twobrid, 1 colourless-hybrid, 4 Phyrexian-hybrid.

They are all one *shape* — an optional generic-or-colourless left side, an optional `/P` tail — so the alternation covers a family that has not been printed yet without another entry here. That is the same argument that put these in a regex rather than a rewrite; the regex just needs to be as wide as the thing it replaced.

`{C/P}` is deliberately **not** in it. Colourless Phyrexian is not a hybrid symbol and Scryfall agrees — `is:hybrid o:"{c/p}"` is empty. The `[WUBRGC]` on the right of the slash is what excludes it, since `P` is not in that class.

## Phyrexian is anywhere on the card

The cost is the smaller half: 36 of the 73 carry the symbol in rules text and nowhere else — Spellskite, the Souleaters, every `{2}{B/P}: transform` back face — so `oracle_text` is doing most of the work, not decorating. Case-insensitive on the text side only, since costs are stored upper-case and rules text quotes the symbol lower-case.

`{C/P}` **is** in this class, unlike in `hybrid`. It exists on cards even though #909's mana-symbol validator rejects it as a query term — which is exactly the case a stored tag can answer and an `m:` rewrite structurally cannot. That seems like a point in favour of the whole `BOOLEAN_IS_TAGS` approach.

## What this does NOT fix

A multi-face printing keeps one row: `preprocess_card` explodes the faces and the unique index on `scryfall_id` keeps the last one. So a symbol that appears only on the **front** face of a two-sided card is absent from both columns, under any expression. That is the row model rather than this expression, it is unchanged here, and merging the faces is what would lift it. I left a comment saying so, so it is not mistaken for fixed.

## Test plan

- [x] Parametrized all four hybrid families (`{R/G}`, `{2/W}`, `{C/U}`, `{G/W/P}`)
- [x] Pinned `{C/P}` as phyrexian-but-not-hybrid, in both directions
- [x] Added the rules-text-only phyrexian case
- [x] `make test-unit` — 3266 passed
- [x] `ruff` — clean