### PR TITLE
Docs: Record PrintingCompose/Perm's Walk Cost-Model Miscalibration

### DIFF
--- a/docs/issues/01025-engine-compose-walk-cost-miscalibrated.md
+++ b/docs/issues/01025-engine-compose-walk-cost-miscalibrated.md
@@ -1,0 +1,85 @@
+# `PrintingCompose`/`Perm`'s cost model under-costs the walk by ~5x at the median
+
+Filed as [#1025](https://github.com/jbylund/sylvan_librarian/issues/1025).
+
+Found as a side effect of building a paging safety net for `Perm`'s Card-mode walk (see
+[#730](https://github.com/jbylund/sylvan_librarian/issues/730) and
+[local-engine-compose-perm-sigma-decision-rule.md](local-engine-compose-perm-sigma-decision-rule.md),
+not yet landed on `main`), not while looking for it — worth its own doc because it's a real,
+independently-shippable finding about `plan_cost`'s existing behavior, unrelated to whether that
+other work ever lands.
+
+## The finding
+
+`cost::plan_cost`'s `PhysicalPlan::PrintingCompose` / `ComposePaging::Perm` arm prices the walk as
+`printings_walked * COMPOSE_WALK_STEP_NS (0.58) + limit * COMPOSE_WALK_EMIT_PER_ROW_NS (2.19)`
+(`card_engine/src/cost.rs`). Graded against real, now-cleanly-isolated `walk_ns` (see below for why
+that's newly possible) on 2,705 real single-predicate `Mode::Card` `Perm` queries, offsets swept
+0-25,000:
+
+```
+predicted / realized:
+p0     p5     p10    p25    p50    p75    p90    p95    p100
+0.018  0.074  0.106  0.149  0.182  0.269  0.439  0.594  2.447
+```
+
+**Under-costs by ~5.5x at the median**, and it isn't a deep-offset-only artifact — broken out by
+offset, the ratio sits flat at 0.15-0.21 from offset 0 through 25,000. This is a real, directional
+bias, not the "wide but centered" variance `WALK_LENGTH_BIAS`'s own doc already concedes.
+
+## Why this wasn't visible before
+
+`explain_analyze`'s `ns_loop` for `PrintingCompose` used to bundle compose-build time (`compose_
+printing_bits` etc.) together with the paging walk as one undivided span — confirmed by reading
+`card_engine/src/lib.rs`: `t_start` started before the compose call ran. That's a real confound for
+grading the walk's own cost, and it isn't hypothetical — a first pass at this analysis read
+~85-170µs at offset=0 even for single-predicate queries, an order of magnitude above any plausible
+per-card walk cost, until it was traced to this.
+
+**Fixed this session**: `ComposePageWork` now splits `ns_build` (the compose step) from `ns_paging`
+(the walk alone), landing in `PhaseStats::ns_setup`/`ns_loop` respectively — the same setup/loop
+split every other plan already uses. `plan_self_ns`'s total is unchanged (`ns_setup + ns_loop`
+still sums to what `ns_loop` alone used to report), so nothing downstream broke, but a harness can
+now read the walk's real cost in isolation for the first time. That split is what made this
+measurement possible at all.
+
+## Likely cause
+
+`COMPOSE_WALK_STEP_NS` prices every printing touched at one flat rate, whether the bit-test finds a
+match (and pays `prefer_score`) or not. A kernel bench that isolates the pure bit-test cost (all-zero
+`pbits`, nothing ever matches) reads roughly half that rate. The real per-printing cost of a printing
+that DOES match — scoring it — isn't small, and a rate fit against a population without enough real
+matches in it would miss that entirely. Not confirmed by a controlled experiment here, but consistent
+with everything else this session found about `printings_walked`'s existing rates.
+
+## Caveat
+
+Measured on single-predicate queries only (`Shape(predicates=1)`) — that restriction was needed to
+isolate the walk's cost from compose-build cost via `explain_analyze`, not because it's the
+representative traffic mix `COMPOSE_WALK_STEP_NS` was presumably tuned against. Worth confirming the
+same ratio holds on the full "realistic" multi-predicate mix before refitting, though a consistent
+~5x miss across a 25,000-offset range on real queries isn't the kind of thing predicate count usually
+explains away.
+
+## What shipping this looks like
+
+A refit of `COMPOSE_WALK_STEP_NS`/`COMPOSE_WALK_EMIT_PER_ROW_NS` against real `(printings_walked,
+ns_paging)` pairs, now that they're cleanly separable — the same kind of natural-query rate
+regression `fit_cost_model.py` already does for other plans, pointed at this one. Independent of,
+and probably lower-risk than, the decision-rule work that found it: this only touches an existing
+cost-model constant used for routing `PrintingCompose` against `GatheredScan`/`StreamedSelect`, not
+new dispatch logic.
+
+## Related
+
+- [local-engine-compose-perm-sigma-decision-rule.md](local-engine-compose-perm-sigma-decision-rule.md)
+  — the work that surfaced this as a side finding.
+- `card_engine/src/cost.rs` — `COMPOSE_WALK_STEP_NS`, `COMPOSE_WALK_EMIT_PER_ROW_NS`,
+  `printings_walked`, `WALK_LENGTH_BIAS`.
+- Branch `engine-compose-cards-visited-estimator` — where the measurement lives
+  (`scripts/bench_compose_card_visited_safety_bound.py`'s production-cost-model grading section).
+
+## Status
+
+Measured, not fixed. Needs a real refit (not just a multiplier bump) against clean data the recent
+`ns_build`/`ns_paging` split now makes available.


### PR DESCRIPTION
Records the finding filed as #1025 — found as a side effect of the #730 safety-net investigation, unrelated to whether that work ever lands. See #1025 / the doc for repro and details.