### PR TITLE
Card Page: The Printings Strip Asks for Every Field but the One It Renders From

### DIFF
--- a/api/static/card.js
+++ b/api/static/card.js
@@ -210,7 +210,10 @@ async function main() {
   document.getElementById('card-loading').style.display = 'none';
 
   try {
-    const printingFields = 'set_code,collector_number,set_name,illustration_id,price_usd,prefer_score';
+    // scryfall_id is what buildImageUrl derives the CDN path from — without it every
+    // alternate-printing thumbnail renders src="". It is the id, not a display field,
+    // which is exactly how it went missing from a list assembled by looking at the strip.
+    const printingFields = 'scryfall_id,set_code,collector_number,set_name,illustration_id,price_usd,prefer_score';
     const resp = await fetch(
       `/search?q=${encodeURIComponent(`!"${escapeExactName(card.name)}"`)}&unique=printing&fields=${printingFields}`
     );


### PR DESCRIPTION
## Summary

The alternate-printings strip on the card page fetches `fields=set_code,collector_number,set_name,illustration_id,price_usd,prefer_score` and hands each row to `buildImageUrl(card, 'normal')` — which derives the CDN path from `card.scryfall_id` and returns `''` without it. Every thumbnail in the strip renders `src=""`: links, labels and prices work, the images are blank.

Verified against the live deployment: the exact fetch `card.js` sends returns rows carrying the six requested keys and nothing else, and the same fetch with `scryfall_id` added returns usable rows.

One field added to the list. It has been this way since the strip landed in #576 — `scryfall_id` is the id rather than a display field, which is how it went missing from a list assembled by looking at what the strip displays.

(Found by CodeRabbit reviewing the file's mirror in a downstream port; confirmed here against the live API before fixing.)

## Test plan

- [x] `npx jest` — 1837 passed
- [x] Live check: `/search?q=!"Lightning Bolt"&unique=printing&fields=scryfall_id,…` returns `scryfall_id` per row