### PR TITLE
Engine: Price GatheredScan's Artwork-Mode Dedupe Check

### DIFF
--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -136,6 +136,14 @@ pub(crate) struct PlanFeatures {
     /// Cards `run_query_streamed` visits in ARTWORK mode, i.e. `eval_domain` there and `0` in card and
     /// printing mode. Charged at `STREAM_ARTWORK_SEEN_PER_CARD_NS`.
     pub artwork_seen_cards: u32,
+    /// Printings `exec_gathered_scan` visits in ARTWORK mode, i.e. `scan_units` there and `0` in card
+    /// and printing mode. `push_card_matches`'s `Mode::Artwork` branch does a `group_best`/`touched`
+    /// dedupe check on every printing in a candidate's span (`Mode::Printing` does not), so unlike
+    /// `artwork_seen_cards` this rides `scan_units` (a printing count) rather than `eval_domain` (a
+    /// card count) -- the two plans' artwork overhead differ in SHAPE, not just rate, because
+    /// `run_query_streamed` dedupes with a fixed per-card bitmask while this loop dedupes per
+    /// printing. Charged at `GATHER_ARTWORK_PER_PRINTING_NS`.
+    pub artwork_seen_printings: u32,
     /// Printings compose's **Gather** paging branch bit-tests, which is NOT `scan_units`.
     ///
     /// `scan_units` is every printing under a candidate card — right for GatheredScan and
@@ -453,6 +461,20 @@ const STREAM_EMIT_PER_MATCH_NS: f64 = 0.12;
 /// sign. One mechanism showing up twice, so it belongs in its own term rather than as a mode-specific
 /// copy of each rate. ~16 word-ops per card is the right order for 2.4 ns.
 const STREAM_ARTWORK_SEEN_PER_CARD_NS: f64 = 1.21;
+/// ns per printing scanned, for `GatheredScan`'s ARTWORK-mode dedupe check
+/// (`push_card_matches`'s `Mode::Artwork` branch: read `artwork_group_col[pid]`, check
+/// `group_best[gid].is_some()`, on every printing in the candidate's span). Unlike
+/// `STREAM_ARTWORK_SEEN_PER_CARD_NS` this could not be fit from an end-to-end query A/B: the two
+/// modes' `matches_pushed` differ sharply (printing pushes every printing, artwork only distinct
+/// groups), so `GATHER_PUSH_PER_MATCH_NS`'s much larger swing dominated the raw delta and even its
+/// sign, and a pooled regression over natural queries hit multicollinearity between
+/// cards_visited/printing_span/matches_pushed and came back negative.
+///
+/// Fit from a kernel test instead (`gather_artwork_kernel_costs`): `push_card_matches` called
+/// directly over the same 5,000-card real-corpus slice with `all_match: true` (no residual
+/// evaluation cost), `Mode::Printing` vs `Mode::Artwork`, min-of-150 rounds. Four runs (two repeats,
+/// one on a different 5,000-card slice): 0.489, 0.528, 0.508, 0.489 ns/printing.
+const GATHER_ARTWORK_PER_PRINTING_NS: f64 = 0.50;
 /// ns per card scanned in the small-total gather (`for cid in 0..n_cards`,
 /// counts[cid]==0 check). Cheaper than a match-phase visit (no filter work). Fit
 /// from the narrow-query floor: cmc>=15 / o:annihilator / cmc==7 card SHALLOW all
@@ -875,6 +897,7 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 + matches * GATHER_PUSH_PER_MATCH_NS
                 + page_span * GATHER_SELECT_PER_PAGE_SLOT_NS
                 + page_rows * GATHER_COLLECT_PER_PAGE_ROW_NS
+                + f64::from(f.artwork_seen_printings) * GATHER_ARTWORK_PER_PRINTING_NS
                 + GATHER_FIXED_COST_NS
         }
     }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -10053,6 +10053,10 @@ fn mk_plan_feats(
         // artwork mode only — so it rides `eval_domain` there and vanishes elsewhere. See
         // STREAM_ARTWORK_SEEN_PER_CARD_NS for the mechanism and the measurement.
         artwork_seen_cards: if matches!(params.mode, Mode::Artwork) { eval_domain } else { 0 },
+        // `exec_gathered_scan` pays its dedupe check unconditionally (no `all_match_known` shortcut
+        // like `run_query_streamed`'s stored-group-count fast path), so unlike `artwork_seen_cards`
+        // above this is never zeroed by `candidate_feats`'s all-match/card-invariant overrides.
+        artwork_seen_printings: if matches!(params.mode, Mode::Artwork) { scan_units } else { 0 },
         compose_scan_printings: 0, // set by every branch that costs a PrintingCompose (its own, or as a competitor)
         gather_group_printings: 0, // only the compose branch, and only when its grouping arm runs
     }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -12,6 +12,7 @@ use super::{
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
     prepare_candidates, verify_cost_tier, scan_units, sort_col_bound, divergent_formats_of, Mode, QueryCtx, QueryParams, Prefer, SortBound,
+    push_card_matches,
     GatherSelect, select_page, GATHER_PRUNE_CHUNK, Match,
     archive_header, archive_payload, ARCHIVE_HEADER_LEN, Mmap,
     bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, split_planes,
@@ -5209,6 +5210,7 @@ fn plan_cost_model_matches_gold() {
                     offset: offset as u32,
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
+                artwork_seen_printings: 0, // no artwork per-printing dedupe check in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
                 };
@@ -5451,6 +5453,7 @@ fn plan_cost_refit() {
                     limit: limit as u32, offset: offset as u32,
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
+                artwork_seen_printings: 0, // no artwork per-printing dedupe check in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
                 };
@@ -5656,6 +5659,7 @@ fn printing_range_route_probe() {
                 limit: LIMIT as u32, offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
+                artwork_seen_printings: 0, // no artwork per-printing dedupe check in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
             };
@@ -6019,6 +6023,7 @@ fn plan_regret_report() {
                 offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
+                artwork_seen_printings: 0, // no artwork per-printing dedupe check in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
             };
@@ -6149,6 +6154,7 @@ fn plan_regret_fuzz() {
                 limit: limit as u32, offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
+                artwork_seen_printings: 0, // no artwork per-printing dedupe check in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
             };
@@ -11031,6 +11037,91 @@ fn range_compose_kernel_costs() {
             "{hi:>8}  {set_prtg:>10}  {scatter_ns:>10}  {per_prtg:>11.3}  {proj_ns:>10}  {exists_cards:>10}  {walk_ns:>9}"
         );
     }
+}
+
+/// `GatheredScan`'s artwork-mode overhead: `push_card_matches`'s `Mode::Artwork` branch does a
+/// `group_best`/`touched` dedupe scan over every printing in `[start, end)` that `Mode::Printing`
+/// does not — see the doc on `STREAM_ARTWORK_SEEN_PER_CARD_NS` for `StreamedSelect`'s analogous
+/// (but differently-shaped: fixed per-CARD there, per-PRINTING here) overhead. `cost::plan_cost`'s
+/// `GatheredScan` arm charges no such term at all, unlike `StreamedSelect`'s.
+///
+/// Calls `push_card_matches` directly (not through a full query) with `all_match: true` so no
+/// residual evaluation cost pollutes the measurement -- isolating exactly the mode-dependent match-
+/// collection cost the two modes' loop bodies differ by, over the same real card/printing data. An
+/// end-to-end `explain_analyze` A/B (`unique=printing` vs `unique=artwork`, same filter) was tried
+/// first and was unusable: `matches_pushed` differs sharply between modes (printing pushes every
+/// printing, artwork only distinct groups), so `GATHER_PUSH_PER_MATCH_NS`'s much larger swing
+/// dominates the raw delta and even its SIGN. A pooled OLS regression over natural corpus queries
+/// (cards_visited/printing_span/matches_pushed as features, `is_artwork*printing_span` for the term
+/// of interest) came back with a negative coefficient and a negative per-match rate too --
+/// multicollinearity between those three features in real query data, not a real negative cost.
+///
+/// `cargo test --release gather_artwork_kernel_costs -- --ignored --nocapture`
+#[test]
+#[ignore = "gather-artwork kernel cost; needs real.store; cargo test --release gather_artwork_kernel_costs -- --ignored --nocapture"]
+fn gather_artwork_kernel_costs() {
+    use std::hint::black_box;
+    use std::time::Instant;
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    const WARMUP: usize = 15;
+    const ITERS: usize = 150;
+    // Enough cards that the printing span dwarfs per-call fixed overhead (Instant::now, branch
+    // mispredicts on the first card of a round), so the resulting rate is dominated by the loop body.
+    const N_CARDS: usize = 5000;
+
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch — rebuild");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let offsets = &archived.offsets;
+    let printings = &archived.printings;
+    let strings = &archived.strings;
+    let indexes = &archived.indexes;
+    let max_groups = usize::from(u16::from(indexes.max_artwork_groups));
+    let printing_span: u64 =
+        (0..N_CARDS).map(|cid| u64::from(u32::from(offsets[cid + 1])) - u64::from(u32::from(offsets[cid]))).sum();
+
+    let bench_mode = |mode: Mode| -> u128 {
+        let mut group_best: Vec<Option<(u32, f64)>> = vec![None; max_groups];
+        let mut touched: Vec<u16> = Vec::new();
+        let mut out: Vec<(u128, u32, u32)> = Vec::with_capacity(4096);
+        let mut best = u128::MAX;
+        for it in 0..(WARMUP + ITERS) {
+            out.clear();
+            let t0 = Instant::now();
+            for cid in 0..N_CARDS {
+                let card = &archived.cards[cid];
+                let start = u32::from(offsets[cid]) as usize;
+                let end = u32::from(offsets[cid + 1]) as usize;
+                black_box(push_card_matches(
+                    card, cid as u32, printings, &indexes.artwork_group_col, start, end, true, &[], false, mode,
+                    Prefer::Default, SortCol::EdhrecRank, false, strings, None, &mut out, &mut group_best, &mut touched,
+                ));
+            }
+            let dt = t0.elapsed().as_nanos();
+            if it >= WARMUP {
+                best = best.min(dt);
+            }
+        }
+        best
+    };
+
+    let printing_ns = bench_mode(Mode::Printing);
+    let artwork_ns = bench_mode(Mode::Artwork);
+    let delta = artwork_ns as i128 - printing_ns as i128;
+    println!("\ngather-artwork kernel costs ({N_CARDS} cards, {printing_span} printings)");
+    println!("  Printing: {printing_ns} ns total, {:.4} ns/printing", printing_ns as f64 / printing_span.max(1) as f64);
+    println!("  Artwork:  {artwork_ns} ns total, {:.4} ns/printing", artwork_ns as f64 / printing_span.max(1) as f64);
+    println!(
+        "  delta: {delta} ns / {printing_span} printings = {:.4} ns/printing (candidate GATHER_ARTWORK_PER_PRINTING_NS)",
+        delta as f64 / printing_span.max(1) as f64
+    );
 }
 
 /// #724 build-side correctness oracle: projecting a printing-space border plane up to card-existence


### PR DESCRIPTION
Split from #1008 into an individually-reviewable chunk — see that PR's description for the full context this arose from. Independent of the other splits (note: #1008's own tooling-fix + card-mode `scan_units` split is stacked on top of *this* one, since it adds a pydict export for the `artwork_seen_printings` field this PR introduces).

Routing-regret sweeps (uniform sampler) showed `StreamedSelect`<->`GatheredScan` confusion as the single largest source of lost time among expensive (100us+) queries. One of its two root causes: `exec_gathered_scan`'s `Mode::Artwork` branch runs a `group_best`/`touched` dedupe check on every printing in a candidate's span (`push_card_matches`), the same mechanism `StreamedSelect` charges via `artwork_seen_cards` — but `GatheredScan`'s cost formula charged nothing for it at all, so it read as a near-exact tie against `StreamedSelect` while measuring 10-16% slower in every observed case.

The two plans' overhead differs in shape (per-card `StreamedSelect`'s fixed `seen_words` bitmask vs per-printing `GatheredScan`'s `group_best` scan), so it needed its own feature (`artwork_seen_printings`, riding `scan_units`) rather than reusing `artwork_seen_cards`. Rate fit via a kernel test (`gather_artwork_kernel_costs`) calling `push_card_matches` directly with `all_match=true` to strip out residual-evaluation noise.

Verified against the real corpus: all three concrete misroutes found by the regret sweep now route to `StreamedSelect`, with `GatheredScan`'s predicted cost moving in the correct direction by roughly the measured gap. `plan_cost_model_matches_gold` stays at 98.9% (no regression).

## Verification (re-run standalone against current `main`)
- `cargo test --release`: 157 passed, 0 failed
- `cargo clippy --release --all-targets`: clean (one pre-existing unrelated dead-code warning)
