### PR TITLE
Docs: Record the Card-Mode matches Estimate Investigation and a Sixth Reverted Refit

### DIFF
--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -153,6 +153,11 @@
 //! support for that ordering -- P3's dispatch median is 32 us against P4's 4 us, and its finish phase is
 //! 12% of all measured ns at mean |log| 2.06.
 //!
+//! **That "applying both arms together" attempt happened (2026-08-23, `bench_streamed_loop`'s own
+//! module docs), after a real feature fix, and still regressed -- through P3/P4-vs-`PrintingCompose`
+//! distortion, not P3-vs-P4 compensating error. See the sixth row of that file's history table before
+//! trying this again: a joint refit needs every plan in the same argmin refit together, not just P3+P4.
+//!
 //! One further limit on all of these: `LIMIT` is fixed, so nothing here constrains how the rates
 //! behave as the page grows.
 //!

--- a/card_engine/src/bench_streamed_loop.rs
+++ b/card_engine/src/bench_streamed_loop.rs
@@ -102,6 +102,54 @@
 //!     P4 reparameterised                        +40%
 //!     P3 and P4 both refit                      +30%
 //!     ... plus symmetric residual floors        +90%
+//!     P3+P4 refit AGAIN after fixing scan_units +54% (mean regret 0.50 -> 0.56 us/query)
+//!
+//! **The sixth attempt (2026-08-23) is not a repeat of the first four.** It came after fixing a real
+//! feature bug (`scan_units`'s card-mode overcharge, `local-engine-card-residual-pass-rate.md`'s
+//! companion) and refitting P3+P4 jointly on the corrected data -- the exact prerequisite this file's
+//! own conclusion asked for. It still regressed, but through a DIFFERENT mechanism than the first five:
+//! not P3-vs-P4 compensating error (fixing the feature and refitting both arms together handles that),
+//! but P3/P4-vs-`PrintingCompose` distortion. `PrintingCompose` was deliberately left unrefit (its own
+//! `Perm` arm is missing a `cards_visited` feature -- see `local-engine-compose-build-rates.md`), so
+//! making P3/P4 cheaper without touching it made them win against `PrintingCompose` in cases where
+//! `PrintingCompose` was actually correct: `PrintingCompose -> StreamedSelect` went from a minor cell to
+//! 309 queries at 99% miss rate and 32% of all lost time, and the `printing_compose` acquire branch's
+//! total share jumped to 72%. Reverted. The lesson generalizes past this one pair: **a joint refit is
+//! only as joint as every plan that competes in the same argmin, not just the two you fixed a feature
+//! for.** `PrintingCompose` needs its own feature fix (the `cards_visited` estimator) before ANY of its
+//! rates -- or any rate for a plan that regularly competes against it -- can be safely moved again.
+//! Full mechanism and revert data:
+//! [local-engine-p3-p4-joint-refit-vs-compose.md](../../docs/issues/local-engine-p3-p4-joint-refit-vs-compose.md).
+//!
+//! The fitted values that attempt computed, for whoever builds the `PrintingCompose` feature fix and
+//! retries this (`fit_cost_model.py` on ~111k/~83k rows post `scan_units` fix, `mirror_matches_engine`
+//! 99.8%; `x` is fitted/shipped):
+//!
+//!     GatheredScan                          shipped  fitted     x
+//!       GATHER_LOOP_PER_CARD_NS                3.88    4.52  1.17
+//!       GATHER_SCAN_PER_ROW_NS                 2.06    2.71  1.32
+//!       CARD_PASS+FLOOR (call held at 3.00)   21.89   24.07  1.10   -> floor 21.07
+//!       GATHER_PUSH_PER_MATCH_NS               2.24    2.05  0.92
+//!       GATHER_SELECT_PER_PAGE_SLOT_NS         3.51    3.32  0.94
+//!       GATHER_COLLECT_PER_PAGE_ROW_NS         9.79    8.41  0.86
+//!       GATHER_ARTWORK_PER_PRINTING_NS         0.50    0.51  1.02   (kernel-measured; left alone)
+//!       GATHER_FIXED_COST_NS                 169.60   93.59  0.55   (curvature-confounded; NOT applied)
+//!
+//!     StreamedSelect                         shipped  fitted     x
+//!       STREAM_LOOP_PER_CARD_NS                2.58    3.20  1.24
+//!       STREAM_SCAN_PER_ROW_NS                 5.97    5.90  0.99
+//!       CARD_PASS+FLOOR (call held at 2.47)    9.05   10.42  1.15   -> floor 7.95
+//!       STREAM_EMIT_PER_MATCH_NS               0.12    0.11  0.95
+//!       STREAM_PERM_STEP_NS                    1.00    1.24  1.24
+//!       STREAM_ARTWORK_SEEN_PER_CARD_NS        1.21    1.10  0.91
+//!       STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS   1.02    0.98  0.96   (already confirmed; left alone)
+//!       STREAM_CORPUS_PASS_PER_CARD_NS         0.02    0.01  0.67   (2 sig figs on an unseparable
+//!                                                                    constant; left alone)
+//!       STREAM_FIXED_COST_NS                 217.00  192.69  0.89   (curvature-confounded; NOT applied)
+//!
+//! `plan_cost_model_matches_gold` on these: 97.7% -> 98.9%. Total routing regret on a uniform sample:
+//! 0.50 -> 0.56 us/query mean, i.e. the gold-test metric improved while the thing that actually matters
+//! got worse -- the reason to gate on the full regret-matrix breakdown, not a single summary number.
 //!
 //! Every one regressed, and the best was the one that moved LEAST from the shipped values. Two of the
 //! attempts were diagnosed and corrected mid-flight -- artwork needed its own arm, and leaving P4's

--- a/docs/issues/local-engine-card-residual-pass-rate.md
+++ b/docs/issues/local-engine-card-residual-pass-rate.md
@@ -1,0 +1,94 @@
+# Card mode's `matches` estimate is bimodal, and a flat pass rate makes it worse, not better
+
+`candidate_feats`'s `Mode::Card` arm sets `matches = count` (the raw candidate-card count) with no
+discount at all, unlike `Mode::Printing`/`Mode::Artwork`, which apply a fitted `RESIDUAL_PASS_RATE_*`.
+That is provably wrong whenever a residual conjunct survives narrowing and is genuinely selective: real
+`matches_pushed` can run up to 132x lower than the `matches` estimate. It has real absolute cost at
+scale (tens of microseconds at large `eval_domain`), and no cheap fix was found. Documented so the next
+pass at this doesn't re-derive the same dead end.
+
+## Why this looked fixable
+
+`matches` only feeds one term in each plan's formula — `GATHER_PUSH_PER_MATCH_NS` (2.24 ns/match) and
+`STREAM_EMIT_PER_MATCH_NS` (0.12 ns/match) — so the natural fix looked like the same shape as the
+`scan_units` card-mode fix landed alongside this investigation: find the systematic bias, add a
+targeted correction.
+
+Concrete examples, all compound (multi-predicate) card-mode queries with a residual:
+
+| query | eval_domain | matches (est) | matches_pushed (real) | ratio |
+| --- | --: | --: | --: | --: |
+| `o:surveil frame:2003` | 215 | 215 | 1 | 215.0x |
+| `ft:shadow year<1995` | 226 | 226 | 3 | 75.3x |
+| `name:ja tix<0.02` | 272 | 272 | 5 | 54.4x |
+| `cn:141 o:nonlegendary` | 40 | 40 | 1 | 40.0x |
+
+The mechanism: `narrow_candidates_exact` narrows on whichever conjunct it can index (`frame:2003`,
+`tix<0.02`, `cn:141`, ...), leaving the *other* conjunct (`o:surveil`, `year<1995`, `o:nonlegendary`) as
+a per-candidate residual whose own selectivity `matches = count` does not account for at all.
+
+## Why the ratio looked bigger than the impact, at first
+
+The four examples above are all small (`eval_domain` 40-272) and their absolute measured times are
+0.75-5.6 µs. Decomposed: for `is:vanilla id:bw frame:etched` (eval_domain 132), the push-term overcharge
+is 293 ns against a 4,437 ns total prediction gap (measured 750 ns vs predicted 5,187 ns) — about 7% of
+the error. The other 93% is the already-known, already-deferred `GATHER_RESIDUAL_FLOOR_NS` overcharge
+(`eval_domain * max(tier, 18.89)` ≈ 132 × 21.89 ≈ 2,889 ns alone). At this scale the ratio is dramatic
+and the absolute damage is not.
+
+That stops being true at scale. Bucketing the real push-term overcharge (`(matches_est -
+matches_pushed) * 2.24 ns`) by `eval_domain`:
+
+| eval_domain bucket | n | median overcharge | p90 | p99 | max |
+| --- | --: | --: | --: | --: | --: |
+| [0, 100) | 13,278 | 0 ns | 27 ns | 134 ns | 215 ns |
+| [100, 1,000) | 3,820 | 0 ns | 488 ns | 1,214 ns | 2,038 ns |
+| [1,000, 10,000) | 2,860 | 651 ns | 5,773 ns | 12,768 ns | 21,517 ns |
+| [10,000, ∞) | 1,008 | 10,062 ns | 26,990 ns | 38,958 ns | 52,477 ns |
+
+Small queries hide it (as expected — everything hides in a query whose whole cost is under a
+microsecond); large ones don't.
+
+## Why no fix shipped
+
+The real pass rate (`matches_pushed / count`) is **bimodal**, not a population that a single constant
+discount can describe:
+
+| population | n | median | geomean | mean | p10 | p90 |
+| --- | --: | --: | --: | --: | --: | --: |
+| compound (multi-predicate) filters | 16,532 | **1.000** | 0.711 | 0.817 | 0.350 | **1.000** |
+| bare (single-predicate) residuals | 4,614 | 1.000 | 0.954 | 0.980 | 1.000 | 1.000 |
+
+Even restricted to compound filters, both the median *and* p90 real pass rate are 1.000 — the
+low-pass-rate tail dragging the geomean down to 0.711 is confined to well under 10% of compound
+queries. A flat `CARD_RESIDUAL_PASS_RATE` fitted to that geomean would under-predict the ~90% of
+compound queries that need no discount at all, while still not reaching the severe end (pass rates
+measured down to ~0.03 on the worst rows) — a bad trade in both directions.
+
+This is not a new failure mode for this codebase. `candidate_feats`'s own doc comment on the
+`Printing`/`Artwork` discount records the same experiment already run and rejected one mode over:
+`estimator::estimate_cardinality` (index-backed, independence-assumption over `And`) was tried
+specifically to do better than a flat rate there, and measured *worse* — "card mean |log| 1.31 against
+0.79, p90 33.38 against 9.91". Nothing here suggests a naive estimator would fare differently for card
+mode's version of the same problem, and the data above says a *flat rate* specifically loses on the
+majority case, which the printing/artwork rate does not (that population isn't bimodal the same way).
+
+## If someone wants to fix this properly
+
+The honest fix is a real per-query cardinality estimate for the *leftover, unnarrowed* residual
+conjunct — not a global rate. Candidates worth trying, none attempted here:
+
+- A conditional correction gated on a cheap, specific signal rather than "is the filter compound":
+  e.g., only apply a discount when the residual conjunct is itself index-backed (a second
+  `CollectionCmp`/range leaf that narrowing didn't pick), where an exact or near-exact count might be
+  cheaply available — the same shape as the `RangeCardCounts::distinct_cards` 9%-coverage path already
+  used elsewhere in this file, adapted to cover more of the compound population.
+- Keying off `proven_conjuncts`: an `And` where narrowing proved *all but one* conjunct is a
+  structurally different case from one where narrowing only partially covers a single unproven
+  conjunct's own selectivity — the current investigation treated "compound vs bare" as the whole
+  signal, but `proven_conjuncts`'s bit count is already computed and unused for this purpose.
+
+## Status
+
+Documented, not implemented. Land alongside `scan_units`'s card-mode fix (same investigation,
+different outcome) as the record of what was tried and why it didn't ship.

--- a/docs/issues/local-engine-compose-build-rates.md
+++ b/docs/issues/local-engine-compose-build-rates.md
@@ -125,3 +125,16 @@ Nothing shipped. The rate measurements are on the production corpus across 0.5x-
 justified by two instruments on two seeds. Not attempted: the joint refit, and the `Perm` per-card
 feature (which needs an estimator for `cards_visited`, plausibly `printings_walked / printings_per_card`,
 ungraded).
+
+**Still true, reconfirmed while joint-refitting `GatheredScan`/`StreamedSelect` in the same session
+that fixed `scan_units`'s card-mode overcharge.** `fit_cost_model.py`'s general fit still cannot
+separate `WALK_STEP` cleanly for the same reason: it fits against the ESTIMATED feature vector
+`plan_cost` reads today, which has no `cards_visited` column for `Perm` to fit against, so the
+question this doc's own hand-built design already answered (add the column, the rate resolves to
+0.31 against `OrderbyWalk`'s near-identical 0.31) never gets re-asked by the general harness — it
+just reports whatever number the wrong shape produces. `PrintingCompose` was excluded from that
+joint refit for exactly this reason: fitting a arm whose shape is known-wrong would ship coefficients
+that compensate for the missing column, which is the same mistake the original 1.07 popcount rate was
+already compensating for. The `GatheredScan`/`StreamedSelect` pair had no equivalent known gap, so it
+went ahead alone. Whoever picks this up next needs the `cards_visited` ESTIMATOR (not just the
+diagnostic column) built and graded before `PrintingCompose`'s rates are worth touching at all.

--- a/docs/issues/local-engine-p3-p4-joint-refit-vs-compose.md
+++ b/docs/issues/local-engine-p3-p4-joint-refit-vs-compose.md
@@ -1,0 +1,69 @@
+# A correct P3+P4 joint refit still regresses routing, because PrintingCompose didn't move
+
+After fixing a real feature bug (`scan_units`'s card-mode overcharge — see
+[local-engine-card-residual-pass-rate.md](local-engine-card-residual-pass-rate.md) for its unfixed
+sibling), `GatheredScan` and `StreamedSelect` were refit jointly on the corrected data — the exact
+prerequisite [bench_streamed_loop.rs](../../card_engine/src/bench_streamed_loop.rs)'s own conclusion
+asked for after its five earlier refit attempts all regressed. It still regressed, through a different
+mechanism than any of those five. Implemented, measured, reverted.
+
+## What was different this time
+
+The five prior attempts (`bench_streamed_loop.rs`'s module docs) all failed because of **P3-vs-P4
+compensating error**: the shipped rates were jointly tuned so that P4's over-estimate and P3's
+over-estimate cancelled in their comparison, and refitting one or both broke that cancellation without
+fixing what caused it. This attempt came after fixing the actual feature bug behind
+`GatheredScan`/`candidates`'s over-prediction, refit both arms' shape/per-unit-rate terms together
+(holding the two `*_FIXED_COST_NS` constants and two already-flagged noise-floor constants unchanged —
+see the commit for which and why), and the P3-vs-P4 relationship specifically improved:
+`plan_cost_model_matches_gold` went 97.7% → 98.9%.
+
+## What regressed instead
+
+Every plan that competes against `GatheredScan`/`StreamedSelect` in the same argmin, not just each
+other. `PrintingCompose` was deliberately left unrefit — its `Perm` arm is missing a `cards_visited`
+feature entirely (`local-engine-compose-build-rates.md`), so its rates cannot be safely refit until
+that's built. Making P3/P4 cheaper without touching `PrintingCompose` made them win against it wherever
+`PrintingCompose` was actually correct:
+
+| transition | before (n, miss%, share) | after (n, miss%, share) |
+| --- | --- | --- |
+| `PrintingCompose -> StreamedSelect` | minor cell | **309, 99%, 32%** |
+| `PrintingCompose -> GatheredScan` | minor cell | **93, 99%, 6%** |
+| `printing_compose` acquire branch, total share | ~47-58% | **72%** |
+| mean regret per query (uniform sample) | 0.50 µs | **0.56 µs** |
+
+The mechanism is exactly [local-engine-compose-build-rates.md](local-engine-compose-build-rates.md)'s
+finding in reverse: that doc made `PrintingCompose` cheaper in isolation and watched it over-win against
+`GatheredScan`/`StreamedSelect`; this made the other two cheaper in isolation and watched them over-win
+against `PrintingCompose`. Same failure, opposite direction, same root cause — refitting one side of an
+argmin without the other.
+
+## The generalization
+
+**A joint refit is only as joint as every plan that competes in the same decision, not just the two you
+happened to fix a feature for.** Fixing `GatheredScan`+`StreamedSelect`'s shared feature bug and
+refitting them together was necessary but not sufficient — `PrintingCompose` sits in the same argmin for
+every `printing_compose`-acquired query (a plurality of traffic; see its 47-72% share across every
+sweep this session), and any rate change to the plans it competes against needs it in the same
+refit-and-gate cycle. It cannot be, until its own feature gap closes first.
+
+## If someone wants to try this again
+
+1. Build the `cards_visited` estimator `local-engine-compose-build-rates.md` names as missing (it names
+   `printings_walked / printings_per_card` as one candidate, explicitly ungraded).
+2. Wire it into `PrintingCompose`'s `Perm` arm as a real `plan_cost` feature, not just a diagnostic
+   column.
+3. Grade it against the realized `cards_visited` counter the way `scan_units` is graded against
+   `printings_examined`.
+4. Only then refit `GatheredScan`, `StreamedSelect`, AND `PrintingCompose` together, gated on the full
+   regret-matrix transition breakdown (not just the aggregate total, and not just the pair you fixed a
+   feature for) — the aggregate total or a single pair's improvement is not sufficient evidence, as this
+   attempt's own `plan_cost_model_matches_gold` improvement (97.7% -> 98.9%) demonstrates: that metric
+   moved the right way while total routing regret got 12% worse.
+
+## Status
+
+Reverted. `card_engine/src/cost.rs` is unchanged from before this attempt. The fitted values (for
+whoever picks this up once `PrintingCompose` has its feature fix) are recorded in
+`bench_streamed_loop.rs`'s and `bench_gather_loop.rs`'s module docs' history tables, not repeated here.


### PR DESCRIPTION
Split from #1008 into an individually-reviewable chunk — see that PR's description for the full context this arose from. Docs-only, no code changes, no behavior risk. Independent of the other splits.

Two investigations recorded rather than shipped, so the next pass at either starts from the measurements instead of re-deriving them:

**Card-mode `matches` estimate (Finding 2, unfixed)**: `Mode::Card`'s undiscounted `matches` = count estimate is provably wrong whenever a residual conjunct survives narrowing (up to 132x on the concrete examples measured, tens of microseconds of real absolute overcharge at large `eval_domain`) — but the real pass-rate distribution is bimodal (median and p90 both 1.000 even restricted to compound filters), so a flat discount rate would hurt the ~90% of queries that need none to chase a tail that needs far more than any single constant provides.

**A sixth reverted P3+P4 joint refit, this time vs `PrintingCompose`**: after fixing `scan_units`' card-mode feature bug (split separately), refit `GatheredScan`/`StreamedSelect` jointly on the corrected data. `plan_cost_model_matches_gold` improved 97.7% -> 98.9%. Reverted anyway: total routing regret got 12% worse, because `PrintingCompose` was deliberately left unrefit (its Perm arm is missing a `cards_visited` feature) and making the other two cheaper let them win against `PrintingCompose` in cases where it was actually correct. Fitted values recorded for whoever builds the missing estimator and retries this with all three plans refit together.

## Verification
Docs-only; `cargo test --release` / `cargo clippy` unaffected (157 passed, 0 failed against current `main`, same as the sibling splits).
