### PR TITLE
Engine: Promote Three-Phase Popcount-Skip Walk Prototypes Out of #[cfg(test)]

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -9035,6 +9035,378 @@ fn walk_grouped_page<'a>(
     (page, work)
 }
 
+/// PROTOTYPE, not called by the fastpath: `Mode::Card`'s equivalent of `walk_grouped_page`, using the
+/// same scatter + popcount-skip technique `run_query_streamed_popcount` already uses for
+/// `PlanePopcountOrder`/`CardRangePopcount`, instead of walking the permutation card by card.
+///
+/// Scatter, in one pass over `pbits`' set printings, straight to a RANK-ordered card-existence
+/// bitmap — not `printing_bits_to_card_bits` followed by a second scatter of ITS set bits; that
+/// two-pass shape costs the projection's `O(popcount(pbits))` and then the re-scatter's
+/// `O(popcount(card_bits))` on top, where visiting each matching printing once here (deduplicating
+/// per card in-line) gets the same rank-existence bitmap for the projection's cost alone. Then skip
+/// to `page_offset` by popcounting 64-card WORDS instead of testing cards one at a time. Cost is
+/// `O(popcount(pbits) + n_cards/64)` — proportional to how many matches the filter has corpus-wide,
+/// completely insensitive to WHERE in the permutation they happen to sit.
+///
+/// `walk_grouped_page`'s cost is the opposite shape: insensitive to match density, sensitive to how
+/// deep the walk has to go to accumulate a page — which is exactly why `cards_visited` has been hard
+/// to estimate (`local-engine-compose-perm-cards-visited-estimator.md`): EDHREC-order clumping means
+/// "how deep" has no simple relationship to the query's own match count. This sidesteps needing that
+/// estimate at all for the population where it would help most — sparse, clumped matches, where
+/// `walk_grouped_page` has to visit many non-matching cards to find enough. It is not a universal
+/// replacement: a shallow page against matches that happen to cluster early costs `walk_grouped_page`
+/// very little and this approach a full `O(popcount(pbits))` scatter regardless, which is why this is
+/// a candidate THIRD strategy to pick between, not a blanket swap — see the doc for the cost trade.
+///
+/// `Mode::Card` only, for now: `Artwork` needs a per-card GROUP count (not existence) and `Printing`
+/// needs a per-card PRINTING count — both a WEIGHTED extension of this same idea, not attempted here.
+// Promoted out of `#[cfg(test)]` (#730); not yet called from the dispatch path -- the sigma decision
+// rule that will call it is a later, separate PR. Correctness stays covered by the differential test
+// against `walk_grouped_page` in the meantime.
+#[allow(dead_code)]
+fn walk_card_page_via_popcount_skip<'a>(
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
+    pbits: &[u64],
+    order: SortOrder<'_>,
+) -> (Vec<(&'a AOracleCard, &'a APrinting)>, ComposePageWork) {
+    debug_assert!(matches!(params.mode, Mode::Card), "prototype is Mode::Card only");
+    let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
+    let QueryParams { prefer, limit, page_offset, .. } = *params;
+    let n_cards = cards.len();
+    let mut work = ComposePageWork::default();
+
+    // Scatter, in ONE pass over `pbits`' set PRINTINGS -- not a separate `printing_bits_to_card_bits`
+    // projection followed by a second scatter of ITS set bits. That two-pass shape cost
+    // `O(popcount(pbits))` for the projection alone (as much as this entire scatter) plus
+    // `O(popcount(card_bits))` on top for re-scattering it; visiting each matching printing once,
+    // here, and deduplicating in-line (a card reached via several of its own matching printings
+    // still counts once) gets the same result for `O(popcount(pbits))` total, not more.
+    let mut permuted = vec![0u64; n_cards.div_ceil(64)];
+    let mut total: usize = 0;
+    for (i, &word) in pbits.iter().enumerate() {
+        let mut w = word;
+        while w != 0 {
+            let pid = ((i as u32) << 6 | w.trailing_zeros()) as usize;
+            w &= w - 1;
+            let cid = u32::from(indexes.printing_to_card[pid]) as usize;
+            let rank = u32::from(order.inv[cid]) as usize;
+            let (block, bit) = (rank / 64, 1u64 << (rank % 64));
+            if permuted[block] & bit == 0 {
+                permuted[block] |= bit;
+                total += 1;
+            }
+        }
+    }
+    if total == 0 || page_offset >= total {
+        return (Vec::new(), work);
+    }
+
+    // Skip: accumulate word popcounts until the boundary word containing `page_offset` -- 64 cards
+    // per word read, so a deep offset is an `n_cards/64`-word scan, not a card-by-card walk.
+    let mut skip = page_offset;
+    let mut word_idx = 0;
+    while word_idx < permuted.len() {
+        let wc = permuted[word_idx].count_ones() as usize;
+        if skip < wc {
+            break;
+        }
+        skip -= wc;
+        word_idx += 1;
+    }
+
+    // Emit: walk set bits from the boundary word onward, mapping rank -> card id via the forward
+    // permutation, and pick each emitted card's best-`prefer_score` printing exactly the way
+    // `walk_grouped_page`'s Card branch does (ties keep the first-found printing). Re-scanning each
+    // emitted card's span here, not during the scatter, is what keeps this bounded by `limit` rather
+    // than by total matches -- the same reason `run_query_streamed_popcount`'s own emit phase does it.
+    let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
+    let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
+    'walk: while word_idx < permuted.len() {
+        let mut w = permuted[word_idx];
+        while w != 0 {
+            let bit = w.trailing_zeros();
+            w &= w - 1;
+            if skip > 0 {
+                skip -= 1;
+                continue;
+            }
+            let pos = (word_idx as u32) << 6 | bit;
+            let cid = u32::from(order.perm[pos as usize]);
+            let card = &cards[cid as usize];
+            let start = u32::from(offsets[cid as usize]) as usize;
+            let end = u32::from(offsets[cid as usize + 1]) as usize;
+            work.cards_visited += 1;
+            work.printings_examined += (end - start) as u64;
+            let mut best: Option<(u32, f64)> = None;
+            #[allow(clippy::needless_range_loop)] // pid also drives is_set/printings[pid] together, same shape as walk_grouped_page
+            for pid in start..end {
+                if !is_set(pid) {
+                    continue;
+                }
+                let score = prefer_score(card, &printings[pid], prefer);
+                if best.is_none_or(|(_, s)| score > s) {
+                    best = Some((pid as u32, score));
+                }
+            }
+            let (bp, _) = best.expect("card_bits set this card because some printing of it matched");
+            page.push((card, &printings[bp as usize]));
+            if page.len() == limit {
+                break 'walk;
+            }
+        }
+        word_idx += 1;
+    }
+    (page, work)
+}
+
+/// PROTOTYPE, not called by the fastpath: the general `Mode::Printing` counterpart to
+/// `walk_card_page_via_popcount_skip`. `Printing` mode's page-fill differs from `Card`'s in the one
+/// way that matters here: a card can contribute more than one row (one per matching printing), so
+/// the scatter needs a per-card COUNT, not a bare existence bit.
+///
+/// Scatter per matching PRINTING rather than per matching card (`printing_to_card[pid] ->
+/// order.inv[cid] -> increment` a per-64-card-block counter) -- `O(popcount(pbits))`, still
+/// density-dependent and insensitive to where those matches sit, same shape as the `Card`-mode
+/// prototype, just weighted instead of bit-set. The skip phase sums those block counts instead of
+/// popcounting bitmap words. Once the target block is found, the fine phase walks forward
+/// card-by-card from its first rank -- same per-card bit-test loop `walk_grouped_page`'s `Printing`
+/// branch already uses, just starting from the located block instead of from rank 0, and continuing
+/// into subsequent blocks if that one block doesn't hold enough remaining matches to fill the page.
+///
+/// A card-invariant filter (every printing of a matching card matches, `!touches_printing_field`)
+/// could scatter over matching CARDS instead, weighted by a static `card_id -> num_printings` lookup
+/// -- `O(matching cards)` instead of `O(matching printings)`. Measured at ~12% of real `Perm`-paging
+/// traffic (`scripts/bench_compose_card_invariance_split.py`); not attempted here, see
+/// `local-engine-compose-perm-popcount-skip-prototype.md` for why it's a targeted speedup on top of
+/// this general version rather than a prerequisite for it.
+// Promoted out of `#[cfg(test)]` (#730); not yet called from the dispatch path.
+#[allow(dead_code)]
+fn walk_printing_page_via_popcount_skip<'a>(
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
+    pbits: &[u64],
+    order: SortOrder<'_>,
+) -> (Vec<(&'a AOracleCard, &'a APrinting)>, ComposePageWork) {
+    debug_assert!(matches!(params.mode, Mode::Printing), "prototype is Mode::Printing only");
+    let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
+    let QueryParams { limit, page_offset, .. } = *params;
+    let n_cards = cards.len();
+    let mut work = ComposePageWork::default();
+
+    let total: u64 = pbits.iter().map(|w| u64::from(w.count_ones())).sum();
+    if total == 0 || page_offset as u64 >= total {
+        return (Vec::new(), work);
+    }
+
+    // Scatter: each matching printing's card contributes one unit of weight to that card's RANK
+    // block -- one increment per match, not per card visited, and completely blind to whether that
+    // match is a rank away or ten thousand.
+    let n_blocks = n_cards.div_ceil(64);
+    let mut block_weight = vec![0u32; n_blocks];
+    for (i, &word) in pbits.iter().enumerate() {
+        let mut w = word;
+        while w != 0 {
+            let pid = ((i as u32) << 6 | w.trailing_zeros()) as usize;
+            w &= w - 1;
+            let cid = u32::from(indexes.printing_to_card[pid]) as usize;
+            let rank = u32::from(order.inv[cid]) as usize;
+            block_weight[rank / 64] += 1;
+        }
+    }
+
+    // Skip: accumulate BLOCK weights (cumulative matching printings, not cumulative cards) until
+    // the block containing `page_offset`.
+    let mut skip = page_offset as u64;
+    let mut block_idx = 0;
+    while block_idx < n_blocks {
+        let bw = u64::from(block_weight[block_idx]);
+        if skip < bw {
+            break;
+        }
+        skip -= bw;
+        block_idx += 1;
+    }
+
+    // Emit: walk cards rank-by-rank from this block's first rank, bit-testing each one's span (the
+    // same loop shape `walk_grouped_page`'s `Printing` branch uses), skipping `skip` more matching
+    // printings before pushing rows -- bounded by one block's worth of cards plus however many more
+    // it takes to fill `limit`, not by how deep the walk would otherwise need to go.
+    let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
+    let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
+    let start_rank = block_idx * 64;
+    'walk: for rank in start_rank..n_cards {
+        let cid = u32::from(order.perm[rank]) as usize;
+        let card = &cards[cid];
+        let start = u32::from(offsets[cid]) as usize;
+        let end = u32::from(offsets[cid + 1]) as usize;
+        work.cards_visited += 1;
+        work.printings_examined += (end - start) as u64;
+        #[allow(clippy::needless_range_loop)] // pid also drives is_set/printings[pid] together, same shape as walk_grouped_page
+        for pid in start..end {
+            if !is_set(pid) {
+                continue;
+            }
+            if skip > 0 {
+                skip -= 1;
+                continue;
+            }
+            page.push((card, &printings[pid]));
+            if page.len() == limit {
+                break 'walk;
+            }
+        }
+    }
+    (page, work)
+}
+
+/// PROTOTYPE, not called by the fastpath: the `Mode::Artwork` counterpart to the two prototypes
+/// above. `Artwork` mode's page-fill differs from `Printing`'s in what a "match" is: one row per
+/// DISTINCT `artwork_group_id` a card touches, not one row per matching printing — several matching
+/// printings of one card can share a group and still contribute only one row, so weighting by raw
+/// printing count (`Printing`'s approach) would overcount.
+///
+/// Still one pass over `pbits`' set printings, still `O(popcount(pbits))`: printings of one card are
+/// contiguous in pid-space (`offsets` partitions it that way), so a card's matching printings arrive
+/// consecutively in this scan too, and `finalize_artwork_card` dedupes the groups touched by ONE card
+/// with a small linear-scan buffer (bounded by how many distinct groups that one card actually has,
+/// not the corpus total) rather than a per-corpus structure. The fine/emit phase, once the target
+/// block is found, is `walk_grouped_page`'s own `Artwork` branch verbatim (`group_best`/`touched`,
+/// best-`prefer_score` representative per group, `page_cmp` order across a card's own multiple
+/// group-rows) -- just starting from the located block's first rank instead of rank 0.
+// Promoted out of `#[cfg(test)]` (#730); not yet called from the dispatch path.
+#[allow(dead_code)]
+fn finalize_artwork_card(order: SortOrder<'_>, block_weight: &mut [u32], total: &mut u64, cid: usize, groups_touched: u32) {
+    if groups_touched == 0 {
+        return;
+    }
+    let rank = u32::from(order.inv[cid]) as usize;
+    block_weight[rank / 64] += groups_touched;
+    *total += u64::from(groups_touched);
+}
+
+// Promoted out of `#[cfg(test)]` (#730); not yet called from the dispatch path.
+#[allow(dead_code)]
+fn walk_artwork_page_via_popcount_skip<'a>(
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
+    pbits: &[u64],
+    order: SortOrder<'_>,
+) -> (Vec<(&'a AOracleCard, &'a APrinting)>, ComposePageWork) {
+    debug_assert!(matches!(params.mode, Mode::Artwork), "prototype is Mode::Artwork only");
+    let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
+    let QueryParams { prefer, sort_col, descending, limit, page_offset, .. } = *params;
+    let n_cards = cards.len();
+    let max_artwork_groups = usize::from(u16::from(indexes.max_artwork_groups));
+    let mut work = ComposePageWork::default();
+
+    // Scatter: dedupe groups touched per card inline, exploiting that one card's matching printings
+    // arrive consecutively (a card boundary is detected the moment `cid` changes, not by a separate
+    // lookup) -- `seen_groups` never grows past one card's own distinct-group count before it's
+    // cleared for the next.
+    let n_blocks = n_cards.div_ceil(64);
+    let mut block_weight = vec![0u32; n_blocks];
+    let mut total: u64 = 0;
+    let mut current_cid: Option<usize> = None;
+    let mut seen_groups: Vec<u16> = Vec::new();
+    for (i, &word) in pbits.iter().enumerate() {
+        let mut w = word;
+        while w != 0 {
+            let pid = ((i as u32) << 6 | w.trailing_zeros()) as usize;
+            w &= w - 1;
+            let cid = u32::from(indexes.printing_to_card[pid]) as usize;
+            if current_cid != Some(cid) {
+                if let Some(prev) = current_cid {
+                    finalize_artwork_card(order, &mut block_weight, &mut total, prev, seen_groups.len() as u32);
+                }
+                current_cid = Some(cid);
+                seen_groups.clear();
+            }
+            let gid = u16::from(printings[pid].artwork_group_id);
+            if !seen_groups.contains(&gid) {
+                seen_groups.push(gid);
+            }
+        }
+    }
+    if let Some(prev) = current_cid {
+        finalize_artwork_card(order, &mut block_weight, &mut total, prev, seen_groups.len() as u32);
+    }
+
+    if total == 0 || page_offset as u64 >= total {
+        return (Vec::new(), work);
+    }
+
+    // Skip: accumulate BLOCK weights (cumulative distinct groups touched, not cumulative cards or
+    // printings) until the block containing `page_offset`.
+    let mut skip = page_offset as u64;
+    let mut block_idx = 0;
+    while block_idx < n_blocks {
+        let bw = u64::from(block_weight[block_idx]);
+        if skip < bw {
+            break;
+        }
+        skip -= bw;
+        block_idx += 1;
+    }
+
+    // Emit: `walk_grouped_page`'s own `Artwork` branch, verbatim, starting from the located block's
+    // first rank instead of rank 0.
+    let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
+    let mut group_best: Vec<Option<(u32, f64)>> = vec![None; max_artwork_groups];
+    let mut touched: Vec<u16> = Vec::new();
+    let mut scratch: Vec<Match> = Vec::new();
+    let mut skip = skip as usize;
+    let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
+    let start_rank = block_idx * 64;
+    for rank in start_rank..n_cards {
+        let cid = u32::from(order.perm[rank]);
+        let card = &cards[cid as usize];
+        let start = u32::from(offsets[cid as usize]) as usize;
+        let end = u32::from(offsets[cid as usize + 1]) as usize;
+        work.cards_visited += 1;
+        work.printings_examined += (end - start) as u64;
+        scratch.clear();
+        touched.clear();
+        #[allow(clippy::needless_range_loop)] // pid also drives is_set/printings[pid] together, same shape as walk_grouped_page
+        for pid in start..end {
+            if !is_set(pid) {
+                continue;
+            }
+            let gid = u16::from(printings[pid].artwork_group_id) as usize;
+            debug_assert!(gid < group_best.len(), "group_best must be pre-sized to max_artwork_groups");
+            let score = prefer_score(card, &printings[pid], prefer);
+            match &group_best[gid] {
+                None => {
+                    group_best[gid] = Some((pid as u32, score));
+                    touched.push(gid as u16);
+                }
+                Some((_, best)) if score > *best => group_best[gid] = Some((pid as u32, score)),
+                _ => {}
+            }
+        }
+        for &gid in &touched {
+            let (bp, _) = group_best[gid as usize].take().unwrap();
+            scratch.push((sort_key_bits(card, &printings[bp as usize], sort_col, descending), cid, bp));
+        }
+        if scratch.is_empty() {
+            continue;
+        }
+        if skip >= scratch.len() {
+            skip -= scratch.len();
+            continue;
+        }
+        scratch.sort_unstable_by(page_cmp);
+        for m in scratch.iter().skip(skip) {
+            page.push((&cards[m.1 as usize], &printings[m.2 as usize]));
+            if page.len() == limit {
+                return (page, work);
+            }
+        }
+        skip = 0;
+    }
+    (page, work)
+}
+
 /// Permutation-free counterpart to `walk_grouped_page`, for when `orderby` has no card-space
 /// permutation (`rarity`/`usd` — the representative printing depends on `prefer` and can't be
 /// precomputed, see `ArchivedSortPermutations::get`'s doc). Same per-card grouping logic (`pbits`
@@ -10436,6 +10808,12 @@ fn acquire_plan_features(
         // and compose was costed as if it returned everything for nothing. Applicability, estimate and
         // execution have to agree on which representation this plan is being judged on.
         let composed = compose_source(filter, unsplit, plane);
+        // Diagnostic only, for measuring how much of compose's own traffic is card-invariant --
+        // shares the field the `candidates` acquire already sets from the identical
+        // `!touches_printing_field(..)` question (just against `composed`, compose's own predicate,
+        // not the pre-split residual). Assigned to `feats` below, once it exists. Not read by
+        // `plan_cost`.
+        let composed_card_invariant = !touches_printing_field(composed);
         let est = compose_printing_estimate(composed, indexes, offsets, n_printings as usize);
         let (printing_matches, broadcast, scatter) = (est.result, est.broadcast, est.scatter);
         // Two build kinds, charged at different rates: `broadcast` = legality broadcast-down (linear
@@ -10614,6 +10992,7 @@ fn acquire_plan_features(
         // count's own variance (`eval_domain` grades p90/p10 3.1 here) and is not a scan-feature problem.
         let scan_units = if nothing_to_verify { printing_matches } else { scan_units };
         let mut feats = mk_plan_feats(ctx, params, result_total as u32, eval_domain as u32, scan_units as u32, tier);
+        feats.residual_card_invariant = composed_card_invariant;
         // What `StreamedSelect` actually examines here, which is NOT `scan_units`. P4 walks a card's whole
         // span to push every match; P3's `card_match_count` answers from span arithmetic for every card
         // `card_pass` resolves at card level, and on a legality-composed filter that is every non-divergent

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -11567,7 +11567,7 @@ fn compose_walk_kernel_costs() {
                 scratch.clear();
                 for pid in s..e {
                     if is_set(pid) {
-                        scratch.push((0u128, cid, pid as u32)); // unreachable: pbits is all-zero
+                        scratch.push((0u64, cid, pid as u32)); // unreachable: pbits is all-zero
                     }
                 }
                 if scratch.is_empty() {

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -11292,6 +11292,569 @@ fn gather_artwork_kernel_costs() {
     );
 }
 
+/// A printing-space bitmap with each bit independently set at probability `density`, tail padding
+/// above `n_printings` cleared -- a real composed bitmap never sets those, and
+/// `printing_bits_to_card_bits`'s cursor walk assumes it (a set bit past the last real printing has
+/// no card to advance the cursor to). Shared by both popcount-skip prototypes' differential tests:
+/// the algorithms' correctness doesn't depend on what the bitmap MEANS, only on its shape.
+fn random_pbits(rng: &mut rand::rngs::SmallRng, words: usize, n_printings: usize, density: f64) -> Vec<u64> {
+    use rand::RngExt;
+    let mut pbits = vec![0u64; words];
+    for word in &mut pbits {
+        for bit in 0..64u32 {
+            if rng.random_bool(density) {
+                *word |= 1u64 << bit;
+            }
+        }
+    }
+    for pid in n_printings..words * 64 {
+        pbits[pid / 64] &= !(1u64 << (pid % 64));
+    }
+    pbits
+}
+
+/// `walk_card_page_via_popcount_skip`'s prototype scatter+skip technique must produce the IDENTICAL
+/// page `walk_grouped_page`'s card-by-card walk does, for it to be a candidate replacement rather than
+/// just a faster wrong answer. Checked against random printing bitmaps (not a specific composed
+/// filter's semantics -- the algorithm's correctness doesn't depend on what the bitmap MEANS, only on
+/// its shape) across several densities (sparse and dense exercise different code paths: a sparse
+/// bitmap's scatter loop does little work and its skip-scan crosses many empty words; a dense one is
+/// closer to `walk_grouped_page`'s own no-early-stop worst case), several sort columns with a real
+/// permutation (this technique is not EDHREC-specific, unlike `WalkCheckpoints` -- see
+/// `local-engine-compose-perm-cards-visited-estimator.md`), both directions, and several page points
+/// including ones past the total (must agree on `Vec::new()`, not panic).
+///
+/// `cargo test --release walk_card_page_via_popcount_skip_matches_walk_grouped_page -- --ignored --nocapture`
+#[test]
+#[ignore = "needs real.store; cargo test --release walk_card_page_via_popcount_skip_matches_walk_grouped_page -- --ignored --nocapture"]
+fn walk_card_page_via_popcount_skip_matches_walk_grouped_page() {
+    use rand::SeedableRng;
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch — rebuild");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let ctx = QueryCtx::from(archived);
+    let n_cards = archived.cards.len();
+    let n_printings = archived.printings.len();
+    let words = n_printings.div_ceil(64);
+
+    const DENSITIES: [f64; 4] = [0.0005, 0.01, 0.2, 0.6];
+    const TRIALS_PER_DENSITY: usize = 3;
+    const PAGE_POINTS: [(usize, usize); 5] = [(0, 1), (0, 50), (10, 200), (5_000, 100), (1_000_000, 20)]; // last: past the total
+    const SORT_COLS: [(super::SortCol, &str); 3] =
+        [(super::SortCol::EdhrecRank, "edhrec"), (super::SortCol::Cmc, "cmc"), (super::SortCol::Name, "name")];
+
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
+    for &density in &DENSITIES {
+        for _ in 0..TRIALS_PER_DENSITY {
+            let pbits = random_pbits(&mut rng, words, n_printings, density);
+            for &(sort_col, label) in &SORT_COLS {
+                for descending in [false, true] {
+                    let order = archived.indexes.sort_perms.order(sort_col, descending, n_cards).expect("permutation exists");
+                    for &(offset, limit) in &PAGE_POINTS {
+                        let params = kernel_params(Mode::Card, sort_col, descending, limit, offset);
+                        let (old_page, _) = super::walk_grouped_page(&ctx, &params, &pbits, order.perm);
+                        let (new_page, _) = super::walk_card_page_via_popcount_skip(&ctx, &params, &pbits, order);
+                        let old_ids: Vec<(*const _, *const _)> = old_page.iter().map(|(c, p)| (*c as *const _, *p as *const _)).collect();
+                        let new_ids: Vec<(*const _, *const _)> = new_page.iter().map(|(c, p)| (*c as *const _, *p as *const _)).collect();
+                        assert_eq!(
+                            old_ids, new_ids,
+                            "density={density}, sort={label}, desc={descending}, offset={offset}, limit={limit}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// `walk_printing_page_via_popcount_skip`'s general (not card-invariance-gated) weighted scatter must
+/// produce the IDENTICAL page `walk_grouped_page`'s `Mode::Printing` branch does -- same rationale
+/// and same random-bitmap methodology as the `Mode::Card` differential test above, since one matching
+/// card can now contribute more than one row and the weighted scatter has its own off-by-one surface
+/// (block-level skip, then a fine per-printing skip within the located block) that a bare existence
+/// scatter doesn't.
+///
+/// `cargo test --release walk_printing_page_via_popcount_skip_matches_walk_grouped_page -- --ignored --nocapture`
+#[test]
+#[ignore = "needs real.store; cargo test --release walk_printing_page_via_popcount_skip_matches_walk_grouped_page -- --ignored --nocapture"]
+fn walk_printing_page_via_popcount_skip_matches_walk_grouped_page() {
+    use rand::SeedableRng;
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch — rebuild");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let ctx = QueryCtx::from(archived);
+    let n_cards = archived.cards.len();
+    let n_printings = archived.printings.len();
+    let words = n_printings.div_ceil(64);
+
+    const DENSITIES: [f64; 4] = [0.0005, 0.01, 0.2, 0.6];
+    const TRIALS_PER_DENSITY: usize = 3;
+    const PAGE_POINTS: [(usize, usize); 5] = [(0, 1), (0, 50), (10, 200), (5_000, 100), (1_000_000, 20)]; // last: past the total
+    const SORT_COLS: [(super::SortCol, &str); 3] =
+        [(super::SortCol::EdhrecRank, "edhrec"), (super::SortCol::Cmc, "cmc"), (super::SortCol::Name, "name")];
+
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(1);
+    for &density in &DENSITIES {
+        for _ in 0..TRIALS_PER_DENSITY {
+            let pbits = random_pbits(&mut rng, words, n_printings, density);
+            for &(sort_col, label) in &SORT_COLS {
+                for descending in [false, true] {
+                    let order = archived.indexes.sort_perms.order(sort_col, descending, n_cards).expect("permutation exists");
+                    for &(offset, limit) in &PAGE_POINTS {
+                        let params = kernel_params(Mode::Printing, sort_col, descending, limit, offset);
+                        let (old_page, _) = super::walk_grouped_page(&ctx, &params, &pbits, order.perm);
+                        let (new_page, _) = super::walk_printing_page_via_popcount_skip(&ctx, &params, &pbits, order);
+                        let old_ids: Vec<(*const _, *const _)> = old_page.iter().map(|(c, p)| (*c as *const _, *p as *const _)).collect();
+                        let new_ids: Vec<(*const _, *const _)> = new_page.iter().map(|(c, p)| (*c as *const _, *p as *const _)).collect();
+                        assert_eq!(
+                            old_ids, new_ids,
+                            "density={density}, sort={label}, desc={descending}, offset={offset}, limit={limit}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// `walk_artwork_page_via_popcount_skip`'s weighted-by-distinct-group scatter must produce the
+/// IDENTICAL page `walk_grouped_page`'s `Mode::Artwork` branch does -- same methodology as the other
+/// two differential tests, but the one most likely to catch a real bug: the scatter's per-card group
+/// dedup (`seen_groups`) and the emit phase's own group/prefer-score grouping have to agree on what
+/// counts as "one row" for a card with several matching printings, or the two implementations would
+/// diverge exactly where a card straddles multiple artwork groups.
+///
+/// `cargo test --release walk_artwork_page_via_popcount_skip_matches_walk_grouped_page -- --ignored --nocapture`
+#[test]
+#[ignore = "needs real.store; cargo test --release walk_artwork_page_via_popcount_skip_matches_walk_grouped_page -- --ignored --nocapture"]
+fn walk_artwork_page_via_popcount_skip_matches_walk_grouped_page() {
+    use rand::SeedableRng;
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch — rebuild");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let ctx = QueryCtx::from(archived);
+    let n_cards = archived.cards.len();
+    let n_printings = archived.printings.len();
+    let words = n_printings.div_ceil(64);
+
+    const DENSITIES: [f64; 4] = [0.0005, 0.01, 0.2, 0.6];
+    const TRIALS_PER_DENSITY: usize = 3;
+    const PAGE_POINTS: [(usize, usize); 5] = [(0, 1), (0, 50), (10, 200), (5_000, 100), (1_000_000, 20)]; // last: past the total
+    const SORT_COLS: [(super::SortCol, &str); 3] =
+        [(super::SortCol::EdhrecRank, "edhrec"), (super::SortCol::Cmc, "cmc"), (super::SortCol::Name, "name")];
+
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(2);
+    for &density in &DENSITIES {
+        for _ in 0..TRIALS_PER_DENSITY {
+            let pbits = random_pbits(&mut rng, words, n_printings, density);
+            for &(sort_col, label) in &SORT_COLS {
+                for descending in [false, true] {
+                    let order = archived.indexes.sort_perms.order(sort_col, descending, n_cards).expect("permutation exists");
+                    for &(offset, limit) in &PAGE_POINTS {
+                        let params = kernel_params(Mode::Artwork, sort_col, descending, limit, offset);
+                        let (old_page, _) = super::walk_grouped_page(&ctx, &params, &pbits, order.perm);
+                        let (new_page, _) = super::walk_artwork_page_via_popcount_skip(&ctx, &params, &pbits, order);
+                        let old_ids: Vec<(*const _, *const _)> = old_page.iter().map(|(c, p)| (*c as *const _, *p as *const _)).collect();
+                        let new_ids: Vec<(*const _, *const _)> = new_page.iter().map(|(c, p)| (*c as *const _, *p as *const _)).collect();
+                        assert_eq!(
+                            old_ids, new_ids,
+                            "density={density}, sort={label}, desc={descending}, offset={offset}, limit={limit}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// `walk_grouped_page`'s per-CARD fixed overhead vs its per-PRINTING bit-test cost, isolated the way
+/// `gather_artwork_kernel_costs` isolates `GATHER_ARTWORK_PER_PRINTING_NS`: reproduce the `Mode::
+/// Printing` loop body directly (`pbits` all-zero, so nothing ever matches and no downstream sort/
+/// emit work runs -- that's `COMPOSE_WALK_EMIT_PER_ROW_NS`'s job, not this kernel's), over several
+/// EDHREC-order card ranges chosen to vary the average printings/card sharply. That variation is the
+/// whole point: `local-engine-compose-perm-cards-visited-estimator.md` measured the first ranks of
+/// ascending EDHREC order at ~73 printings/card (reprint-heavy staples) against a corpus mean of ~3,
+/// so a two-term regression (ns ~= a*cards + b*printings) can actually separate the two rates here --
+/// unlike `local-engine-compose-build-rates.md`'s pooled-OLS-over-natural-queries attempt, which hit
+/// multicollinearity between cards_visited/printings_walked/matches and came back unusable.
+///
+/// `cargo test --release compose_walk_kernel_costs -- --ignored --nocapture`
+#[test]
+#[ignore = "compose-walk kernel cost; needs real.store; cargo test --release compose_walk_kernel_costs -- --ignored --nocapture"]
+fn compose_walk_kernel_costs() {
+    use std::hint::black_box;
+    use std::time::Instant;
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    const WARMUP: usize = 20;
+    const ITERS: usize = 200;
+
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch — rebuild");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let offsets = &archived.offsets;
+    let n_cards = archived.cards.len();
+    let n_printings = archived.printings.len();
+    // Materialized once, outside the timed section -- `walk_grouped_page` itself takes the archived
+    // permutation directly, but a plain `Vec<u32>` lets this kernel slice arbitrary rank RANGES the
+    // real function's own always-start-at-0 signature can't address.
+    let perm: Vec<u32> =
+        archived.indexes.sort_perms.get(super::SortCol::EdhrecRank, false).expect("edhrec perm").iter().map(|x| u32::from(*x)).collect();
+    // All-zero: no printing is ever "set", so `is_set` is always false, `scratch` never receives a
+    // push, and the loop never does the sort/skip/emit work below it -- exactly the isolation
+    // `gather_artwork_kernel_costs` gets from `all_match: true`, just for the opposite reason (there,
+    // every printing matches and residual cost is what's removed; here, none does, and match-handling
+    // cost is what's removed). What's left is only the walk itself: `cards_visited`'s per-step
+    // overhead and `printings_walked`'s per-printing bit-test, which is exactly what
+    // `COMPOSE_WALK_STEP_NS` and the candidate `COMPOSE_WALK_CARD_STEP_NS` are meant to price.
+    let pbits: Vec<u64> = vec![0u64; n_printings.div_ceil(64)];
+    let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
+
+    // (start, end) rank ranges spanning very different printings/card densities -- the labels are
+    // for readability, the regression only reads each range's own measured (cards, printings).
+    let ranges: [(usize, usize, &str); 6] = [
+        (0, 200, "edhrec top 200 (staples)"),
+        (200, 2_000, "edhrec 200-2k"),
+        (2_000, 6_000, "edhrec 2k-6k"),
+        (10_000, 16_000, "edhrec 10k-16k"),
+        (20_000, 28_000, "edhrec 20k-28k"),
+        (n_cards - 6_000, n_cards, "edhrec tail"),
+    ];
+
+    let bench_range = |start: usize, end: usize| -> (u128, u64, u64) {
+        let mut best = u128::MAX;
+        let (mut cards_visited, mut printings_examined) = (0u64, 0u64);
+        let mut scratch: Vec<Match> = Vec::new();
+        for it in 0..(WARMUP + ITERS) {
+            let (mut cv, mut pe) = (0u64, 0u64);
+            let t0 = Instant::now();
+            for &cid in &perm[start..end] {
+                let c = cid as usize;
+                let s = u32::from(offsets[c]) as usize;
+                let e = u32::from(offsets[c + 1]) as usize;
+                cv += 1;
+                pe += (e - s) as u64;
+                scratch.clear();
+                for pid in s..e {
+                    if is_set(pid) {
+                        scratch.push((0u128, cid, pid as u32)); // unreachable: pbits is all-zero
+                    }
+                }
+                if scratch.is_empty() {
+                    continue;
+                }
+                unreachable!("pbits is all-zero; scratch can never receive a push");
+            }
+            black_box(&scratch);
+            let dt = t0.elapsed().as_nanos();
+            if it >= WARMUP {
+                best = best.min(dt);
+                cards_visited = cv;
+                printings_examined = pe;
+            }
+        }
+        (best, cards_visited, printings_examined)
+    };
+
+    println!("\ncompose-walk kernel costs (real.store: {n_cards} cards, {n_printings} printings)");
+    println!("{:>28}  {:>8}  {:>10}  {:>10}  {:>12}", "range", "cards", "printings", "ns", "ns/card@0pr");
+    let mut rows: Vec<(f64, f64, f64)> = Vec::new();
+    for &(start, end, label) in &ranges {
+        let (ns, cards, printings) = bench_range(start, end);
+        println!("{label:>28}  {cards:>8}  {printings:>10}  {ns:>10}  {:>12.3}", ns as f64 / cards.max(1) as f64);
+        rows.push((cards as f64, printings as f64, ns as f64));
+    }
+
+    // Two-term, no-intercept OLS (`ns ~= a*cards + b*printings`): all-zero pbits means the loop body
+    // has no per-call fixed setup an intercept would legitimately absorb, so forcing one to zero
+    // spends both degrees of freedom on the two rates the kernel exists to separate. Normal equations
+    // for a 2x2 system, solved directly rather than pulling in a linear-algebra crate for two numbers.
+    let (mut sxx, mut sxy, mut syy, mut sxz, mut syz) = (0.0, 0.0, 0.0, 0.0, 0.0);
+    for &(cards, printings, ns) in &rows {
+        sxx += cards * cards;
+        sxy += cards * printings;
+        syy += printings * printings;
+        sxz += cards * ns;
+        syz += printings * ns;
+    }
+    let det = sxx * syy - sxy * sxy;
+    println!("\ncompose-walk kernel costs: two-term fit (ns = a*cards + b*printings, no intercept)");
+    if det.abs() < 1e-6 {
+        println!("  singular normal equations (ranges too collinear) — cannot separate the two rates");
+    } else {
+        let a = (syy * sxz - sxy * syz) / det; // candidate COMPOSE_WALK_CARD_STEP_NS
+        let b = (sxx * syz - sxy * sxz) / det; // candidate COMPOSE_WALK_STEP_NS, re-fit
+        println!("  a (ns/card)     = {a:.4}   <- candidate COMPOSE_WALK_CARD_STEP_NS");
+        println!("  b (ns/printing) = {b:.4}   <- candidate COMPOSE_WALK_STEP_NS, re-fit");
+        for &(cards, printings, ns) in &rows {
+            let pred = a * cards + b * printings;
+            println!("    cards={cards:>8.0}  printings={printings:>10.0}  meas={ns:>10.0}  pred={pred:>10.0}  pred/meas={:.3}", pred / ns);
+        }
+    }
+}
+
+/// Real-traffic wall-clock comparison of `walk_grouped_page` (`Mode::Card`) against the prototype
+/// `walk_card_page_via_popcount_skip`, over real keyword/oracle-tag values chosen to span the two
+/// regimes the two algorithms trade off on -- see `local-engine-compose-perm-cards-visited-estimator.md`:
+///
+/// - a COMMON value (`keyword:flying`, matches most of the corpus) at a SHALLOW page: the old walk
+///   should win, since it stops almost immediately and the new one pays a full scatter over every
+///   match regardless of how little of the walk was actually needed.
+/// - a SPARSE, CLUMPED value (`otag:triggered-ability` -- this session's own worked example, whose
+///   matches sit disproportionately among reprint-heavy EDHREC-early staples) at a deep page: the old
+///   walk has to step past many non-matching cards to accumulate enough matches, while the new one's
+///   cost is bounded by the match count alone, independent of where those matches happen to sit.
+///
+/// `cargo test --release compose_walk_popcount_skip_vs_walk -- --ignored --nocapture`
+#[test]
+#[ignore = "needs real.store; cargo test --release compose_walk_popcount_skip_vs_walk -- --ignored --nocapture"]
+fn compose_walk_popcount_skip_vs_walk() {
+    use std::hint::black_box;
+    use std::time::Instant;
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    const WARMUP: usize = 20;
+    const ITERS: usize = 300;
+
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch — rebuild");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let ctx = QueryCtx::from(archived);
+    let n_cards = archived.cards.len();
+    let n_printings = archived.printings.len();
+    let offsets = &archived.offsets;
+
+    let pbits_for = |field_ids: Option<Vec<u32>>| -> Vec<u64> {
+        let ids = field_ids.expect("value exists in this corpus");
+        super::broadcast_card_ids_to_printings(ids.into_iter(), offsets, n_printings)
+    };
+    let flying = pbits_for(archived.indexes.keywords.ids_of("flying"));
+    let triggered = pbits_for(archived.indexes.oracle_tags.ids_of("triggered-ability"));
+
+    let bench = |label: &str, pbits: &[u64], offset: usize, limit: usize| {
+        let order = archived.indexes.sort_perms.order(SortCol::EdhrecRank, false, n_cards).expect("edhrec perm");
+        let params = kernel_params(Mode::Card, SortCol::EdhrecRank, false, limit, offset);
+        let mut old_best = u128::MAX;
+        let mut new_best = u128::MAX;
+        for it in 0..(WARMUP + ITERS) {
+            let t0 = Instant::now();
+            let page = black_box(super::walk_grouped_page(&ctx, &params, pbits, order.perm).0);
+            let dt = t0.elapsed().as_nanos();
+            if it >= WARMUP {
+                old_best = old_best.min(dt);
+            }
+            black_box(page.len());
+        }
+        for it in 0..(WARMUP + ITERS) {
+            let t0 = Instant::now();
+            let page = black_box(super::walk_card_page_via_popcount_skip(&ctx, &params, pbits, order).0);
+            let dt = t0.elapsed().as_nanos();
+            if it >= WARMUP {
+                new_best = new_best.min(dt);
+            }
+            black_box(page.len());
+        }
+        println!(
+            "{label:<48} offset={offset:<8} limit={limit:<5} old={old_best:>8}ns  new={new_best:>8}ns  old/new={:.2}x",
+            old_best as f64 / new_best.max(1) as f64
+        );
+    };
+
+    println!("\ncompose walk: popcount-skip prototype vs walk_grouped_page ({n_cards} cards, {n_printings} printings)");
+    bench("keyword:flying (common, shallow page)", &flying, 0, 20);
+    bench("keyword:flying (common, deep-ish page)", &flying, 2_000, 20);
+    for &offset in &[0usize, 500, 1_000, 2_000, 4_000, 8_000, 15_000, 25_000] {
+        bench("otag:triggered-ability (offset sweep)", &triggered, offset, 20);
+    }
+}
+
+/// Same real-traffic comparison as `compose_walk_popcount_skip_vs_walk`, `Mode::Printing` instead of
+/// `Mode::Card` -- `walk_printing_page_via_popcount_skip` against `walk_grouped_page`'s `Printing`
+/// branch. The general (not card-invariance-shortcut) weighted scatter costs more per match than the
+/// bare existence one (a card-space lookup plus a rank lookup per matching PRINTING, not per matching
+/// card), so the crossover point is expected to sit further out than the `Mode::Card` sweep found --
+/// this measures where, rather than assuming the same offset carries over.
+///
+/// `cargo test --release compose_printing_walk_popcount_skip_vs_walk -- --ignored --nocapture`
+#[test]
+#[ignore = "needs real.store; cargo test --release compose_printing_walk_popcount_skip_vs_walk -- --ignored --nocapture"]
+fn compose_printing_walk_popcount_skip_vs_walk() {
+    use std::hint::black_box;
+    use std::time::Instant;
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    const WARMUP: usize = 20;
+    const ITERS: usize = 300;
+
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch — rebuild");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let ctx = QueryCtx::from(archived);
+    let n_cards = archived.cards.len();
+    let n_printings = archived.printings.len();
+    let offsets = &archived.offsets;
+
+    let pbits_for = |field_ids: Option<Vec<u32>>| -> Vec<u64> {
+        let ids = field_ids.expect("value exists in this corpus");
+        super::broadcast_card_ids_to_printings(ids.into_iter(), offsets, n_printings)
+    };
+    let flying = pbits_for(archived.indexes.keywords.ids_of("flying"));
+    let triggered = pbits_for(archived.indexes.oracle_tags.ids_of("triggered-ability"));
+
+    let bench = |label: &str, pbits: &[u64], offset: usize, limit: usize| {
+        let order = archived.indexes.sort_perms.order(SortCol::EdhrecRank, false, n_cards).expect("edhrec perm");
+        let params = kernel_params(Mode::Printing, SortCol::EdhrecRank, false, limit, offset);
+        let mut old_best = u128::MAX;
+        let mut new_best = u128::MAX;
+        for it in 0..(WARMUP + ITERS) {
+            let t0 = Instant::now();
+            let page = black_box(super::walk_grouped_page(&ctx, &params, pbits, order.perm).0);
+            let dt = t0.elapsed().as_nanos();
+            if it >= WARMUP {
+                old_best = old_best.min(dt);
+            }
+            black_box(page.len());
+        }
+        for it in 0..(WARMUP + ITERS) {
+            let t0 = Instant::now();
+            let page = black_box(super::walk_printing_page_via_popcount_skip(&ctx, &params, pbits, order).0);
+            let dt = t0.elapsed().as_nanos();
+            if it >= WARMUP {
+                new_best = new_best.min(dt);
+            }
+            black_box(page.len());
+        }
+        println!(
+            "{label:<48} offset={offset:<8} limit={limit:<5} old={old_best:>8}ns  new={new_best:>8}ns  old/new={:.2}x",
+            old_best as f64 / new_best.max(1) as f64
+        );
+    };
+
+    println!("\ncompose PRINTING-mode walk: popcount-skip prototype vs walk_grouped_page ({n_cards} cards, {n_printings} printings)");
+    bench("keyword:flying (common, shallow page)", &flying, 0, 20);
+    bench("keyword:flying (common, deep-ish page)", &flying, 2_000, 20);
+    for &offset in &[0usize, 500, 1_000, 2_000, 4_000, 8_000, 15_000, 25_000] {
+        bench("otag:triggered-ability (offset sweep)", &triggered, offset, 20);
+    }
+}
+
+/// Same real-traffic comparison again, `Mode::Artwork` instead of `Mode::Printing` --
+/// `walk_artwork_page_via_popcount_skip` against `walk_grouped_page`'s `Artwork` branch. The scatter
+/// here does more per-printing work than either other mode (a linear `seen_groups` scan on top of
+/// the card/rank lookups), so the crossover is expected to sit further out still; this measures
+/// where, rather than assuming it.
+///
+/// `cargo test --release compose_artwork_walk_popcount_skip_vs_walk -- --ignored --nocapture`
+#[test]
+#[ignore = "needs real.store; cargo test --release compose_artwork_walk_popcount_skip_vs_walk -- --ignored --nocapture"]
+fn compose_artwork_walk_popcount_skip_vs_walk() {
+    use std::hint::black_box;
+    use std::time::Instant;
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    const WARMUP: usize = 20;
+    const ITERS: usize = 300;
+
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch — rebuild");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let ctx = QueryCtx::from(archived);
+    let n_cards = archived.cards.len();
+    let n_printings = archived.printings.len();
+    let offsets = &archived.offsets;
+
+    let pbits_for = |field_ids: Option<Vec<u32>>| -> Vec<u64> {
+        let ids = field_ids.expect("value exists in this corpus");
+        super::broadcast_card_ids_to_printings(ids.into_iter(), offsets, n_printings)
+    };
+    let flying = pbits_for(archived.indexes.keywords.ids_of("flying"));
+    let triggered = pbits_for(archived.indexes.oracle_tags.ids_of("triggered-ability"));
+
+    let bench = |label: &str, pbits: &[u64], offset: usize, limit: usize| {
+        let order = archived.indexes.sort_perms.order(SortCol::EdhrecRank, false, n_cards).expect("edhrec perm");
+        let params = kernel_params(Mode::Artwork, SortCol::EdhrecRank, false, limit, offset);
+        let mut old_best = u128::MAX;
+        let mut new_best = u128::MAX;
+        for it in 0..(WARMUP + ITERS) {
+            let t0 = Instant::now();
+            let page = black_box(super::walk_grouped_page(&ctx, &params, pbits, order.perm).0);
+            let dt = t0.elapsed().as_nanos();
+            if it >= WARMUP {
+                old_best = old_best.min(dt);
+            }
+            black_box(page.len());
+        }
+        for it in 0..(WARMUP + ITERS) {
+            let t0 = Instant::now();
+            let page = black_box(super::walk_artwork_page_via_popcount_skip(&ctx, &params, pbits, order).0);
+            let dt = t0.elapsed().as_nanos();
+            if it >= WARMUP {
+                new_best = new_best.min(dt);
+            }
+            black_box(page.len());
+        }
+        println!(
+            "{label:<48} offset={offset:<8} limit={limit:<5} old={old_best:>8}ns  new={new_best:>8}ns  old/new={:.2}x",
+            old_best as f64 / new_best.max(1) as f64
+        );
+    };
+
+    println!("\ncompose ARTWORK-mode walk: popcount-skip prototype vs walk_grouped_page ({n_cards} cards, {n_printings} printings)");
+    bench("keyword:flying (common, shallow page)", &flying, 0, 20);
+    bench("keyword:flying (common, deep-ish page)", &flying, 2_000, 20);
+    for &offset in &[0usize, 500, 1_000, 2_000, 4_000, 8_000, 15_000, 25_000] {
+        bench("otag:triggered-ability (offset sweep)", &triggered, offset, 20);
+    }
+}
+
 /// #724 build-side correctness oracle: projecting a printing-space border plane up to card-existence
 /// (`printing_bits_to_card_bits`) must equal #664's card-space border plane for the same value —
 /// both mean "this card has a printing with border=value" (existence projection). Diffed for the


### PR DESCRIPTION
Part of #730's landing plan, step 2. Code-only, harvested from the `#[cfg(test)]` prototypes on `engine-compose-cards-visited-estimator` (#1009) — docs and benchmark scripts for this work land separately via #1028.

Promotes the three popcount-skip scatter prototypes (`walk_card_page_via_popcount_skip`, `walk_printing_page_via_popcount_skip`, `walk_artwork_page_via_popcount_skip`, plus their shared `finalize_artwork_card` helper) from `#[cfg(test)]`-only to real, always-compiled code. **Zero behavior change** — nothing in the dispatch path calls any of them yet; `#[allow(dead_code)]` (with a comment pointing at #730) suppresses the expected unused-function warnings until the decision-rule PR wires one in.

**Scope note**: dropped one test (`edhrec_walk_checkpoints_in_handles_three_conjuncts`) that was swept into the same investigation session but actually exercises the *rejected* `cards_visited` estimator work (see #1027), not the three-phase walk — out of scope here, and its subject was never going to ship anyway.

## Test plan

- [x] `cargo build --release`: clean
- [x] `cargo test --release`: 158/158 passing
- [x] `cargo clippy --release --all-targets`: clean (one pre-existing unrelated dead-code warning)
- [x] Rebuilt `real.store` fresh and re-ran the three differential correctness tests (`walk_{card,printing,artwork}_page_via_popcount_skip_matches_walk_grouped_page`, 360 cases each against `walk_grouped_page`) — all pass