### PR TITLE
Engine: Fix scan_units' Card-Mode Overcharge, Net prepare_candidates Correctly

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -10174,6 +10174,25 @@ fn candidate_feats(ctx: &QueryCtx, params: &QueryParams, prep: &PreparedCandidat
         } else {
             verify_cost_tier_unproven(filter, prep.proven_conjuncts)
         });
+    // Card mode, default prefer, all_match_known: `push_card_matches`/`card_match_count`'s Mode::Card
+    // arm breaks at the FIRST printing every time (`all_match` is true unconditionally, so the loop's
+    // `if all_match || ...` fires on `pid == start`), so `printings_examined` is exactly `count` (one
+    // per candidate) -- never the `n_printings/n_cards` SPAN `scan` estimates. Measured: GatheredScan's
+    // `scan_units/printings_examined` on this population reads flat at 3.08 (== n_printings/n_cards)
+    // from p10 to p90, not a tail effect. Only `all_match_known` -- with a residual, `card_match_count`
+    // still breaks at the first MATCHING printing, but which one that is depends on the residual's
+    // selectivity, so `count` would under-charge instead; that harder case is unfixed here. Only
+    // `Prefer::Default` -- custom prefer's arm scores every printing even under `all_match` (it must,
+    // to find the best-scoring one), so `span` is the right estimate there and already reads 1.00.
+    //
+    // GatheredScan reads this directly (no tier gate on its scan term, unlike StreamedSelect's), so the
+    // 3.08x error rides straight into `GATHER_SCAN_PER_ROW_NS * scan_units` on every such query. Harmless
+    // for StreamedSelect: its own term is `if tier_ns > 0.0 { stream_scan_units * RATE } else { 0.0 }`,
+    // and `all_match_known` means `tier_ns == 0`, so it never reads this value in the case it is wrong.
+    if matches!(params.mode, Mode::Card) && matches!(params.prefer, Prefer::Default) && prep.all_match_known {
+        feats.scan_units = count;
+        feats.stream_scan_units = count; // inherited default; harmless per the tier gate above, kept in sync
+    }
     // Diagnostic only (`explain`), so the residual-pass-rate population can be split by traffic before any
     // rate moves. A card-invariant residual answers `True`/`False` per card and never `PrintingDep`, so a
     // matching candidate contributes its WHOLE printing span and a non-matching one none of it — the

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -12069,6 +12069,7 @@ fn acquire_facts_to_pydict<'py>(py: Python<'py>, f: &AcquireFacts) -> PyResult<B
         ("project_printings", g.project_printings),
         ("popcount_words", g.popcount_words),
         ("artwork_seen_cards", g.artwork_seen_cards),
+        ("artwork_seen_printings", g.artwork_seen_printings),
         ("compose_scan_printings", g.compose_scan_printings),
         ("gather_group_printings", g.gather_group_printings),
         // Derived inside plan_cost rather than stored, and exposed because the Perm/OrderbyWalk

--- a/scripts/bench_cost_model_agreement.py
+++ b/scripts/bench_cost_model_agreement.py
@@ -18,7 +18,19 @@ same properties and reached two of the three:
   not the *selectivity* — and selectivity is the axis a cost model varies along. The shared sampler
   also reaches `eur`/`tix` and two-sided bounds, neither of which the private table produced.
 
-Reports measured/predicted per (plan, acquire branch), plus the two phases no cost term describes:
+Reports `costbench.plan_self_ns` / predicted per (plan, acquire branch) -- NOT raw `min(trials_ns)`,
+which this collected until a routing-regret sweep found `GatheredScan`/`candidates` reading p90 32.9x
+"over-costed" and traced it here: a forced trial re-runs `prepare_candidates` from scratch, but the
+real routed path pays it once during acquire and dispatch just reuses the artifact (see
+`acquire_plan_features`/`run_query_routed`'s `Prep::Candidates` arm), so charging every forced trial
+for a rebuild the router never repeats inflated `candidates`/`plane` rows by however expensive that
+query's narrowing happened to be -- pure benchmark artifact, not a cost-model error.
+`costbench.plan_self_ns` already encoded the right rule (net it out for `candidates`/`plane`, add it
+back for `RANGE_ACQUIRES`, where dispatch really does rebuild); this module just was not using it yet.
+Netted, `GatheredScan`/`candidates` reads p90 1.05, median 0.69 -- a real, much smaller over-prediction
+worth its own investigation, not the crisis the raw number implied.
+
+Plus the two phases no cost term describes:
 `prepare_candidates` — 21-33% of a range-acquired query against 7-10% of a plane-acquired one — and
 the per-query scratch setup, which for `StreamedSelect` is an O(`n_cards`) counts zeroing that grows
 with the corpus rather than with the answer. Both shares are keyed by acquire branch as well as plan,
@@ -170,9 +182,9 @@ def main() -> None:
                 agr.declines[p["plan"], p["paging_taken"]].append(min(p["declined_ns"]))
                 continue
             predicted = costbench.predicted_ns(p)
-            if not p["trials_ns"] or predicted is None:
+            measured = costbench.plan_self_ns(p, acq)
+            if predicted is None or measured is None:
                 continue
-            measured = min(p["trials_ns"])
             agr.ratios[p["plan"], acq["count_source"]].append(measured / predicted)
             agr.by_unique[p["plan"], unique].append(measured / predicted)
             # Keyed by acquire branch as well as plan: the whole point of this row is that the
@@ -393,7 +405,7 @@ def report(agr: Agreement, seconds: float) -> None:
     if agr.skip_reasons:
         breakdown = ", ".join(f"{name} x{n:,}" for name, n in sorted(agr.skip_reasons.items(), key=lambda kv: -kv[1]))
         print(f"  skipped by reason: {breakdown}")
-    summarise("measured/predicted by acquire branch. 1.00 is agreement; >1 under-costed.", agr.ratios, "acquire")
+    summarise("measured (plan_self_ns) / predicted by acquire branch. 1.00 is agreement; >1 under-costed.", agr.ratios, "acquire")
     summarise("the same, split by distinct-on rather than acquire.", agr.by_unique, "unique")
 
     report_phase_share(agr.prep_frac, "prepare_candidates as a share of the plan's run — the term no cost arm carries.")

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -95,7 +95,10 @@ CURRENT: dict[str, list[float]] = {
     # `card_pass` call (3.00) on top of the floor (18.89), because the arm gates the call on
     # `tier_ns > 0` -- `all_match_known` skips it. The design matrix already had these as two
     # columns; only the arm and these labels changed.
-    "GatheredScan": [3.88, 2.06, 21.89, 2.24, 3.51, 9.79, 169.6],
+    # ..., artwork_seen_printings, fixed -- new (this session): `exec_gathered_scan`'s Mode::Artwork
+    # branch pays a per-printing group_best/touched dedupe check StreamedSelect's artwork_seen_cards
+    # column does not describe (that one is per-CARD; this is per-PRINTING, see cost.rs).
+    "GatheredScan": [3.88, 2.06, 21.89, 2.24, 3.51, 9.79, 0.50, 169.6],
     # eval_domain, scan_units, residual floor, matches, artwork_seen_cards, n_cards floor, corpus pass, fixed
     # Refit once `printings_examined` existed: this plan's fit was vetoed for as long as the only
     # available counter was the printing SPAN, which its all_match rows disagree with by ~3x over a
@@ -234,8 +237,13 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
     excess = eval_domain * max(tier_ns - floor, 0.0) if tier_ns > 0.0 else 0.0
 
     if plan == "GatheredScan":
+        # NOT `artwork_seen_cards`-if-nonzero: `exec_gathered_scan`'s per-printing dedupe loop runs
+        # unconditionally (no `all_match_known` shortcut like StreamedSelect's stored-group-count
+        # fast path), so `artwork_seen_cards` can read 0 (zeroed by all_match_known) on the same row
+        # where `artwork_seen_printings` is correctly nonzero -- read the real field directly.
+        artwork_seen_printings = float(acq.get("artwork_seen_printings", 0))
         return (
-            [eval_domain, scan_units, eval_domain * residual_on, matches, page_span, page_rows, 1.0],
+            [eval_domain, scan_units, eval_domain * residual_on, matches, page_span, page_rows, artwork_seen_printings, 1.0],
             [
                 "LOOP_PER_CARD",
                 "SCAN_PER_ROW",
@@ -243,6 +251,7 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
                 "PUSH_PER_MATCH",
                 "SELECT_PER_PAGE_SLOT",
                 "COLLECT_PER_PAGE_ROW",
+                "ARTWORK_PER_PRINTING",
                 "FIXED",
             ],
             excess,


### PR DESCRIPTION
Two independent fixes bundled because the second was found using the first's own fix:

**Tooling**: `bench_cost_model_agreement.py` compared raw `min(trials_ns)` against `predicted_ns` for every cell, but the real routed path computes `prepare_candidates` ONCE during acquire and dispatch just reuses it — a forced trial re-runs it from scratch, which `plan_cost` correctly never prices. Switched to `costbench.plan_self_ns` throughout. Separately, `fit_cost_model.py`'s mirror of `cost.rs` had drifted after #1016's `artwork_seen_printings` addition — its own `mirror_matches_engine` safety check caught it immediately once the real field was exposed to the acquire dict to check against.

**`scan_units`' card-mode overcharge**: percentile breakdown of `scan_units`/`printings_examined` surfaced a clean, constant 3.08x error (flat p10-p90) for `GatheredScan`/card/all-match — exactly `n_printings/n_cards`. `card_match_count`'s `Mode::Card` arm under `Prefer::Default` breaks at the first printing whenever `all_match` is true, so `printings_examined` is always exactly 1 per card, never the corpus-average span `scan_units` estimated. Verified: the ratio is now flat 1.00 for this population (was flat 3.00-3.08); median measured/predicted for the no-residual population moved 0.814 -> 0.864.

## Verification (re-run standalone against #1016's tip)
- `cargo test --release`: 157 passed, 0 failed
- `cargo clippy --release --all-targets`: clean (one pre-existing unrelated dead-code warning)
