### PR TITLE
Engine: Fix scan_units Argument Swap in Cost-Model Gold/Refit/Probe Tests

### DIFF
--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -5195,7 +5195,7 @@ fn plan_cost_model_matches_gold() {
                 let eval_domain = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
                 // Tier reflects the residual AFTER memoize (what the walk pays).
                 let residual_tier_ns100 = if prep.all_match_known { 0 } else { verify_cost_tier(&res) };
-                let su = scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, eval_domain);
+                let su = scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, n_cards);
                 let feats = PlanFeatures {
                     n_cards, n_printings,
                     matches: total as u32,
@@ -5441,7 +5441,7 @@ fn plan_cost_refit() {
                 );
                 let prep = prepare_candidates(&QueryCtx::from(archived), &mode_only_params(mode_enum), &mut res, pe.as_ref());
                 let eval_domain = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
-                let su = scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, eval_domain);
+                let su = scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, n_cards);
                 let feats = PlanFeatures {
                     n_cards, n_printings, matches: total as u32, eval_domain,
                     scan_units: su,
@@ -5646,7 +5646,7 @@ fn printing_range_route_probe() {
             let prep = prepare_candidates(&QueryCtx::from(archived), &mode_only_params(Mode::Printing), &mut res, pe.as_ref());
             let eval_domain = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
             let residual_tier_ns100 = if prep.all_match_known { 0 } else { verify_cost_tier(&res) };
-            let su = scan_units(Mode::Printing, prep.candidate_cards.as_deref(), &archived.offsets, n_printings as u32, eval_domain);
+            let su = scan_units(Mode::Printing, prep.candidate_cards.as_deref(), &archived.offsets, n_printings as u32, n_cards);
             let feats = PlanFeatures {
                 n_cards, n_printings, matches: total as u32, eval_domain,
                 scan_units: su,


### PR DESCRIPTION
Split from #1008 into an individually-reviewable chunk — see that PR's description for the full context this arose from. Fully independent of the other splits; test-only, no production behavior change.

`scan_units()`'s last argument is the true total `n_cards` (matches the real router's call site), but three test harnesses (`plan_cost_model_matches_gold`, `plan_cost_refit`, `printing_range_route_probe`) passed `eval_domain` instead, wildly inflating the model's own self-check on narrow queries. `cmc>=15`/`o:annihilator`'s reported "120x misroutes" were entirely this bug — confirmed the real router already routes them correctly via `explain_analyze` against the real corpus before touching anything else. `plan_cost_model_matches_gold`: 90.9% -> 98.9%.

## Verification (re-run standalone against current `main`)
- `cargo test --release`: 157 passed, 0 failed
- `cargo clippy --release --all-targets`: clean (one pre-existing unrelated dead-code warning)
