### PR TITLE
Engine: Exact Walk-Length Checkpoints for otag:/keyword:/t: Ordered by EDHREC

### DIFF
--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -207,6 +207,11 @@ pub(crate) struct PlanFeatures {
     /// uniformly across the whole permutation. `None` everywhere except a bare card-space collection
     /// leaf ordered by EDHREC, which is the only dimension `WalkCheckpoints` covers today.
     pub walked_hint: Option<f64>,
+    /// Printings a CARD-SPACE collection leaf's build broadcasts (`ids_of` +
+    /// `broadcast_card_ids_to_printings`). See `ComposeEstimate::collection_broadcast`'s doc for why
+    /// this is not just folded into `scatter_printings`. `0` for everything except `PrintingCompose`
+    /// on a card-space `subtypes`/`keywords`/`oracle_tags` leaf.
+    pub collection_broadcast_printings: u32,
 }
 
 // ─── P1: PrintingRangeScan ──────────────────────────────────────────────────
@@ -620,6 +625,22 @@ const GATHER_FIXED_COST_NS: f64 = 169.6;
 pub(crate) const COMPOSE_LINEAR_PASS_PER_PRINTING_NS: f64 = 1.93;
 /// Range-slice scatter into the printing bitmap during build.
 pub(crate) const COMPOSE_SCATTER_PER_PRINTING_NS: f64 = 0.48;
+
+/// A CARD-SPACE collection leaf's build (`ids_of` + `broadcast_card_ids_to_printings`) used to ride
+/// `COMPOSE_SCATTER_PER_PRINTING_NS`, on the assumption that it was the same shape of operation as a
+/// range's contiguous slice-scatter. It measurably is not: a card-cursor lookup per id (`offsets[c]`/
+/// `offsets[c+1]`) plus a variable-width printing-range fill, against a range's single contiguous
+/// write.
+///
+/// Backed out of `otag:triggered-ability`/`otag:cycle`/`otag:activated-ability` (`unique=printing`,
+/// EDHREC): with `printings_walked` corrected (`WalkCheckpoints`) and every other term in
+/// `PhysicalPlan::PrintingCompose`'s formula computed from measured features, the residual against real
+/// wall time scaled cleanly with `collection_broadcast_printings` (not a flat offset), implying 1.41,
+/// 1.30, and 1.31 ns/printing -- tight enough (2.7-2.9x `COMPOSE_SCATTER_PER_PRINTING_NS`, all three
+/// within 8% of each other) to be a real rate and not sampling noise, but from 3 points on one corpus
+/// size, not the corpus-scaling sweep the rates above this comment were fit with. Revisit if a wider
+/// measurement disagrees.
+pub(crate) const COMPOSE_COLLECTION_BROADCAST_PER_PRINTING_NS: f64 = 1.34;
 /// Result-space bitmap words popcounted for the total.
 const COMPOSE_POPCOUNT_PER_WORD_NS: f64 = 1.07;
 /// Per printing stepped over by the Perm / OrderbyWalk page fill.
@@ -746,6 +767,7 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
         PhysicalPlan::PrintingCompose => {
             let build = f64::from(f.broadcast_printings) * COMPOSE_LINEAR_PASS_PER_PRINTING_NS  // legality broadcast-down into the printing bitmap (border/rarity read a plane → 0)
                 + f64::from(f.scatter_printings) * COMPOSE_SCATTER_PER_PRINTING_NS  // range-slice scatter into the printing bitmap (cheap: no card cursor)
+                + f64::from(f.collection_broadcast_printings) * COMPOSE_COLLECTION_BROADCAST_PER_PRINTING_NS  // card-space collection leaf's build (ids_of + broadcast_card_ids_to_printings) — a card cursor per id, pricier than a range's contiguous scatter
                 + f64::from(f.project_printings) * COMPOSE_LINEAR_PASS_PER_PRINTING_NS  // second pass: project printing→card/artwork (0 for printing mode) — the pass CardRangePopcount fuses away
                 + f64::from(f.popcount_words) * COMPOSE_POPCOUNT_PER_WORD_NS; // popcount the result-space bitmap for the total (printing/card/artwork words)
             let page = match f.compose_paging {

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -202,6 +202,11 @@ pub(crate) struct PlanFeatures {
     /// in ~`page_span/selectivity` steps), while the permutation-free gather visits every match — so
     /// the formula branches on this rather than assuming one. Ignored by every other plan.
     pub compose_paging: super::ComposePaging,
+    /// Interpolated walk length from `WalkCheckpoints`, when the acquire branch found one for this
+    /// value/sort-column -- `printings_walked` uses this directly instead of assuming matches spread
+    /// uniformly across the whole permutation. `None` everywhere except a bare card-space collection
+    /// leaf ordered by EDHREC, which is the only dimension `WalkCheckpoints` covers today.
+    pub walked_hint: Option<f64>,
 }
 
 // ─── P1: PrintingRangeScan ──────────────────────────────────────────────────
@@ -687,6 +692,11 @@ const COMPOSE_BUILD_PER_PRINTING_NS: f64 = 0.0835;
 /// entirely on this quantity and nothing else validates them.
 pub(crate) fn printings_walked(f: &PlanFeatures) -> f64 {
     let page_span = f64::from((f.offset.saturating_add(f.limit)).min(f.matches));
+    // `WalkCheckpoints`: an exact-anchored interpolation for a value whose cards' EDHREC positions are
+    // known, in place of assuming they spread uniformly across the whole permutation. See its doc.
+    if let Some(hint) = f.walked_hint {
+        return hint;
+    }
     let match_rate = (f64::from(f.matches) / f64::from(f.n_printings.max(1))).max(MATCH_RATE_FLOOR);
     page_span / match_rate * WALK_LENGTH_BIAS
 }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2573,6 +2573,183 @@ fn legality_totals_key(shift: u8, expected: u64) -> u16 {
     (u16::from(shift) << 2) | (expected as u16 & 0b11)
 }
 
+/// Cumulative PRINTING counts at which `WalkCheckpoints` records a position (see
+/// `WalkCheckpoints::from_weighted_positions` for why printings, not cards). Chosen to bracket real
+/// traffic rather than spread evenly: `REALISTIC_OFFSET_WEIGHTS`/`LIMITS` in the client's sampler top
+/// out around `offset + limit` ~875, so checkpoint[800] sits almost exactly at the deepest page real
+/// queries ask for, and the four gaps below it give the interpolation four independent anchors across
+/// the range that matters instead of one.
+const WALK_CHECKPOINT_COUNTS: [u32; 5] = [1, 100, 200, 400, 800];
+
+/// Positions (within one EDHREC permutation direction) at which cumulative PRINTINGS from matching
+/// cards reaches 1/100/200/400/800, for card-space collection fields whose `Perm`-branch walk length
+/// (`cost::printings_walked`) is otherwise a single global rate blind to WHERE a value's cards sit in
+/// EDHREC order.
+///
+/// #1005/#1006/#1007 fixed the tier and candidate-count features on this branch; this is the
+/// remaining piece docs/issues/local-engine-compose-paging-cost-based.md leaves unresolved --
+/// `otag:triggered-ability` measured a 3.2x walk-length miss (predicted 602, realized 1,942) that a
+/// ~10% printings-per-matching-card skew cannot explain, so the error is genuine EDHREC-order
+/// clumping, not a rate. `matches`/`SpaceTotals` give an exact total; this gives the SHAPE of where
+/// those matches fall, which no scalar total can.
+///
+/// 20 bytes per (value, direction) — five `u32` positions, no separate rate to fit.
+#[derive(Archive, Serialize, Deserialize, Default, Clone, Copy)]
+struct WalkCheckpoints {
+    /// Ascending by construction (each is a position further into the walk than the last). Fewer than
+    /// `WALK_CHECKPOINT_COUNTS.len()` meaningful entries when the value has fewer total matches --
+    /// `len` says how many of `positions` are real; the rest are zero and must not be read.
+    positions: [u32; 5],
+    len: u8,
+}
+
+impl WalkCheckpoints {
+    /// Builds from a value's `(position, printing_span)` pairs in ONE permutation direction, not
+    /// necessarily sorted yet -- one pair per matching card, `printing_span` that card's own printing
+    /// count. NOT one card per checkpoint slot: `unique=printing` needs "cumulative PRINTINGS reaches
+    /// N", and a card-level predicate's matching cards can each contribute more than one printing at
+    /// once, so this walks matches in permutation order accumulating printing span, not card count,
+    /// and records a checkpoint's position the moment that running total reaches it.
+    fn from_weighted_positions(mut entries: Vec<(u32, u32)>) -> WalkCheckpoints {
+        entries.sort_unstable_by_key(|&(pos, _)| pos);
+        let mut out = WalkCheckpoints::default();
+        let mut cumulative: u64 = 0;
+        let mut next = 0usize;
+        for (pos, span) in entries {
+            cumulative += u64::from(span);
+            while next < WALK_CHECKPOINT_COUNTS.len() && cumulative >= u64::from(WALK_CHECKPOINT_COUNTS[next]) {
+                out.positions[next] = pos;
+                out.len = (next + 1) as u8;
+                next += 1;
+            }
+            if next >= WALK_CHECKPOINT_COUNTS.len() {
+                break;
+            }
+        }
+        out
+    }
+}
+
+impl ArchivedWalkCheckpoints {
+    /// Estimated walk length (permutation entries to visit) to accumulate `k` matches, by linear
+    /// interpolation between the two stored checkpoints bracketing `k` -- or extrapolation from the
+    /// last segment's slope past the final checkpoint. `None` when there are no checkpoints at all
+    /// (an empty value, which `len_of`/`SpaceTotals` already answer as an exact zero elsewhere).
+    fn walk_length_for(&self, k: u32) -> Option<f64> {
+        let len = usize::from(self.len);
+        if len == 0 {
+            return None;
+        }
+        let count_at = |i: usize| WALK_CHECKPOINT_COUNTS[i] as f64;
+        let pos_at = |i: usize| f64::from(u32::from(self.positions[i]));
+        // Below the first checkpoint: interpolate from the origin (position 0, count 0) -- the walk
+        // has not found anything yet at that point, so the origin is an exact anchor, not an estimate.
+        if k as f64 <= count_at(0) {
+            return Some(pos_at(0) * (k as f64 / count_at(0)));
+        }
+        // Between two stored checkpoints: interpolate the segment they bound.
+        for i in 1..len {
+            if k as f64 <= count_at(i) {
+                let (c0, c1, p0, p1) = (count_at(i - 1), count_at(i), pos_at(i - 1), pos_at(i));
+                return Some(p0 + (p1 - p0) * (k as f64 - c0) / (c1 - c0));
+            }
+        }
+        // Past the last checkpoint: extrapolate the final segment's slope. `len == 1` has no segment to
+        // slope from, so it falls back to the same origin-to-first-checkpoint rate used below count(0).
+        let (c0, c1, p0, p1) = if len >= 2 {
+            (count_at(len - 2), count_at(len - 1), pos_at(len - 2), pos_at(len - 1))
+        } else {
+            (0.0, count_at(0), 0.0, pos_at(0))
+        };
+        let rate = (p1 - p0) / (c1 - c0);
+        Some(p1 + rate * (k as f64 - c1))
+    }
+}
+
+/// One value's `(position, printing_span)` pairs in each EDHREC direction, in one pass over `cards`.
+/// Generic over the key exactly like `build_value_totals`, for the same reason: subtypes/keywords/
+/// oracle_tags are the same shape of dimension (multi-valued, `coll_vocab`-keyed, card-space), just
+/// answering a different question here.
+/// Prefix sum, in EACH permutation direction, of every VISITED card's printing span -- matching or
+/// not. The walk bit-tests every card it steps past, so "how many printings has the walk examined by
+/// position P" is this, not P itself: a card position is a CARD-count quantity (0..n_cards), while
+/// `printings_walked` answers in PRINTING units (0..n_printings, ~3.1x larger on this corpus) because
+/// that is what it is compared against (`printings_examined`). One array per direction, shared by
+/// every value's checkpoints -- not itself keyed by value.
+fn build_perm_prefix_printings(offsets: &[u32], edhrec_perm: &[Vec<u32>; 2]) -> [Vec<u32>; 2] {
+    let prefix_of = |perm: &[u32]| -> Vec<u32> {
+        let mut cumulative = 0u32;
+        perm.iter()
+            .map(|&cid| {
+                cumulative += offsets[cid as usize + 1] - offsets[cid as usize];
+                cumulative
+            })
+            .collect()
+    };
+    [prefix_of(&edhrec_perm[0]), prefix_of(&edhrec_perm[1])]
+}
+
+fn build_walk_checkpoints<K: Eq + std::hash::Hash>(
+    cards: &[OracleCard],
+    offsets: &[u32],
+    edhrec_inv: &[Vec<u32>; 2],
+    perm_prefix_printings: &[Vec<u32>; 2],
+    keys_of: impl Fn(&OracleCard) -> Vec<K>,
+) -> HashMap<K, [WalkCheckpoints; 2]> {
+    let mut entries: HashMap<K, [Vec<(u32, u32)>; 2]> = HashMap::new();
+    for (cid, card) in cards.iter().enumerate() {
+        let span = offsets[cid + 1] - offsets[cid];
+        for key in keys_of(card) {
+            let e = entries.entry(key).or_insert_with(|| [Vec::new(), Vec::new()]);
+            for dir in 0..2 {
+                let pos = edhrec_inv[dir][cid] as usize;
+                // The "position" a checkpoint records is printings examined walking up to and
+                // including THIS card, not the card's own rank -- exact, since it comes straight off
+                // the prefix sum, not an averaged printings-per-card ratio.
+                e[dir].push((perm_prefix_printings[dir][pos], span));
+            }
+        }
+    }
+    entries
+        .into_iter()
+        .map(|(k, [asc, desc])| {
+            (k, [WalkCheckpoints::from_weighted_positions(asc), WalkCheckpoints::from_weighted_positions(desc)])
+        })
+        .collect()
+}
+
+/// `WalkCheckpoints` for the three card-space collection fields, EDHREC only -- the dimension that
+/// produced every `Perm`-branch mis-route measured this session, and (per `REALISTIC_FAMILY_WEIGHTS`)
+/// the dominant orderby by far. `art_tags`/`is_tags` are printing-space (no card permutation to build
+/// checkpoints against) and `frame_data` already routes around this via its own gate; not attempted.
+#[derive(Archive, Serialize, Deserialize, Default)]
+struct EdhrecWalkCheckpoints {
+    subtypes: HashMap<String, [WalkCheckpoints; 2]>,
+    keywords: HashMap<String, [WalkCheckpoints; 2]>,
+    oracle_tags: HashMap<String, [WalkCheckpoints; 2]>,
+}
+
+fn build_edhrec_walk_checkpoints(
+    cards: &[OracleCard],
+    offsets: &[u32],
+    coll_vocab: &[String],
+    edhrec_perm: &[Vec<u32>; 2],
+    edhrec_inv: &[Vec<u32>; 2],
+) -> EdhrecWalkCheckpoints {
+    let perm_prefix_printings = build_perm_prefix_printings(offsets, edhrec_perm);
+    EdhrecWalkCheckpoints {
+        subtypes: build_walk_checkpoints(cards, offsets, edhrec_inv, &perm_prefix_printings, |card| {
+            card.card_subtypes.iter().map(|v| coll_vocab[*v as usize].clone()).collect()
+        }),
+        keywords: build_walk_checkpoints(cards, offsets, edhrec_inv, &perm_prefix_printings, |card| {
+            card.card_keywords.iter().map(|v| coll_vocab[*v as usize].clone()).collect()
+        }),
+        oracle_tags: build_walk_checkpoints(cards, offsets, edhrec_inv, &perm_prefix_printings, |card| {
+            card.card_oracle_tags.iter().map(|v| coll_vocab[*v as usize].clone()).collect()
+        }),
+    }
+}
+
 /// A value is worth PAIRING only if it is broad enough that an estimate about it can change a routing
 /// decision. `STREAM_MIN_MATCHES` is that line: below it the sparse floor decides the plan, not the
 /// estimate's precision, and min-over-singles is already within a small factor of the truth.
@@ -3669,6 +3846,9 @@ struct CardIndexes {
     /// Exact 3-space totals for PAIRS of dense low-cardinality values (~14 KB), so a two-leaf `And` over
     /// them is answered rather than bounded by `min`.
     pair_totals:    PairTotals,
+    /// Where a card-space collection value's cards fall in EDHREC order, so the `Perm`-branch walk
+    /// length can be interpolated instead of assumed uniform. See `WalkCheckpoints`.
+    edhrec_walk_checkpoints: EdhrecWalkCheckpoints,
     sort_perms:     SortPermutations,          // card space (streamed selection)
     artwork_groups: Vec<u16>,                  // card space: distinct illustration groups
     // card space, n_cards+1 entries: prefix sum of artwork_groups, so card c's artworks are the
@@ -8589,6 +8769,23 @@ fn compose_leaf_nothing_to_verify(filter: &FilterExpr) -> bool {
     )
 }
 
+/// `WalkCheckpoints` for a bare card-space collection leaf, in the direction the query walks --
+/// `None` for every other filter shape (compound, wrong field, wrong op) and for a value the table
+/// happens not to cover (never built, so `len == 0`). Deliberately the SAME shape
+/// `compose_leaf_nothing_to_verify` matches: both ask "is this filter a bare Ge leaf on one of the
+/// three card-space fields", just for different reasons.
+fn edhrec_walk_checkpoints_for<'i>(indexes: &'i Archived<CardIndexes>, filter: &FilterExpr, descending: bool) -> Option<&'i Archived<WalkCheckpoints>> {
+    let FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value, .. } = filter else { return None };
+    let table = match field {
+        CollField::Subtypes => &indexes.edhrec_walk_checkpoints.subtypes,
+        CollField::Keywords => &indexes.edhrec_walk_checkpoints.keywords,
+        CollField::OracleTags => &indexes.edhrec_walk_checkpoints.oracle_tags,
+        CollField::ArtTags | CollField::IsTags | CollField::FrameData => return None,
+    };
+    let cp = &table.get(value.as_str())?[usize::from(descending)];
+    (cp.len > 0).then_some(cp)
+}
+
 /// The candidate materialization + filter rewriting shared by `StreamedSelect`
 /// and `GatheredScan`, extracted verbatim from `run_query`. Mutates `filter` via
 /// `memoize_text_predicates` + `order_children_by_verify_cost` under the same
@@ -10049,6 +10246,7 @@ fn mk_plan_feats(
         project_printings: 0,  // PrintingCompose's card/artwork projection pass; CardRangePopcount sets it too (for costing compose)
         popcount_words: 0,     // PrintingCompose overrides this (result-space bitmap words)
         compose_paging: ComposePaging::Gather, // PrintingCompose overrides this (which paging strategy it'll actually use)
+        walked_hint: None, // PrintingCompose's bare-collection-leaf-on-EDHREC branch overrides this
         // `run_query_streamed`'s per-card artwork overhead applies to every candidate it visits, in
         // artwork mode only — so it rides `eval_domain` there and vanishes elsewhere. See
         // STREAM_ARTWORK_SEEN_PER_CARD_NS for the mechanism and the measurement.
@@ -10571,6 +10769,14 @@ fn acquire_plan_features(
             .flatten();
         feats.compose_paging =
             compose_paging_with_total(indexes, cards.len(), composed, mode, sort_col, descending, Some(result_total), gather_declines);
+        // `WalkCheckpoints` only covers `unique=printing` ordered by EDHREC today (see its doc for why
+        // printing mode specifically: a card-level match can contribute more than one printing at
+        // once, which is what the table is built to weight by). `filter`, not `composed`: the same
+        // "ask about what the WALK sees" reasoning `compose_leaf_nothing_to_verify`'s call site uses.
+        if matches!(mode, Mode::Printing) && matches!(sort_col, SortCol::EdhrecRank) {
+            let k = (params.page_offset as u32).saturating_add(params.limit as u32).min(result_total as u32);
+            feats.walked_hint = edhrec_walk_checkpoints_for(indexes, filter, descending).and_then(|cp| cp.walk_length_for(k));
+        }
         (feats, Prep::Range(CountSource::PrintingCompose))
     } else {
         let prep = prepare_candidates(ctx, params, filter, plane);
@@ -11790,7 +11996,10 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 // 2026082301 — `ValueTotals` gains `colors`/`color_identity`/`produced_mana`, exact per-combination
 // totals for `ColorCmp`. Same blind spot as the previous bump: entirely inside `CardIndexes`, so the
 // header's `AOracleCard`/`APrinting` sizes don't move and can't catch it.
-const ARCHIVE_FORMAT_VERSION: u32 = 2026082301;
+//
+// 2026082302 — new `CardIndexes` field `edhrec_walk_checkpoints` (`WalkCheckpoints` for subtypes/
+// keywords/oracle_tags against the EDHREC permutation). Same blind spot again.
+const ARCHIVE_FORMAT_VERSION: u32 = 2026082302;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -12335,6 +12544,11 @@ impl QueryEngine {
             &coll_vocab,
             usize::from(artwork_group_counts.iter().copied().max().unwrap_or(0)),
         );
+        // Out here (rather than inline in the struct literal, like `pair_totals`/`value_totals` above)
+        // because `edhrec_walk_checkpoints` needs its `edhrec_inv` before the literal moves `cards`.
+        let sort_perms = build_sort_permutations(&cards);
+        let edhrec_walk_checkpoints =
+            build_edhrec_walk_checkpoints(&cards, &offsets, &coll_vocab, &sort_perms.edhrec, &sort_perms.edhrec_inv);
         let value_totals = build_all_value_totals(
             &cards,
             &printings,
@@ -12388,7 +12602,8 @@ impl QueryEngine {
             price_eur_cards,
             price_tix_cards,
             collector_number_cards,
-            sort_perms:     build_sort_permutations(&cards),
+            sort_perms,
+            edhrec_walk_checkpoints,
             max_artwork_groups: artwork_group_counts.iter().copied().max().unwrap_or(0),
             artwork_groups: artwork_group_counts,
             // Columnar copy of each printing's assigned artwork_group_id, derived here — the single

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -7362,12 +7362,27 @@ struct ComposeEstimate {
     candidate: usize,
     broadcast: usize,
     scatter: usize,
+    /// Printings a CARD-SPACE collection leaf's build broadcasts (`ids_of` +
+    /// `broadcast_card_ids_to_printings`) -- kept apart from `scatter` because it is a different,
+    /// pricier operation (a card-cursor lookup per id, then a variable-width printing-range fill) than
+    /// a range's contiguous slice-scatter. Measured riding `scatter`'s rate on `otag:triggered-ability`
+    /// /`otag:cycle`/`otag:activated-ability`: 2.7-2.9x too cheap, consistently across all three (see
+    /// `COMPOSE_COLLECTION_BROADCAST_PER_PRINTING_NS`). Printing-space collection leaves (art_tags/
+    /// is_tags) still ride `scatter`: their build IS a contiguous `bits()` copy, the same shape a
+    /// range's is, and measured fine.
+    collection_broadcast: usize,
 }
 
 impl ComposeEstimate {
     /// A leaf: nothing to tighten, so both figures are the same count.
     fn leaf(k: usize, broadcast: usize, scatter: usize) -> Self {
-        Self { result: k, candidate: k, broadcast, scatter }
+        Self { result: k, candidate: k, broadcast, scatter, collection_broadcast: 0 }
+    }
+
+    /// A card-space collection leaf specifically -- see `collection_broadcast`'s doc for why this
+    /// isn't just `leaf(k, 0, k)`.
+    fn collection_leaf(k: usize) -> Self {
+        Self { result: k, candidate: k, broadcast: 0, scatter: 0, collection_broadcast: k }
     }
 }
 
@@ -7397,6 +7412,7 @@ fn compose_printing_estimate(
                     candidate: a.candidate.min(c.candidate),
                     broadcast: a.broadcast + c.broadcast,
                     scatter: a.scatter + c.scatter,
+                    collection_broadcast: a.collection_broadcast + c.collection_broadcast,
                 });
             // Tighten the `min` bound with every PAIR of children the table stores. `min` over singles
             // lets the most selective leaf decide alone, which is why `f:modern r:rare border:white`
@@ -7419,6 +7435,7 @@ fn compose_printing_estimate(
                     candidate: a.candidate + c.candidate,
                     broadcast: a.broadcast + c.broadcast,
                     scatter: a.scatter + c.scatter,
+                    collection_broadcast: a.collection_broadcast + c.collection_broadcast,
                 });
             ComposeEstimate {
                 result: summed.result.min(n_printings),
@@ -7454,17 +7471,20 @@ fn compose_printing_estimate(
         }
         // Collection containment leaf (`type:`/`kw:`/`otag:`/`art:`/`is:`, `Ge`): `k` = the exact
         // printing count the leaf matches (card-space sums the matching cards' printing ranges,
-        // printing-space is the postings length). The build scatters `k` printings → rides `scatter`,
-        // the cheap range-slice rate.
+        // printing-space is the postings length). Card-space fields build via `ids_of` +
+        // `broadcast_card_ids_to_printings` (a card-cursor lookup per id) -- `collection_broadcast`,
+        // not `scatter`. Printing-space fields build via a contiguous `bits()` copy, the same shape a
+        // range's scatter is, so they keep riding `scatter`'s rate.
         FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value, .. }
             if collection_compose_index(indexes, *field).is_some() =>
         {
             let src = collection_compose_index(indexes, *field).expect("guarded by the if");
             let k = collection_leaf_printing_count(&src, value.as_str(), offsets);
-            ComposeEstimate::leaf(k, 0, k)
+            if src.card_space { ComposeEstimate::collection_leaf(k) } else { ComposeEstimate::leaf(k, 0, k) }
         }
-        // Negated collection leaf: all printings minus the positive `k`; the scatter cost rides the
-        // (small) positive `k` cleared, not the (large) complement it produces — same shape as `-set:`.
+        // Negated collection leaf: all printings minus the positive `k`; the build cost rides the
+        // (small) positive `k` cleared, not the (large) complement it produces — same shape as `-set:`,
+        // and the same card-space-vs-printing-space split as the positive leaf above.
         FilterExpr::Not(inner)
             if matches!(inner.as_ref(), FilterExpr::CollectionCmp { field, op: CmpOp::Ge, .. } if collection_compose_index(indexes, *field).is_some()) =>
         {
@@ -7473,7 +7493,12 @@ fn compose_printing_estimate(
             };
             let src = collection_compose_index(indexes, *field).expect("guarded by the matches!");
             let k = collection_leaf_printing_count(&src, value.as_str(), offsets);
-            ComposeEstimate::leaf(n_printings.saturating_sub(k), 0, k)
+            let complement = n_printings.saturating_sub(k);
+            if src.card_space {
+                ComposeEstimate { result: complement, candidate: complement, broadcast: 0, scatter: 0, collection_broadcast: k }
+            } else {
+                ComposeEstimate::leaf(complement, 0, k)
+            }
         }
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op, rhs: NumExpr::Const(c) } => {
             ComposeEstimate::leaf(popcount(&rarity_cmp_leaf_bits(*op, *c, &indexes.rarity_printing, n_printings)), 0, 0)
@@ -10247,6 +10272,7 @@ fn mk_plan_feats(
         popcount_words: 0,     // PrintingCompose overrides this (result-space bitmap words)
         compose_paging: ComposePaging::Gather, // PrintingCompose overrides this (which paging strategy it'll actually use)
         walked_hint: None, // PrintingCompose's bare-collection-leaf-on-EDHREC branch overrides this
+        collection_broadcast_printings: 0, // PrintingCompose overrides this for a card-space collection leaf
         // `run_query_streamed`'s per-card artwork overhead applies to every candidate it visits, in
         // artwork mode only — so it rides `eval_domain` there and vanishes elsewhere. See
         // STREAM_ARTWORK_SEEN_PER_CARD_NS for the mechanism and the measurement.
@@ -10521,7 +10547,7 @@ fn acquire_plan_features(
         // execution have to agree on which representation this plan is being judged on.
         let composed = compose_source(filter, unsplit, plane);
         let est = compose_printing_estimate(composed, indexes, offsets, n_printings as usize);
-        let (printing_matches, broadcast, scatter) = (est.result, est.broadcast, est.scatter);
+        let (printing_matches, broadcast, scatter, collection_broadcast) = (est.result, est.broadcast, est.scatter, est.collection_broadcast);
         // Two build kinds, charged at different rates: `broadcast` = legality broadcast-down (linear
         // pass), `scatter` = range-slice scatter (cheap). `project` = the second pass (printing→
         // card/artwork), 0 for printing mode. Keeping all three separate is what lets a bare range's
@@ -10741,6 +10767,7 @@ fn acquire_plan_features(
         };
         feats.broadcast_printings = broadcast as u32;
         feats.scatter_printings = scatter as u32;
+        feats.collection_broadcast_printings = collection_broadcast as u32;
         feats.project_printings = project as u32;
         feats.popcount_words = popcount_words as u32;
         feats.compose_scan_printings = (printing_matches as f64 * COMPOSE_GATHER_SPAN_PER_MATCH) as u32;

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -5207,7 +5207,7 @@ fn plan_cost_model_matches_gold() {
                     residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                     limit: limit as u32,
                     offset: offset as u32,
-                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None,
+                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None, collection_broadcast_printings: 0,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
@@ -5449,7 +5449,7 @@ fn plan_cost_refit() {
                     residual_tier_ns100: if prep.all_match_known { 0 } else { verify_cost_tier(&res) },
                     residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                     limit: limit as u32, offset: offset as u32,
-                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None,
+                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None, collection_broadcast_printings: 0,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
@@ -5654,7 +5654,7 @@ fn printing_range_route_probe() {
                 residual_tier_ns100,
                 residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                 limit: LIMIT as u32, offset: offset as u32,
-                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None, collection_broadcast_printings: 0,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
@@ -6017,7 +6017,7 @@ fn plan_regret_report() {
                 residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                 limit: limit as u32,
                 offset: offset as u32,
-                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None, collection_broadcast_printings: 0,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
@@ -6147,7 +6147,7 @@ fn plan_regret_fuzz() {
                 residual_tier_ns100: tier,
                 residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                 limit: limit as u32, offset: offset as u32,
-                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None, collection_broadcast_printings: 0,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     and_child_rank, assign_name_ranks,
     build_numeric_index, build_oracle_text_index, build_trigram_index,
-    build_rarity_index, build_flavor_index, build_hybrid_tag_index, bitmap_beats_postings, HybridTagIndex, build_sort_permutations,
+    build_rarity_index, build_flavor_index, build_hybrid_tag_index, bitmap_beats_postings, HybridTagIndex, build_sort_permutations, EdhrecWalkCheckpoints,
     assign_artwork_groups, build_artwork_base_from, build_bit_planes, build_border_printing_planes, build_rarity_printing_planes, build_divergent_ids, build_name_bigram_index, build_name_unigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_printing_value_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
@@ -5207,7 +5207,7 @@ fn plan_cost_model_matches_gold() {
                     residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                     limit: limit as u32,
                     offset: offset as u32,
-                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
+                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
@@ -5449,7 +5449,7 @@ fn plan_cost_refit() {
                     residual_tier_ns100: if prep.all_match_known { 0 } else { verify_cost_tier(&res) },
                     residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                     limit: limit as u32, offset: offset as u32,
-                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
+                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
@@ -5654,7 +5654,7 @@ fn printing_range_route_probe() {
                 residual_tier_ns100,
                 residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                 limit: LIMIT as u32, offset: offset as u32,
-                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
@@ -6017,7 +6017,7 @@ fn plan_regret_report() {
                 residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                 limit: limit as u32,
                 offset: offset as u32,
-                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
@@ -6147,7 +6147,7 @@ fn plan_regret_fuzz() {
                 residual_tier_ns100: tier,
                 residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                 limit: limit as u32, offset: offset as u32,
-                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather, walked_hint: None,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
                 gather_group_printings: 0,
@@ -6472,6 +6472,7 @@ fn bench_checked_vs_unchecked_access() {
         art_tags:       build_hybrid_tag_index(&printings, &vocab.strings, |p| &p.card_art_tags),
         is_tags:        build_hybrid_tag_index(&printings, &vocab.strings, |p| &p.card_is_tags),
         frame_data:     HybridTagIndex::default(),
+        edhrec_walk_checkpoints: EdhrecWalkCheckpoints::default(),
         artists:        ArtistIndex::default(),
         flavor:         build_flavor_index(&printings, &strings),
         set_codes:      HashMap::new(),


### PR DESCRIPTION
Split from #1008 into an individually-reviewable chunk — see that PR's description for the full context this arose from. Fully independent of the other splits.

`docs/issues/local-engine-compose-paging-cost-based.md` leaves the Perm/OrderbyWalk walk-length estimate ("how many printings does the walk examine to fill a page") as a single global rate, and says plainly that "how matches clump along a sort order is not something a density ratio can see, and no constant will fix that." `otag:triggered-ability` measured exactly that: the formula predicted 602 printings walked against a real 1,942 — a 3.2x miss a ~10% printings-per-matching-card skew cannot explain, so the error is EDHREC-order clumping specific to this value, not a rate problem.

**`WalkCheckpoints`** replaces the single rate with five exact anchors per (value, direction): the permutation position at which cumulative PRINTINGS from matching cards reaches 1/100/200/400/800 (not card count — a card-level match can contribute many printings at once, so the threshold has to be printing-weighted). Interpolated at query time between whichever two anchors bracket `offset+limit`. 20 bytes per (value, direction), built once at store time from data already computed for other purposes.

Scoped to `unique=printing` ordered by EDHREC, `subtypes`/`keywords`/`oracle_tags` only: the dominant orderby (40% of `REALISTIC_ORDERBY_WEIGHTS`) and exactly the fields producing every `otag:`-shaped mis-route measured this session. `art_tags`/`is_tags` are printing-space (no card permutation to build against); card/artwork mode and the other 7 orderby columns are unattempted.

Verified against the real corpus: `printings_walked` now predicts 1,998 against a realized 1,942 (2.9% off, down from the old formula's 602 — a 3.2x miss). The mechanism is real: only 50 cards need visiting to accumulate 1,942 printings, because EDHREC's most popular cards are disproportionately old, heavily-reprinted staples (~39 printings/card among the first 50, against a 3.1 corpus average) — genuine clumping, not noise.

**Second commit, found while validating the first**: `compose_printing_estimate`'s `CollectionCmp` arm charges a card-space collection leaf's build at `COMPOSE_SCATTER_PER_PRINTING_NS`, whose own doc comment says it is calibrated for a range's cheap contiguous scatter — but a card-space leaf's actual build (`ids_of` + `broadcast_card_ids_to_printings`) needs a card cursor that rate assumes away. Backed out a real rate (1.30-1.41 ns/printing, 2.7-2.9x the range rate) from the same three `otag:` queries. Together the two commits flip real routing: all three now correctly pick `StreamedSelect` over `PrintingCompose`, both plans predicted within 0.90-1.08x of measured.

## Verification (re-run standalone against current `main`)
- `cargo test --release`: 157 passed, 0 failed
- `cargo clippy --release --all-targets`: clean (one pre-existing unrelated dead-code warning)

Bumps `ARCHIVE_FORMAT_VERSION` (new `CardIndexes` field `edhrec_walk_checkpoints`). If another open split also bumps it and merges first, this one needs a trivial rebase to the next number.
