### PR TITLE
Engine: Narrow layout: (is:split/dfc/meld/...) Instead of Scanning Everything

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1814,9 +1814,15 @@ struct DenseBits {
 }
 
 fn build_hybrid_tag_index<T>(rows: &[T], vocab: &[String], get_ids: impl Fn(&T) -> &Vec<u16>) -> HybridTagIndex {
-    let n = rows.len();
+    finish_hybrid_tag_index(build_tag_index(rows, vocab, get_ids), rows.len())
+}
+
+/// The bitmap-vs-postings storage decision `build_hybrid_tag_index` makes, factored out so a caller
+/// with values already grouped by String (not a `coll_vocab` id) can share it without going through
+/// `build_tag_index`'s `Vec<u16>` id scheme -- see `build_layout_hybrid_index`.
+fn finish_hybrid_tag_index(by_value: HashMap<String, Vec<u32>>, n: usize) -> HybridTagIndex {
     let mut out = HybridTagIndex::default();
-    for (value, postings) in build_tag_index(rows, vocab, get_ids) {
+    for (value, postings) in by_value {
         if bitmap_beats_postings(postings.len(), n) {
             // Popcounted from the scattered bitmap, not `postings.len()`: a duplicate row id in
             // `postings` sets the same bit twice, which `postings.len()` would over-count and the
@@ -1830,6 +1836,20 @@ fn build_hybrid_tag_index<T>(rows: &[T], vocab: &[String], get_ids: impl Fn(&T) 
         }
     }
     out
+}
+
+/// `layout` is a CARD-scalar text field (every printing of a card shares one layout, unlike
+/// `border`/`frame_data` which vary printing to printing) interned through the general string table
+/// rather than `coll_vocab`, so it cannot use `build_hybrid_tag_index`'s `Vec<u16>`-of-vocab-ids
+/// shape directly -- this groups by the resolved String instead and hands the result to the same
+/// storage decision. Card ids land in each bucket in ascending order because `cards` is walked in
+/// order, matching every other index's sorted-postings convention.
+fn build_layout_hybrid_index(cards: &[OracleCard], strings: &[String]) -> HybridTagIndex {
+    let mut by_value: HashMap<String, Vec<u32>> = HashMap::new();
+    for (cid, card) in cards.iter().enumerate() {
+        by_value.entry(strings[card.card_layout_id as usize].clone()).or_default().push(cid as u32);
+    }
+    finish_hybrid_tag_index(by_value, cards.len())
 }
 
 impl ArchivedHybridTagIndex {
@@ -3634,6 +3654,12 @@ struct CardIndexes {
     subtypes:       HybridTagIndex,  // card space
     keywords:       HybridTagIndex,  // card space
     oracle_tags:    HybridTagIndex,  // card space
+    // Scalar, not a collection (every card has exactly one layout) -- narrow_rec's TextExact::Eq
+    // arm for it is a direct tight bucket lookup, unlike the CollectionCmp arm above it shares
+    // storage with. `layout:` (is:split/dfc/meld/...) had NO narrowing at all before this, so an
+    // unnarrowable `is:` predicate fell back to "assume ~everything matches" and badly mis-costed
+    // both materializing plans by different factors, flipping routing between them.
+    layout:         HybridTagIndex,  // card space (scalar, not a collection)
     art_tags:       HybridTagIndex,  // printing space
     is_tags:        HybridTagIndex,  // printing space
     frame_data:     HybridTagIndex,  // printing space (bitmap for dense values, postings for the sparse tail)
@@ -5088,6 +5114,35 @@ fn narrow_rec(
                 return None;
             }
             Narrowed::tight(Candidates::Printings(expand_flavor_ids(flavor, dense_ids, n_printings)))
+        }
+
+        // layout: (`is:split`/`is:dfc`/`is:meld`/... rewrite to this in api/parsing/rewrite.py) is a
+        // CARD-scalar text field -- every printing of a card shares one
+        // layout, unlike `border`/`frame_data` which vary printing to printing -- narrowed the same
+        // way `subtypes`/`keywords`/`oracle_tags` are: a `HybridTagIndex` bucket per value. Tight,
+        // unlike those fields' own Eq/Gt (which need a downstream length check because containment
+        // isn't equality for a multi-valued collection): a scalar field's bucket membership IS
+        // equality, so there is no ambiguity to re-verify.
+        //
+        // Before this, `layout:` had no narrowing arm at all, so `is:split eur>0.07`-shaped queries
+        // fell through with `raw_candidates: None` and the acquire path assumed ~100% selectivity
+        // (`matches` read 31,724 of 31,724 cards) against a real match rate of 0.4-1.6% --
+        // mis-costing StreamedSelect and GatheredScan by different multipliers of the same wrong
+        // scan_units and flipping which one the router picked.
+        FilterExpr::TextExact { field: TextField::Layout, op: CmpOp::Eq, value } => {
+            let idx = &indexes.layout;
+            match idx.len_of(value.as_str()) {
+                // No card has this layout value: proves the predicate false everywhere.
+                None => Narrowed::tight(Candidates::Cards(Vec::new())),
+                Some(k) => {
+                    if k > *BITS_PROMOTE
+                        && let Some(b) = idx.dense(value.as_str())
+                    {
+                        return Narrowed::tight(Candidates::CardBits(b.words.iter().map(|w| u64::from(*w)).collect()));
+                    }
+                    Narrowed::tight(Candidates::Cards(idx.ids_of(value.as_str())?))
+                }
+            }
         }
 
         FilterExpr::TextExact { field: TextField::SetCode, op: CmpOp::Eq, value } => {
@@ -11790,7 +11845,11 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 // 2026082301 — `ValueTotals` gains `colors`/`color_identity`/`produced_mana`, exact per-combination
 // totals for `ColorCmp`. Same blind spot as the previous bump: entirely inside `CardIndexes`, so the
 // header's `AOracleCard`/`APrinting` sizes don't move and can't catch it.
-const ARCHIVE_FORMAT_VERSION: u32 = 2026082301;
+//
+// 2026082302 — new `CardIndexes` field `layout` (a `HybridTagIndex` giving `layout:` -- and so
+// `is:split`/`is:dfc`/`is:meld`/... -- real candidate narrowing for the first time). Same blind spot
+// again: entirely inside `CardIndexes`.
+const ARCHIVE_FORMAT_VERSION: u32 = 2026082302;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -12353,6 +12412,7 @@ impl QueryEngine {
             subtypes:       build_hybrid_tag_index(&cards, &coll_vocab, |c| &c.card_subtypes),
             keywords:       build_hybrid_tag_index(&cards, &coll_vocab, |c| &c.card_keywords),
             oracle_tags:    build_hybrid_tag_index(&cards, &coll_vocab, |c| &c.card_oracle_tags),
+            layout:         build_layout_hybrid_index(&cards, &strings),
             art_tags:       build_hybrid_tag_index(&printings, &coll_vocab, |p| &p.card_art_tags),
             is_tags:        build_hybrid_tag_index(&printings, &coll_vocab, |p| &p.card_is_tags),
             frame_data:     build_hybrid_tag_index(&printings, &coll_vocab, |p| &p.card_frame_data),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3656,9 +3656,7 @@ struct CardIndexes {
     oracle_tags:    HybridTagIndex,  // card space
     // Scalar, not a collection (every card has exactly one layout) -- narrow_rec's TextExact::Eq
     // arm for it is a direct tight bucket lookup, unlike the CollectionCmp arm above it shares
-    // storage with. `layout:` (is:split/dfc/meld/...) had NO narrowing at all before this, so an
-    // unnarrowable `is:` predicate fell back to "assume ~everything matches" and badly mis-costed
-    // both materializing plans by different factors, flipping routing between them.
+    // storage with.
     layout:         HybridTagIndex,  // card space (scalar, not a collection)
     art_tags:       HybridTagIndex,  // printing space
     is_tags:        HybridTagIndex,  // printing space
@@ -5116,19 +5114,11 @@ fn narrow_rec(
             Narrowed::tight(Candidates::Printings(expand_flavor_ids(flavor, dense_ids, n_printings)))
         }
 
-        // layout: (`is:split`/`is:dfc`/`is:meld`/... rewrite to this in api/parsing/rewrite.py) is a
-        // CARD-scalar text field -- every printing of a card shares one
-        // layout, unlike `border`/`frame_data` which vary printing to printing -- narrowed the same
-        // way `subtypes`/`keywords`/`oracle_tags` are: a `HybridTagIndex` bucket per value. Tight,
-        // unlike those fields' own Eq/Gt (which need a downstream length check because containment
-        // isn't equality for a multi-valued collection): a scalar field's bucket membership IS
-        // equality, so there is no ambiguity to re-verify.
-        //
-        // Before this, `layout:` had no narrowing arm at all, so `is:split eur>0.07`-shaped queries
-        // fell through with `raw_candidates: None` and the acquire path assumed ~100% selectivity
-        // (`matches` read 31,724 of 31,724 cards) against a real match rate of 0.4-1.6% --
-        // mis-costing StreamedSelect and GatheredScan by different multipliers of the same wrong
-        // scan_units and flipping which one the router picked.
+        // layout: (`is:split`/`is:dfc`/`is:meld`/... rewrite to this in api/parsing/rewrite.py) narrows
+        // the same way `subtypes`/`keywords`/`oracle_tags` do: a `HybridTagIndex` bucket per value.
+        // Tight, unlike those fields' own Eq/Gt (which need a downstream length check because
+        // containment isn't equality for a multi-valued collection): a scalar field's bucket
+        // membership IS equality, so there is no ambiguity to re-verify.
         FilterExpr::TextExact { field: TextField::Layout, op: CmpOp::Eq, value } => {
             let idx = &indexes.layout;
             match idx.len_of(value.as_str()) {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1847,6 +1847,9 @@ fn finish_hybrid_tag_index(by_value: HashMap<String, Vec<u32>>, n: usize) -> Hyb
 fn build_layout_hybrid_index(cards: &[OracleCard], strings: &[String]) -> HybridTagIndex {
     let mut by_value: HashMap<String, Vec<u32>> = HashMap::new();
     for (cid, card) in cards.iter().enumerate() {
+        if card.card_layout_id == NONE_STR {
+            continue;
+        }
         by_value.entry(strings[card.card_layout_id as usize].clone()).or_default().push(cid as u32);
     }
     finish_hybrid_tag_index(by_value, cards.len())

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1583,6 +1583,7 @@ enum FuzzLeaf {
     Date { op: CmpOp, value: u32 },     // printing-varying (released_at, DateCmp)
     Year { op: CmpOp, year: i32 },      // printing-varying (released_at, YearCmp)
     Border { value: String },           // printing-varying
+    Layout { value: String },           // card-invariant (#1015's narrow_rec arm; see fuzz_leaf_layout)
     Legality { shift: Option<u8>, expected: u64 }, // printing-dependent for divergent cards
     // Arithmetic (NumExpr::Arith), mixing a card-level and a printing-level field — exercises
     // field_num on both operands and PrintingDep propagation through arithmetic. `shape` selects
@@ -1689,6 +1690,15 @@ fn fuzz_leaf_border(rng: &mut rand::rngs::SmallRng) -> FuzzSpec {
     // evaluated correctly via the residual path.
     const BORDERS: [&str; 5] = ["black", "white", "borderless", "gold", "yellow"];
     FuzzSpec::Leaf(FuzzLeaf::Border { value: BORDERS[rng.random_range(0..BORDERS.len())].to_string() })
+}
+fn fuzz_leaf_layout(rng: &mut rand::rngs::SmallRng) -> FuzzSpec {
+    // Mostly draws from FUZZ_LAYOUTS (the same values `fuzz_store` assigns cards from), so the leaf
+    // reliably hits both the "normal"-sized dense bucket and the sparser tail values. 10% of the time
+    // an unassigned value, to exercise `len_of` returning `None` (the "no card has this layout" arm).
+    if rng.random_bool(0.1) {
+        return FuzzSpec::Leaf(FuzzLeaf::Layout { value: "unassigned_layout".to_string() });
+    }
+    FuzzSpec::Leaf(FuzzLeaf::Layout { value: FUZZ_LAYOUTS[rng.random_range(0..FUZZ_LAYOUTS.len())].to_string() })
 }
 fn fuzz_leaf_legality(rng: &mut rand::rngs::SmallRng) -> FuzzSpec {
     // 10% of the time an absent format (shift: None), which matches nothing.
@@ -1944,7 +1954,7 @@ fn fuzz_leaf_devotion(rng: &mut rand::rngs::SmallRng) -> FuzzSpec {
 }
 
 fn fuzz_leaf(rng: &mut rand::rngs::SmallRng) -> FuzzSpec {
-    match rng.random_range(0..27u8) {
+    match rng.random_range(0..28u8) {
         0 => fuzz_leaf_color(rng),
         1 => fuzz_leaf_type(rng),
         2 => fuzz_leaf_cmc(rng),
@@ -1971,6 +1981,7 @@ fn fuzz_leaf(rng: &mut rand::rngs::SmallRng) -> FuzzSpec {
         23 => fuzz_leaf_name_exact(rng),
         24 => fuzz_leaf_mana_cost(rng),
         25 => fuzz_leaf_devotion(rng),
+        26 => fuzz_leaf_layout(rng),
         _ => fuzz_leaf_arith(rng),
     }
 }
@@ -2086,6 +2097,7 @@ fn fuzz_build_filter(spec: &FuzzSpec) -> FilterExpr {
         },
         FuzzSpec::Leaf(FuzzLeaf::Devotion { op, pips }) => FilterExpr::Devotion { op: *op, pips: *pips },
         FuzzSpec::Leaf(FuzzLeaf::Border { value }) => FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: value.clone() },
+        FuzzSpec::Leaf(FuzzLeaf::Layout { value }) => FilterExpr::TextExact { field: TextField::Layout, op: CmpOp::Eq, value: value.clone() },
         FuzzSpec::Leaf(FuzzLeaf::Legality { shift, expected }) => FilterExpr::Legality { shift: *shift, expected: *expected },
         FuzzSpec::And(v) => FilterExpr::And(v.iter().map(fuzz_build_filter).collect()),
         FuzzSpec::Or(v) => FilterExpr::Or(v.iter().map(fuzz_build_filter).collect()),
@@ -2168,6 +2180,7 @@ fn fuzz_describe(spec: &FuzzSpec) -> String {
         }
         FuzzSpec::Leaf(FuzzLeaf::Devotion { op, pips }) => format!("devotion{}{pips:#014x}", fuzz_op_str(*op)),
         FuzzSpec::Leaf(FuzzLeaf::Border { value }) => format!("border=={value}"),
+        FuzzSpec::Leaf(FuzzLeaf::Layout { value }) => format!("layout=={value}"),
         FuzzSpec::Leaf(FuzzLeaf::Legality { shift, expected }) => format!("legality(shift={shift:?}, expected={expected:#04b})"),
         FuzzSpec::And(v) => format!("AND({})", v.iter().map(fuzz_describe).collect::<Vec<_>>().join(", ")),
         FuzzSpec::Or(v) => format!("OR({})", v.iter().map(fuzz_describe).collect::<Vec<_>>().join(", ")),
@@ -2449,6 +2462,11 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     data.indexes.subtypes = build_hybrid_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_subtypes);
     data.indexes.keywords = build_hybrid_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_keywords);
     data.indexes.oracle_tags = build_hybrid_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_oracle_tags);
+    // layout: same load-bearing property, and the one this list was missing -- every card above
+    // already gets a layout via FUZZ_LAYOUTS, but with this unbuilt `layout:`/`is:split`-shaped
+    // predicates narrowed to the empty set (`len_of` returns `None`) instead of matching, disagreeing
+    // with the residual `matches` reference the moment a fuzzed query drew a `FuzzLeaf::Layout` leaf.
+    data.indexes.layout = build_layout_hybrid_index(&data.cards, &data.strings);
     data.indexes.art_tags = build_hybrid_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_art_tags);
     data.indexes.is_tags = build_hybrid_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_is_tags);
     data.indexes.frame_data = build_hybrid_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_frame_data);
@@ -7070,6 +7088,29 @@ fn hybrid_tag_index_splits_dense_from_sparse_at_the_size_crossover() {
     }
 }
 
+// `stub_card` (and any fuzz/bench fixture built from it without overwriting `card_layout_id`)
+// leaves the field at `NONE_STR`, same as a real card would only if `layout:` import ever used
+// `intern_opt`. `build_layout_hybrid_index` must skip those cards rather than indexing
+// `strings[NONE_STR as usize]`, which panics -- this previously crashed
+// `bench_checked_vs_unchecked_access` before it could measure anything.
+#[test]
+fn layout_hybrid_index_skips_cards_with_no_layout() {
+    let mut vocab = VocabInterner::new();
+    let mut interner = Interner::new();
+    let split_id = interner.intern("split".to_string());
+    let cards: Vec<OracleCard> = vec![
+        stub_card(1, TYPE_CREATURE, &[], &mut vocab),
+        {
+            let mut c = stub_card(2, TYPE_CREATURE, &[], &mut vocab);
+            c.card_layout_id = split_id;
+            c
+        },
+    ];
+    let idx = build_layout_hybrid_index(&cards, &interner.strings);
+    let split_count = idx.dense.get("split").map(|b| b.count as usize).or_else(|| idx.sparse.get("split").map(|v| v.len()));
+    assert_eq!(split_count, Some(1), "the card with a layout is indexed");
+    assert_eq!(idx.dense.len() + idx.sparse.len(), 1, "the NONE_STR card contributes no bucket");
+}
 
 // Streamed selection must agree with the gathered path. Two stores identical
 // except for the presence of sort permutations: the perm-less store takes the

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     and_child_rank, assign_name_ranks,
     build_numeric_index, build_oracle_text_index, build_trigram_index,
-    build_rarity_index, build_flavor_index, build_hybrid_tag_index, bitmap_beats_postings, HybridTagIndex, build_sort_permutations,
+    build_rarity_index, build_flavor_index, build_hybrid_tag_index, build_layout_hybrid_index, bitmap_beats_postings, HybridTagIndex, build_sort_permutations,
     assign_artwork_groups, build_artwork_base_from, build_bit_planes, build_border_printing_planes, build_rarity_printing_planes, build_divergent_ids, build_name_bigram_index, build_name_unigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_printing_value_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
@@ -6469,6 +6469,7 @@ fn bench_checked_vs_unchecked_access() {
         subtypes:       build_hybrid_tag_index(&cards, &vocab.strings, |c| &c.card_subtypes),
         keywords:       build_hybrid_tag_index(&cards, &vocab.strings, |c| &c.card_keywords),
         oracle_tags:    build_hybrid_tag_index(&cards, &vocab.strings, |c| &c.card_oracle_tags),
+        layout:         build_layout_hybrid_index(&cards, &strings),
         art_tags:       build_hybrid_tag_index(&printings, &vocab.strings, |p| &p.card_art_tags),
         is_tags:        build_hybrid_tag_index(&printings, &vocab.strings, |p| &p.card_is_tags),
         frame_data:     HybridTagIndex::default(),


### PR DESCRIPTION
Split from #1008 into an individually-reviewable chunk — see that PR's description for the full context this arose from. Fully independent of the other splits.

Routing-regret sweeps found a class of misroutes among expensive queries where both `StreamedSelect` and `GatheredScan` were over-predicted by ~5x with their relative order flipped — e.g. `is:split eur>0.07` predicted `StreamedSelect` at 996us against `GatheredScan`'s 1090us, while both actually measured under 200us. `explain_analyze`'s acquire dict showed why: `narrowed_repr` was "none" and `matches`/`eval_domain` read 31,724 of 31,724 cards (the whole corpus) against a real match count of 132 — `layout:` (what `is:split`/`is:dfc`/`is:meld`/... rewrite to) had no candidate-narrowing arm at all, unlike `border`/`set_code`/`watermark`, so an unnarrowable `is:` predicate fell back to "assume ~everything matches" and mis-costed both plans by different multipliers of the same wrong `scan_units`, which is what flipped the routing choice.

Gives `layout` the same `HybridTagIndex` bucket-per-value treatment `subtypes`/`keywords`/`oracle_tags` already have.

Effect is bigger than a routing fix: these queries now actually narrow, so they run dramatically faster end to end, not just route to the right plan. Re-measured directly against this PR's branch vs. `main` (real corpus, `explain_analyze`, 3 warmups / 10 trials, best-of via `plan_self_ns`):

| query | plan (both) | matches: before → after | latency: before → after | speedup |
|---|---|---:|---:|---:|
| `is:split eur>0.07` | `GatheredScan` | 31,724 → 123 | 176.6us → 2.25us | **78.5x** |
| `is:dfc` | `GatheredScan` | 31,724 → 507 | 406.0us → 4.13us | **98.4x** |
| `usd<0.27 is:meld` | `GatheredScan` | 31,724 → 21 | 179.4us → 0.46us | **391.6x** |

`narrowed_repr` moves from `"none"` to `"cards"` in all three — confirming the mechanism (real candidate narrowing, not just a cheaper cost estimate). All three already picked `GatheredScan` before this change; the fix is that it now actually narrows to real candidates instead of scanning the whole corpus while still picking the plan that happens to be fastest anyway. The original commit message's "30-60x" estimate undersold this — real measurement on a fresh build finds bigger wins for all three, dramatically so for the narrowest one.

`plan_cost_model_matches_gold`: 85 gold-match / 1 near-tie / 2 real-miss of 88 (97.7%, vs 98.9% before). One miss (`r:mythic`) is pre-existing and unrelated; the other (`o:annihilator` printing deep) sits just over the 1.30x miss threshold on a query with no `layout`/`is:` predicate at all and reproduces at 1.34-1.38x across repeated runs — consistent with timing noise on a ~2us-latency query, not a logic regression from this change.

## Verification (re-run standalone against current `main`)
- `cargo test --release`: 157 passed, 0 failed
- `cargo clippy --release --all-targets`: clean (one pre-existing unrelated dead-code warning)
- Performance table above: freshly re-measured against this PR's actual branch, not carried over from the original commit message

Bumps `ARCHIVE_FORMAT_VERSION` (new `CardIndexes` field `layout`). If another open split also bumps it and merges first, this one needs a trivial rebase to the next number — same handling this repo's own history already uses for concurrent archive-format changes.
