### PR TITLE
Docs: Three-Phase Popcount-Skip Prototype and the One-Phase Rejection

### DIFF
--- a/docs/issues/00730-engine-popcount-skip-walk.md
+++ b/docs/issues/00730-engine-popcount-skip-walk.md
@@ -1,8 +1,14 @@
 # Engine: Popcount-Skip Walk for Deep Pagination, Generalized to All Distinct-Ons
 
-Status: todo, filed as [#730](https://github.com/jbylund/sylvan_librarian/issues/730). Deferred
-optimization split out of the #724 printing-space compose work
-([00724](done/00724-engine-printing-existential-planes.md)).
+Status: **prototyped and measured for all three distinct-ons, not wired in.** Filed as
+[#730](https://github.com/jbylund/sylvan_librarian/issues/730). Deferred optimization split out of
+the #724 printing-space compose work ([00724](done/00724-engine-printing-existential-planes.md)). See
+[local-engine-compose-perm-popcount-skip-prototype.md](local-engine-compose-perm-popcount-skip-prototype.md)
+for the prototypes, correctness tests, and real-corpus crossover measurements this doc's "the idea"
+section asked for, and
+[reference-engine-compose-perm-cards-visited-estimator.md](reference-engine-compose-perm-cards-visited-estimator.md)
+for why the alternative (a better cost-model *estimate* of the forward walk's depth) turned out to be
+the harder path, which is what led back to this doc.
 
 ## Two ways to page a match bitmap
 
@@ -67,7 +73,32 @@ without a bitmap. **2.4–2.9 µs per query against 0.2–0.3 µs to scatter int
 against 5.5 µs when every printing matches — O(k log k) with two dependent random loads per element, against an
 O(k) scatter. Numbers in `card_engine/src/bench_membership_check.rs`. The scatter is the right shape.
 
-## Why deferred
+## Progress: prototyped, measured, not yet worth the deferral reasoning below
+
+A later session, arriving from the cost-model side (trying to *estimate* `walk_grouped_page`'s depth
+accurately enough to price it — see the estimator doc linked above), ended up building exactly what
+this doc proposed instead of a better estimate. `#[cfg(test)]` prototypes for all three distinct-ons
+(`walk_card_page_via_popcount_skip`, `walk_printing_page_via_popcount_skip`,
+`walk_artwork_page_via_popcount_skip`), each verified against `walk_grouped_page` row-for-row across
+360 random-bitmap cases, and measured on real corpus data: a genuine crossover in every mode, old
+cheaper at shallow offsets, the popcount-skip approach 1.2-4x cheaper by offset 8,000-25,000
+(`otag:triggered-ability`, this session's own worked clumped-tag example). Full numbers in
+[local-engine-compose-perm-popcount-skip-prototype.md](local-engine-compose-perm-popcount-skip-prototype.md).
+
+Also prototyped: a v1 decision rule (which strategy to run, decided at acquire time) for the one
+population with a validated depth estimate (`unique=printing`, bare leaf, EDHREC —
+`WalkCheckpoints`), and a follow-on design question — whether the scatter phase can select the page
+directly in one pass instead of a separate skip+re-walk, and if so with what data structure — split
+into [reference-engine-compose-popcount-skip-topk-select.md](reference-engine-compose-popcount-skip-topk-select.md).
+**Answered, negatively**: built and measured both a heap and a specialized batch-prune one-phase
+selector; both lose to the three-phase design in the offset range that matters, because a live
+top-*k* structure's cost grows with `offset + limit` in a way the three-phase design's cheap-count /
+bounded-materialize split avoids. The three-phase design is the one to keep.
+
+None of this is wired into the fastpath yet — see the prototype doc's own open items (no decision
+rule for `Card`/`Artwork`) before the reasoning below about whether it's worth building applies.
+
+## Why deferred (the original reasoning, before the above)
 
 Deep pagination is rare, and unifying the three modes onto one walk was the larger win. This is a
 targeted optimization to build once/if deep-offset compose queries prove hot — measure the offset
@@ -80,6 +111,12 @@ worth serving. Which is currently **unmeasured**: it never appeared in #856's sa
 
 ## Related
 
+- [local-engine-compose-perm-popcount-skip-prototype.md](local-engine-compose-perm-popcount-skip-prototype.md)
+  — the prototypes, correctness tests, and crossover measurements for all three distinct-ons.
+- [reference-engine-compose-popcount-skip-topk-select.md](reference-engine-compose-popcount-skip-topk-select.md)
+  — collapsing the skip+re-walk into the scatter itself, and which structure should hold the page.
+- [reference-engine-compose-perm-cards-visited-estimator.md](reference-engine-compose-perm-cards-visited-estimator.md)
+  — the cost-model-estimation path that turned out to be the harder alternative to this doc's own idea.
 - [00724](done/00724-engine-printing-existential-planes.md) — the printing-space compose plan whose
   unification this splits off from.
 - `run_query_streamed_popcount` (`card_engine/src/lib.rs`) — the existing card-space popcount-skip walk

--- a/docs/issues/local-engine-compose-perm-popcount-skip-prototype.md
+++ b/docs/issues/local-engine-compose-perm-popcount-skip-prototype.md
@@ -1,0 +1,211 @@
+# A popcount-scatter alternative to `Perm`'s card walk, prototyped and measured
+
+`PrintingCompose`'s `Perm` paging (`walk_grouped_page`) walks the sort permutation card by card,
+bit-testing each visited card's whole printing span, until enough matches fill the page. Its cost is
+*position-dependent*: insensitive to how many matches a filter has, sensitive to how deep into the
+permutation the walk must go — which is exactly why `cards_visited` has been hard to estimate
+([reference-engine-compose-perm-cards-visited-estimator.md](reference-engine-compose-perm-cards-visited-estimator.md)):
+EDHREC-order clumping means "how deep" has no simple relationship to the query's own match count.
+
+`run_query_streamed_popcount` (serving `PlanePopcountOrder`/`CardRangePopcount`) already solves a
+sibling problem differently: scatter a card-existence bitmap into sort-rank order via the inverse
+permutation, then skip to an offset by popcounting 64-card *words* instead of testing cards one at a
+time. Cost is `O(popcount(bitmap) + n_cards/64)` — *density-dependent*, completely insensitive to
+where the matches sit. This doc prototypes porting that technique to `Perm`'s own walk, for all three
+`unique` modes, and measures whether it's actually better, not just differently-shaped.
+
+**This turns out to be exactly what [00730-engine-popcount-skip-walk.md](00730-engine-popcount-skip-walk.md)
+already proposed and filed**, arrived at independently from the cost-model-estimation side rather than
+recognized up front — see that doc's own "the idea" section. This doc is the prototyping/measurement
+half of it; [reference-engine-compose-popcount-skip-topk-select.md](reference-engine-compose-popcount-skip-topk-select.md)
+is a follow-on design question (collapsing the skip+re-walk into the scatter itself).
+
+## What was built
+
+Three `#[cfg(test)]` prototypes, not wired into the fastpath, all built against the general
+`SortOrder`/`ArchivedSortPermutations::order` API `run_query_streamed_popcount` already uses — so all
+three generalize to every sort column with a permutation for free, unlike `WalkCheckpoints`, which is
+EDHREC-only:
+
+- **`walk_card_page_via_popcount_skip`** (`Mode::Card`). Scatter, in one pass over `pbits`' set
+  printings, straight to a rank-ordered card-existence bitmap (`printing_to_card[pid] ->
+  order.inv[cid]`, deduplicated in-line so a card reached via several of its own matching printings
+  still counts once), skip by word-popcount, then re-scan only the *emitted* cards' spans to pick
+  each one's best-`prefer_score` printing.
+- **`walk_printing_page_via_popcount_skip`** (`Mode::Printing`). A card can contribute more than one
+  row here, so the scatter is *weighted* rather than a bare existence bit: one increment per matching
+  printing (`printing_to_card[pid] -> order.inv[cid] -> block_weight[rank/64] += 1`). The fine phase,
+  once the target block is found, walks forward card by card re-testing each one's span — the same
+  loop shape `walk_grouped_page`'s own `Printing` branch already uses.
+- **`walk_artwork_page_via_popcount_skip`** (`Mode::Artwork`). One row per *distinct*
+  `artwork_group_id` a card touches, not one row per matching printing, so raw per-printing weighting
+  would overcount. Still one pass, still `O(popcount(pbits))`: printings of one card are contiguous
+  in pid-space (`offsets` partitions it that way), so a card boundary is detected simply by the card
+  id changing, and a small `seen_groups` buffer (bounded by one card's own distinct-group count, not
+  the corpus total) dedupes within it. The fine/emit phase reuses `walk_grouped_page`'s own `Artwork`
+  branch verbatim (`group_best`/`touched`, best-`prefer_score` representative per group, `page_cmp`
+  order across a card's own multiple group-rows).
+
+All three share a single skip/scatter shape: scatter into rank-ordered 64-card blocks weighted by
+whatever "one row" means for that mode (existence, printing count, or distinct-group count), then
+skip by summing block weights instead of testing cards one at a time.
+
+**`Mode::Card` was originally built as two passes** (project `pbits` to card-existence via
+`printing_bits_to_card_bits`, *then* scatter that into rank order) — a real inefficiency caught by
+comparing it against `Mode::Printing`'s one-pass design, since the projection alone already costs as
+much as `Printing`'s entire scatter, before `Card` paid a second pass on top. Folded down to one pass,
+matching the other two; see the performance numbers below for the before/after.
+
+## Correctness
+
+Three differential tests, `#[ignore]`d (need `real.store`), sharing one `random_pbits` helper (a
+printing-space bitmap at a given density, tail padding cleared): `walk_card_page_via_popcount_skip_matches_walk_grouped_page`,
+`walk_printing_page_via_popcount_skip_matches_walk_grouped_page`, and
+`walk_artwork_page_via_popcount_skip_matches_walk_grouped_page` — 360 cases each (4 bitmap densities
+x 3 random trials x 3 sort columns x 2 directions x 5 page points, including one past the total).
+Deliberately not tied to any real filter's semantics — the algorithms' correctness depends only on
+the bitmap's shape, not what it means. `Artwork`'s is the one most likely to have caught a real bug
+(the scatter's group dedup and the emit phase's own grouping have to agree on what counts as "one
+row"); it passed on the first run. Every case, all three modes, matches `walk_grouped_page` row for
+row by pointer identity.
+
+## Performance: a real, measured crossover — in all three modes
+
+Real corpus, `otag:triggered-ability` (a tag whose matches front-load among reprint-heavy
+EDHREC-early staples, per this session's own earlier finding, then thin out), `limit=20`, sweeping
+`offset`. `Card`'s numbers are post-single-pass-fix:
+
+| offset | Card old/new | Printing old/new | Artwork old/new |
+| --: | --: | --: | --: |
+| 0 | 0.02x | 0.02x | 0.01x |
+| 2,000 | 0.46x | 0.21x | 0.28x |
+| 4,000 | 0.93x | 0.39x | 0.57x |
+| 8,000 | **2.00x** | 0.73x | **1.24x** |
+| 15,000 | 3.53x | **1.62x** | 2.84x |
+| 25,000 | 3.81x | 3.26x | 4.00x |
+
+All three show the same shape: old scales roughly linearly with offset (position-dependent — exactly
+what's made `cards_visited` hard to estimate), new is flat past its fixed scatter cost
+(density-dependent, indifferent to depth). Crossover sits earliest for `Card` (between 4,000 and
+8,000), latest for `Printing` (between 8,000 and 15,000), with `Artwork` in between — ordering that
+roughly tracks each mode's own scatter cost (`Artwork`'s per-printing `seen_groups` scan costs more
+than `Printing`'s bare increment; `Card`'s single-pass fix undercut both of the others' "new" times
+for the same tag). A shallow-page control on a common value (`keyword:flying`) shows the opposite in
+all three: old wins by several x at `offset=0`, new wins within a couple thousand offset — the same
+crossover, driven by depth rather than by rarity, on a filter with ~20x more total matches.
+
+**`Card`'s single-pass fix was a real, large win**, not just a cleanup: crossover moved from
+offset ~4,000-8,000 down to ~2,000-4,000, and the win at depth roughly doubled (offset=25,000: 2.16x
+before the fix, 3.81x after).
+
+**Neither strategy dominates, in any mode.** This is exactly why it needs to be a *choice*, not a
+replacement: build the scatter only when it's predicted cheaper than walking, using quantities
+already available (match count vs. an estimated walk depth) — the same three-way shape
+`Perm`/`OrderbyWalk`/`Gather` already is, one more option.
+
+## The card-invariant shortcut: not built yet, and how much it would cover
+
+`Printing` mode's general scatter above already works for any filter, card-invariant or not — the
+weight is 1 per matching printing regardless. A cheaper, but conditional, alternative was discussed
+before building the general version: project to a card-existence bitmap and weight each matching card
+by a static `card_id -> num_printings` lookup (`offsets[cid+1]-offsets[cid]`, already free), turning
+the scatter into `O(matching cards)` instead of `O(matching printings)` — cheapest exactly where
+clumping already makes cards expensive (heavily-reprinted matches). This is only EXACT when the
+composed filter is **card-invariant**: every printing of a matching card matches, nothing
+printing-level narrows it further (`touches_printing_field`, already used elsewhere in this codebase
+for the identical question on the `candidates` acquire path). Not built — the general version above
+covers correctness for every filter already, so this is a targeted speedup layered on top, not a
+prerequisite.
+
+**Measured how much of real `Perm` traffic that shortcut's gate would actually cover**
+(`scripts/bench_compose_card_invariance_split.py`, uniform sampler, `residual_card_invariant` newly
+exposed on `PrintingCompose`'s own acquire branch — see `card_engine/src/lib.rs`'s
+`compose_source`/`mk_plan_feats` call site):
+
+| paging | invariant | varying | invariant% |
+| --- | --: | --: | --: |
+| Decline | 55,229 | 147,240 | 27.3% |
+| Gather | 14 | 7,715 | 0.2% |
+| OrderbyWalk | 6,899 | 47,588 | 12.7% |
+| **Perm** | **11,601** | **84,159** | **12.1%** |
+| ALL | 73,743 | 286,702 | 20.5% |
+
+Stable across seeds (12.0-12.3% for `Perm` specifically, 20.4-20.5% overall). Lower than a hopeful
+prior might guess — most real compose traffic touches at least one printing-varying field (price,
+border, rarity, set code, artist, flavor text are all common in realistic query mixes). **This does
+not mean the popcount-skip approach only helps 12% of `Perm` traffic** — the *general* per-printing
+scatter (still `O(popcount(pbits))`, still density- not depth-dependent) applies regardless of
+card-invariance; the 12% is specifically how much traffic would get the *cheapest* card-level-only
+form of it.
+
+## A v1 decision rule, validated against real data — right ballpark, not calibrated
+
+Getting a rate for the scatter phase alone turned out to be its own small investigation. A kernel
+bench isolating it (`compose_popcount_skip_kernel_costs`, `Mode::Card`, `offset=0, limit=1`, varying
+match count via synthetic random card samples of controlled size — real tags only offer a handful of
+discrete match counts to fit against) hit a real confound at first: even at `offset=0`, the skip
+phase still has to scan forward through empty blocks until it finds the *first* match in rank order,
+and for a sparse random sample that position is itself random — not the scatter-only cost this was
+meant to isolate. Fixed by forcing the rank-0 card into every sample. Even after the fix, the small
+sizes (100-1,000 cards) stayed noise-dominated — a fixed per-call cost (allocation, function-call
+overhead) comparable to or larger than the true per-match signal at that scale — but the larger sizes
+agreed with each other: 6.575 ns/card between the 5,000 and 10,000-card points, 6.529 ns/card between
+10,000 and 20,000. Averaging 5 random draws per size (not just one) helped but didn't fully clean up
+the small end.
+
+Rather than chase that further, `Mode::Printing`'s own rate came from a 2-point calibration using
+already-measured, already-clean data instead: `keyword:flying` (9,100 matches) and
+`otag:triggered-ability` (41,216 matches), reading their real `new` plateau from
+`compose_printing_walk_popcount_skip_vs_walk`. That gives `new_ns ~= 0.872 * matches - 935` — a
+near-zero intercept, consistent with `Printing` mode's scatter cost dominating almost entirely (no
+big fixed skip/emit overhead to speak of), and it predicts both calibration points' own measured
+values back within a few percent.
+
+Combined with the reconciled natural-query regression for the OLD walk (`1.9 * cards_visited_estimate
++ 0.32 * printings_walked_estimate`, from `reference-engine-compose-perm-cards-visited-estimator.md`) and
+`WalkCheckpoints`' own depth estimate (the one validated case — see that doc, `unique=printing`,
+EDHREC, bare leaf), this is enough for an actual decision rule:
+`scripts/bench_compose_popcount_skip_decision_rule.py` predicts, for every offset in
+`otag:triggered-ability`'s own sweep, which strategy should win — and gets the *qualitative* shape
+right (old cheaper through offset 15,000, new cheaper by 25,000) but the *crossover position* wrong
+by about 50%: predicted ~15,566, real measured ~10,200. Right ballpark, wrong precision — exactly
+what a rate built from a 2-point calibration and an estimator with its own ~10-15% typical error
+(`WalkCheckpoints`' own p10-p90 band) should produce.
+
+## What this doesn't answer yet
+
+- **The decision rule only covers `unique=printing`, bare-leaf/EDHREC traffic** — the one population
+  with a validated depth estimator. `Card` and `Artwork` mode have no such estimator at all (the
+  checkpoint machinery is `Printing`-mode-only), so a decision rule there would have to fall back to
+  the ratio estimator this whole investigation started by showing fails badly, or use a cruder
+  always-prefer-the-safer-option heuristic. Not attempted.
+- **The rates themselves are rough.** `Printing`'s is a 2-point calibration, not a properly isolated
+  kernel rate; `Card`'s kernel attempt is noisy below ~5,000 matches. Both are good enough to get the
+  right qualitative answer, not to trust the exact crossover position.
+- **The card-invariant shortcut isn't built.** Measured how much it would cover; not implemented.
+- **Not wired in.** These are `#[cfg(test)]`-only prototypes, exercised by seven tests, plus a
+  Python-side decision-rule validation that reads real acquire output but doesn't touch the engine.
+  Making any of the walk prototypes real execution behavior is a bigger, riskier change than anything
+  else in this doc chain — it touches the executor, not the cost model, with its own row-order
+  correctness surface (covered here for all three modes, but only against random bitmaps, not the
+  full fuzz suite's real-filter coverage).
+- **If this pans out, it plausibly obsoletes most of the `WalkCheckpoints` estimator work**: the
+  executor would just do the cheap thing and report real time, and the cost model would need
+  `O(matches + n_cards/64)` — quantities that don't blow up with clumping — instead of an approximated
+  `cards_visited`. That would be a good problem to have, but it's not resolved by this doc.
+
+## Status
+
+Prototyped and measured, not shipped, all three `unique` modes, plus a v1 decision rule validated
+(not yet calibrated) for `unique=printing`. Seven new `#[cfg(test)]`-gated tests in
+`card_engine/src/tests.rs` (three differential correctness tests, three real-corpus offset-sweep
+performance comparisons, one scatter-rate kernel bench), all `--ignored` (need `real.store`).
+`residual_card_invariant` now also set on `PrintingCompose`'s own acquire branch (diagnostic only, not
+read by `plan_cost`). Two new scripts: `bench_compose_card_invariance_split.py` (the invariance split
+above) and `bench_compose_popcount_skip_decision_rule.py` (the decision-rule validation). `cargo test
+--release` 156/156, `cargo clippy --all-targets -- -D warnings` clean.
+
+Next: tighten the `Printing`-mode rates (a cleaner kernel isolation, or more calibration points),
+extend the decision rule's coverage to `Card`/`Artwork` (needs a depth estimator there first, which
+doesn't exist), or accept the v1 rule as directionally useful and move toward actually wiring
+something in.

--- a/docs/issues/reference-engine-compose-popcount-skip-topk-select.md
+++ b/docs/issues/reference-engine-compose-popcount-skip-topk-select.md
@@ -1,0 +1,179 @@
+# The popcount-skip scatter CAN select the page directly — but measured, it's a net loss
+
+[local-engine-compose-perm-popcount-skip-prototype.md](local-engine-compose-perm-popcount-skip-prototype.md)
+prototyped a three-phase design for all three `unique` modes: scatter matches into rank-ordered
+64-card blocks, skip by block-popcount to find the target block, then re-walk that one block's cards
+to emit. This doc started as a proposal to collapse that into one phase — read on for why, once
+built and measured (see "Measured" below), that turned out to be the wrong call.
+
+## The one-phase version
+
+The scatter already visits every match once (`O(popcount(pbits))`). If, instead of just tallying a
+block-weight count, it maintains a structure holding the *k* = `offset + limit` matches with the
+smallest sort keys seen so far, then after one pass that structure holds — exactly, not
+approximately — the rows the page needs: pop them in order, skip the first `offset`, and the
+remaining `limit` are the page. No separate skip phase, no separate re-walk. `Card`/`Artwork` still
+need the existing per-card finalization (best-`prefer_score` printing, or distinct
+`artwork_group_id` representatives) before a row is eligible to enter the structure — that part is
+unchanged from the current prototype's `finalize_artwork_card`-style logic.
+
+This looked like a real structural win regardless of which structure implements "hold the *k*
+smallest" — removing the separate skip+re-walk phases sounds like pure upside. Measured below, it
+isn't: those two phases were doing useful work (keeping the expensive part bounded by `limit`
+instead of `k`), and collapsing them costs more than it saves.
+
+## Which structure: two candidates, one already proven in this codebase
+
+**A bounded max-heap.** Push each candidate row; once the heap holds *k* entries, only push when the
+new row sorts before the current maximum, evicting it. Standard bounded top-*k*, correct by
+construction. Cost is `O(popcount(pbits) · log k)` — cheap shedding matters here specifically because
+most candidates, once the heap has filled with genuinely small keys, will fail a cheap
+"is this even smaller than the current max" check before paying for the O(log k) heap update.
+
+**`GatherSelect`'s existing pattern**, already implemented and tested for the unordered `GatheredScan`
+path (`card_engine/src/lib.rs`): append candidates into a plain buffer; cheaply drop anything
+`>= cutoff` as it's appended (`absorb`'s compaction pass); once the buffer grows `GATHER_PRUNE_CHUNK`
+past *k*, batch-prune with `select_nth_unstable_by` (quickselect, `O(n)` average) and truncate,
+tightening `cutoff`. No live heap at all — the "keep only the *k* best" step happens in occasional
+large batches instead of a per-item structure update.
+
+**Prior, directly relevant evidence points at the batch-prune shape.** [#730](00730-engine-popcount-skip-walk.md)
+(the filed issue this whole prototype arc has been implementing) already measured a closely related
+choice in this same code area: keying each candidate by its card's permutation position and
+*sorting* it, versus scattering into a bitmap directly. The sort-based version — `O(k log k)`,
+comparison-heavy, non-sequential access, the same general shape a per-item heap has — measured
+**2.4–2.9 µs against 0.2–0.3 µs for the scatter**, widening to **23 µs against 5.5 µs** at full
+density. Not the identical problem (that was membership testing, not top-*k* selection), but the same
+family of shape, and it lost by 8–10x. `GatherSelect`'s design already reflects the same lesson: cheap
+per-item rejection plus rare, amortized batch work over a live per-item structure.
+
+That is suggestive, not conclusive — a top-*k* selection isn't a sort, and a heap's `O(log k)` is not
+`O(k log k)` — so the honest position is the user's own: **measure before deciding**, not assume the
+prior result transfers.
+
+## Measured: is the already-shipped `gather_composed_page` already the answer?
+
+Before building anything, worth checking whether `ComposePaging::Gather`'s existing executor
+(`gather_composed_page`, `card_engine/src/lib.rs`) — which already runs `GatherSelect`'s append +
+cheap-shed + batch-`select_nth_unstable_by`-prune pattern, keyed by `sort_key_bits` rather than a
+permutation, so it needs no permutation at all — already *is* the one-phase selector this doc
+proposes building. `compose_paging_with_total` never lets it compete against `Perm` today (it
+returns `Perm` unconditionally whenever a permutation exists for the sort column), so this had never
+actually run in that regime and the question was open.
+
+Checked directly: called `gather_composed_page` on the same permutation-available Card-mode queries
+already used for the three-phase prototype, both for correctness (360-case random-bitmap sweep
+across density/sort-column/direction/offset, row-identity against `walk_grouped_page`, all passing)
+and for performance (same real-corpus `otag:triggered-ability` / `keyword:flying` offset sweep,
+same process, same corpus, same test run as the three-phase prototype's own bench for an
+apples-to-apples number):
+
+| offset | `walk_grouped_page` | 3-phase prototype | `gather_composed_page` |
+|---|---|---|---|
+| 0 | 1.7 µs | 71.9 µs | 179.2 µs |
+| 2,000 | 34.2 µs | 55.2 µs | 212.6 µs |
+| 8,000 | 109.6 µs | 53.0 µs | 211.1 µs |
+| 15,000 | 257.7 µs | 61.1 µs | 180.3 µs |
+| 25,000 | 254.3 µs | 58.7 µs | 150.3 µs |
+
+Both alternatives are flat in offset as expected — the difference is the flat *level*.
+`gather_composed_page` beats `walk_grouped_page` only past offset ≈ 10,000-12,000 (vs. the
+three-phase prototype's ≈ 4,000), and even past its own crossover it is **2.5-5x slower in absolute
+terms than the three-phase prototype**, not merely later to cross even.
+
+**Conclusion: no, it is not already the answer, and the gap is not close.** It is correct — the
+algorithm shape (append + cheap-shed + batch-prune) is fine — but `sort_key_bits`'s generic
+tuple-based key extraction plus a comparator-driven `select_nth_unstable_by` costs measurably more
+per candidate than a raw scatter into rank-indexed 64-bit words. This doesn't resolve the heap vs.
+batch-prune question this doc asks — it rules out "just reuse `GatherSelect` unmodified," not batch
+pruning in general. A *specialized* batch-prune over plain `u32` permutation ranks (no tuple key, no
+dynamic comparator) is still a live candidate against a heap; only the "build nothing, flip the
+decision" option is closed off. The build-both plan below stands.
+
+## Measured: does the one-phase collapse itself win, once built properly?
+
+Built both candidates for `Mode::Card` (`walk_card_page_via_popcount_heap`,
+`walk_card_page_via_popcount_batch_prune`, `card_engine/src/lib.rs`), verified against
+`walk_grouped_page` the same way as the three-phase prototype (360-case random-bitmap sweep, row
+identity, all passing), then measured all four strategies together in one test run
+(`compose_card_one_phase_selectors_vs_walk`) against the same real-corpus
+`otag:triggered-ability` offset sweep:
+
+A first version tracked each candidate card's best-`prefer_score` printing *during* selection — the
+natural reading of "the scatter selects the page directly." That version lost to the three-phase
+prototype by 3-8x at every offset, because it paid `prefer_score` for every one of
+`popcount(pbits)` matching printings, not just the page's own `limit` cards. The fix: selection only
+ever needs a card's RANK to decide whether it's in the top-*k* — never its printings. Deferred the
+best-printing pick to a `best_matching_printing` helper called only for the final page's `limit`
+cards (mirroring the three-phase prototype's own bounded emit phase), and re-measured:
+
+| offset | `walk_grouped_page` | 3-phase prototype | heap | batch-prune |
+|---|---|---|---|---|
+| 0 | 1.9 µs | 65.6 µs | 34.6 µs | 37.8 µs |
+| 500 | 13.7 µs | 51.6 µs | 56.4 µs | 44.0 µs |
+| 2,000 | 35.5 µs | 63.0 µs | 121.3 µs | 60.3 µs |
+| 8,000 | 131.3 µs | 49.8 µs | 322.5 µs | 108.9 µs |
+| 15,000 | 313.6 µs | 70.4 µs | 423.0 µs | 141.3 µs |
+| 25,000 | 318.2 µs | 56.1 µs | 429.0 µs | 136.5 µs |
+
+Removing the `prefer_score` bug closed most of the gap, but a real one remains and it doesn't close
+with more engineering: **both one-phase selectors' cost grows with `k = offset+limit`, and the
+three-phase prototype's does not.** The three-phase design's scatter does one thing per match —
+flip a dedup bit, `O(1)`, independent of `k` — and defers everything expensive (the skip-scan, the
+per-card printing pick) to bounded, `k`-independent or `limit`-bounded work. A live top-*k*
+structure cannot do that: maintaining "the *k* smallest seen so far" against candidates arriving in
+an order uncorrelated with rank (pid order, not rank order) means the number of candidates that
+actually update the structure scales with *k* itself (each of the ~N arrivals is accepted with
+probability roughly `k / i` at arrival position `i`, so total accepted work is `O(k · ln(N/k))`),
+not merely `O(log k)` per candidate as the heap's local complexity suggests. That is exactly the
+`k`-dependence the popcount-skip idea exists to avoid in the first place — collapsing to one phase
+reintroduces it.
+
+Batch-prune is decisively the better of the two — flatter, and 2.4-3.1x cheaper than the heap at
+every offset past 500, confirming the doc's own suspicion and #730's sort-vs-scatter lesson: cheap
+append + rare batch work beats a live per-item structure. But it still loses to the three-phase
+design by ~2.4x at offset 25,000, and the gap does not shrink as offset grows — if anything it's
+roughly constant past offset 8,000, meaning there is no larger offset at which batch-prune would
+overtake the three-phase design for this query's density.
+
+**Conclusion: don't collapse to one phase.** The three-phase design
+(`local-engine-compose-perm-popcount-skip-prototype.md`) already separates cheap counting from
+bounded materialization, which is the actual reason it's fast — "select the page directly in one
+pass" sounded like it would remove overhead, but it removes a separation of concerns that was
+carrying the performance instead. The heap-vs-`GatherSelect` question this doc opened with is
+answered (batch-prune wins, decisively), but the premise question — is a one-phase collapse worth
+building at all — is answered no. Kept as `#[cfg(test)]` prototypes with correctness tests, same as
+the repo's other measured-and-not-adopted candidates, so the negative result and its cause don't
+need re-deriving.
+
+## Related
+
+- [local-engine-compose-perm-popcount-skip-prototype.md](local-engine-compose-perm-popcount-skip-prototype.md)
+  — the three-phase design that wins; this doc's attempt to collapse it lost, measured.
+- [00730-engine-popcount-skip-walk.md](00730-engine-popcount-skip-walk.md) — the filed issue this
+  whole arc implements; carries the sort-vs-scatter measurement this doc leans on.
+- `GatherSelect` / `prune_to_smallest` / `select_page` / `gather_composed_page`
+  (`card_engine/src/lib.rs`) — the existing, tested batch-prune pattern and its shipped executor;
+  measured above as correct but 2.5-5x slower per candidate than the three-phase prototype, ruling
+  out "reuse as-is" but not batch-pruning in general — confirmed separately when the *specialized*
+  batch-prune built for this doc still lost to the three-phase design on its own.
+- `walk_card_page_via_popcount_heap` / `walk_card_page_via_popcount_batch_prune` /
+  `best_matching_printing` (`card_engine/src/lib.rs`) — the two one-phase prototypes this doc's
+  question led to building, and the shared bounded-emit helper that fixed their first (much slower)
+  version's `prefer_score` mistake.
+
+## Status
+
+**Measured, not adopted.** Both one-phase candidates were built, verified correct against
+`walk_grouped_page`, and benchmarked against the three-phase design on the same real-corpus offset
+sweep. Batch-prune beats a live heap decisively (answering this doc's original question), but
+neither beats the three-phase design in the offset range popcount-skip exists to serve — a live
+top-*k* structure's cost grows with `k = offset + limit`, which is exactly the dependence the
+three-phase design's cheap-count/bounded-materialize split avoids. Recommendation: keep the
+three-phase design as the one to eventually wire in (per `local-engine-compose-perm-popcount-skip-
+prototype.md`'s own open items), not this one-phase collapse.
+
+That "how do we decide when to use it" question turned into its own doc:
+[local-engine-compose-perm-sigma-decision-rule.md](local-engine-compose-perm-sigma-decision-rule.md)
+— a `sigma` safety margin over the no-clumping model, measured as the best balance found between
+`walk_grouped_page` and the three-phase walk this doc settled on.


### PR DESCRIPTION
Docs-only, part of splitting #1009 (same pattern as #1027 and #1025/#1026). Stacked after #1027 only in the sense that it links to the file that PR renames — no code, safe to merge in either order, GitHub will just show a broken relative link in the preview until both land.

Two docs recording real progress on #730:

- `local-engine-compose-perm-popcount-skip-prototype.md` — the three-phase popcount-skip walk, prototyped and correctness-tested (360 cases each) for all three `unique` modes, independently rediscovering #730's own proposal from the cost-model-estimation side. Real measured crossovers: 1.2-4x cheaper than the forward walk by offset 8,000-25,000.
- `reference-engine-compose-popcount-skip-topk-select.md` — the one-phase selector detour (a heap and a batch-prune structure, testing whether skip+re-walk could collapse into one pass) and its rejection. `reference-` since this specific approach is a concluded dead end.

Also updates `00730-engine-popcount-skip-walk.md`'s own tracking doc to record both outcomes, matching what's now also in the GitHub issue's body/comments.

No code changes.