### PR TITLE
API: Bound limit and offset with continuously growing pagination ceiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,8 +412,17 @@ curl -u admin:$(jq -r .ADMIN_PASSWORD env.json) http://localhost:28080/_admin/im
 
 ### Query Parameters
 
-The search endpoint supports comprehensive Scryfall syntax.
-See [syntax analysis](docs/technical/scryfall_syntax_analysis.md) for complete documentation.
+The `/search` endpoint accepts the following query parameters:
+
+- `q` or `query` (string): The search query in Scryfall-compatible syntax (see [syntax analysis](docs/technical/scryfall_syntax_analysis.md) for complete documentation).
+- `limit` (integer, default `100`): Maximum number of results to return. Must be an integer between `0` and the annual pagination ceiling: `(UTC current year - 2013) * 10_000` (e.g. 130,000 in 2026).
+- `offset` (integer, default `0`): Number of results to skip before returning cards. Must be an integer between `0` and the annual pagination ceiling: `(UTC current year - 2013) * 10_000` (e.g. 130,000 in 2026).
+- `orderby` (string, default `edhrec`): Field to sort by (`name`, `cmc`, `power`, `toughness`, `edhrec`, `rarity`, `usd`, `cubecobra`).
+- `direction` (string, default `asc`): Sort direction (`asc` or `desc`).
+- `unique` (string, default `card`): Result deduplication mode (`card`, `art`/`artwork`, `prints`/`printing`).
+- `prefer` (string, default `default`): Preferred printing selection when grouping (`oldest`, `newest`, `usd-low`, `usd-high`, `promo`, `default`).
+- `fields` (string): Comma-separated list of fields to return per card (see `RESULT_FIELD_COLUMNS` in `api/api_resource.py`).
+- `shape` (string, default `rows`): Response layout format (`rows` for list of card objects, `columnar` for columnar field dictionary).
 
 ## Development Notes
 

--- a/README.md
+++ b/README.md
@@ -415,8 +415,8 @@ curl -u admin:$(jq -r .ADMIN_PASSWORD env.json) http://localhost:28080/_admin/im
 The `/search` endpoint accepts the following query parameters:
 
 - `q` or `query` (string): The search query in Scryfall-compatible syntax (see [syntax analysis](docs/technical/scryfall_syntax_analysis.md) for complete documentation).
-- `limit` (integer, default `100`): Maximum number of results to return. Must be an integer between `0` and the annual pagination ceiling: `(UTC current year - 2013) * 10_000` (e.g. 130,000 in 2026).
-- `offset` (integer, default `0`): Number of results to skip before returning cards. Must be an integer between `0` and the annual pagination ceiling: `(UTC current year - 2013) * 10_000` (e.g. 130,000 in 2026).
+- `limit` (integer, default `100`): Maximum number of results to return. Must be an integer between `0` and the continuously growing pagination ceiling: `floor((current Unix timestamp - 1_409_018_789) / 3_155)`, which adds approximately 10,000 per year.
+- `offset` (integer, default `0`): Number of results to skip before returning cards. Must be an integer between `0` and the continuously growing pagination ceiling: `floor((current Unix timestamp - 1_409_018_789) / 3_155)`, which adds approximately 10,000 per year.
 - `orderby` (string, default `edhrec`): Field to sort by (`name`, `cmc`, `power`, `toughness`, `edhrec`, `rarity`, `usd`, `cubecobra`).
 - `direction` (string, default `asc`): Sort direction (`asc` or `desc`).
 - `unique` (string, default `card`): Result deduplication mode (`card`, `art`/`artwork`, `prints`/`printing`).

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -16,7 +16,7 @@ import time
 # of coercion. Ruff's TC003 wants it moved; the runtime-evaluated-decorators setting will make the noqa
 # unnecessary once handlers carry a route decorator.
 from collections.abc import Sequence  # noqa: TC003
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any, NoReturn
 
 import falcon
@@ -107,13 +107,13 @@ INTERNAL_ERROR_DESCRIPTION = "An internal error occurred."
 # search methods keep it optional (per review) and route/internal defaults can
 # never drift apart.
 DEFAULT_OFFSET = 0
-PAGINATION_BASE_YEAR = 2013
-PAGINATION_ANNUAL_STEP = 10_000
+PAGINATION_BASE_TIMESTAMP = 1_409_018_789
+PAGINATION_GROWTH_INTERVAL_SECONDS = 3_155
 
 
 def pagination_ceiling() -> int:
-    """Return the annual pagination ceiling for limit and offset: (UTC current year - 2013) * 10_000."""
-    return (datetime.now(tz=UTC).year - PAGINATION_BASE_YEAR) * PAGINATION_ANNUAL_STEP
+    """Return the continuously growing pagination ceiling for limit and offset."""
+    return int((time.time() - PAGINATION_BASE_TIMESTAMP) // PAGINATION_GROWTH_INTERVAL_SECONDS)
 
 
 RESULT_FIELD_COLUMNS: dict[str, str] = {
@@ -575,13 +575,15 @@ class APIResource:
             fields: Which fields to return per card (comma-separated in the query string). Defaults
                 to the usual 9 (name, set_code, collector_number, power, toughness, mana_cost,
                 oracle_text, set_name, type_line). See RESULT_FIELD_COLUMNS for the full vocabulary.
-            limit: Maximum number of results to return. Must be between 0 and the annual
-                pagination ceiling ((UTC current year - 2013) * 10,000; 130,000 in 2026). Defaults to 100.
+            limit: Maximum number of results to return. Must be between 0 and the
+                continuously growing pagination ceiling (approximately 10,000 additional
+                results per year). Defaults to 100.
             offset: Number of results to skip before the first returned card, in the
                 same sort order the query uses -- limit/offset together give clients
                 pagination over the full result set (total_cards is always the
-                unpaginated count). Must be between 0 and the annual pagination ceiling
-                ((UTC current year - 2013) * 10,000; 130,000 in 2026). Defaults to 0.
+                unpaginated count). Must be between 0 and the continuously growing
+                pagination ceiling (approximately 10,000 additional results per year).
+                Defaults to 0.
             orderby: Field to sort by.
             shape: Shape of the "cards" list: 'rows' (list of card objects, default) or
                 'columnar' (one list per field, keyed by field name — smaller on the wire).

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -16,7 +16,7 @@ import time
 # of coercion. Ruff's TC003 wants it moved; the runtime-evaluated-decorators setting will make the noqa
 # unnecessary once handlers carry a route decorator.
 from collections.abc import Sequence  # noqa: TC003
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, NoReturn
 
 import falcon
@@ -107,6 +107,14 @@ INTERNAL_ERROR_DESCRIPTION = "An internal error occurred."
 # search methods keep it optional (per review) and route/internal defaults can
 # never drift apart.
 DEFAULT_OFFSET = 0
+PAGINATION_BASE_YEAR = 2013
+PAGINATION_ANNUAL_STEP = 10_000
+
+
+def pagination_ceiling() -> int:
+    """Return the annual pagination ceiling for limit and offset: (UTC current year - 2013) * 10_000."""
+    return (datetime.now(tz=UTC).year - PAGINATION_BASE_YEAR) * PAGINATION_ANNUAL_STEP
+
 
 RESULT_FIELD_COLUMNS: dict[str, str] = {
     "name": "card_name",
@@ -567,11 +575,13 @@ class APIResource:
             fields: Which fields to return per card (comma-separated in the query string). Defaults
                 to the usual 9 (name, set_code, collector_number, power, toughness, mana_cost,
                 oracle_text, set_name, type_line). See RESULT_FIELD_COLUMNS for the full vocabulary.
-            limit: Maximum number of results to return.
+            limit: Maximum number of results to return. Must be between 0 and the annual
+                pagination ceiling ((UTC current year - 2013) * 10,000; 130,000 in 2026). Defaults to 100.
             offset: Number of results to skip before the first returned card, in the
                 same sort order the query uses -- limit/offset together give clients
                 pagination over the full result set (total_cards is always the
-                unpaginated count).
+                unpaginated count). Must be between 0 and the annual pagination ceiling
+                ((UTC current year - 2013) * 10,000; 130,000 in 2026). Defaults to 0.
             orderby: Field to sort by.
             shape: Shape of the "cards" list: 'rows' (list of card objects, default) or
                 'columnar' (one list per field, keyed by field name — smaller on the wire).
@@ -599,27 +609,23 @@ class APIResource:
 
     def _validate_offset(self, offset: int) -> int:
         """Validate the offset and return it if valid."""
-        if not isinstance(offset, int) or offset < 0:
+        ceiling = pagination_ceiling()
+        if not isinstance(offset, int) or isinstance(offset, bool) or offset < 0 or offset > ceiling:
             raise falcon.HTTPBadRequest(
                 title="Invalid Offset",
-                description="Offset must be a non-negative integer.",
+                description=f"Offset must be an integer between 0 and {ceiling}.",
             )
         return offset
 
     def _validate_limit(self, limit: int | None) -> int | None:
         """Validate the limit and return it if valid."""
         if limit is None:
-            pass
-        elif isinstance(limit, int):
-            if limit < 0:
-                raise falcon.HTTPBadRequest(
-                    title="Invalid Limit",
-                    description="Limit must be a positive integer.",
-                )
-        else:
+            return None
+        ceiling = pagination_ceiling()
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit < 0 or limit > ceiling:
             raise falcon.HTTPBadRequest(
                 title="Invalid Limit",
-                description="Limit must be an integer.",
+                description=f"Limit must be an integer between 0 and {ceiling}.",
             )
         return limit
 

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -607,16 +607,132 @@ class TestSearchResponseShape(TestBaseAPIResourceTest):
         assert list(api_resource_module._columnarize_cards(cards)) == ["b", "a"]
 
 
-class TestOffsetValidation(TestBaseAPIResourceTest):
-    """offset must be a non-negative integer; violations are 400s, not silent clamps."""
+class TestPaginationCeiling(unittest.TestCase):
+    """Annual pagination ceiling formula: (UTC current year - 2013) * 10,000."""
 
-    def test_negative_offset_rejected(self) -> None:
-        with pytest.raises(falcon.HTTPBadRequest):
-            self.api_resource._validate_offset(-1)
+    def test_annual_ceiling_formula_current_year(self) -> None:
+        ceiling = api_resource_module.pagination_ceiling()
+        current_year = api_resource_module.datetime.now(tz=api_resource_module.UTC).year
+        assert ceiling == (current_year - api_resource_module.PAGINATION_BASE_YEAR) * api_resource_module.PAGINATION_ANNUAL_STEP
+
+    def test_annual_ceiling_formula_historical_and_future_years(self) -> None:
+        with patch("api.api_resource.datetime") as mock_dt:
+            mock_dt.now.return_value.year = 2026
+            assert api_resource_module.pagination_ceiling() == 130_000
+
+            mock_dt.now.return_value.year = 2024
+            assert api_resource_module.pagination_ceiling() == 110_000
+
+            mock_dt.now.return_value.year = 2030
+            assert api_resource_module.pagination_ceiling() == 170_000
+
+
+class TestLimitValidation(TestBaseAPIResourceTest):
+    """limit must be None or an integer within [0, ceiling]; violations are 400s."""
+
+    def test_none_limit_passes_through(self) -> None:
+        assert self.api_resource._validate_limit(None) is None
+
+    def test_zero_limit_is_valid(self) -> None:
+        assert self.api_resource._validate_limit(0) == 0
+
+    def test_default_limit_is_valid(self) -> None:
+        assert self.api_resource._validate_limit(100) == 100
+
+    def test_exact_boundary_ceiling_is_valid(self) -> None:
+        ceiling = api_resource_module.pagination_ceiling()
+        assert self.api_resource._validate_limit(ceiling) == ceiling
+
+    def test_max_plus_one_limit_rejected(self) -> None:
+        ceiling = api_resource_module.pagination_ceiling()
+        with pytest.raises(falcon.HTTPBadRequest) as exc_info:
+            self.api_resource._validate_limit(ceiling + 1)
+        assert exc_info.value.title == "Invalid Limit"
+        assert exc_info.value.description == f"Limit must be an integer between 0 and {ceiling}."
+
+    def test_negative_limit_rejected(self) -> None:
+        ceiling = api_resource_module.pagination_ceiling()
+        with pytest.raises(falcon.HTTPBadRequest) as exc_info:
+            self.api_resource._validate_limit(-1)
+        assert exc_info.value.title == "Invalid Limit"
+        assert exc_info.value.description == f"Limit must be an integer between 0 and {ceiling}."
+
+    @pytest.mark.parametrize("invalid_value", [True, False, "100", 10.5, [100], {"limit": 100}])
+    def test_non_integer_limit_rejected(self, invalid_value: Any) -> None:
+        with pytest.raises(falcon.HTTPBadRequest) as exc_info:
+            self.api_resource._validate_limit(invalid_value)
+        assert exc_info.value.title == "Invalid Limit"
+
+
+class TestOffsetValidation(TestBaseAPIResourceTest):
+    """offset must be an integer within [0, ceiling]; violations are 400s, not silent clamps."""
+
+    def test_zero_offset_is_valid(self) -> None:
+        assert self.api_resource._validate_offset(0) == 0
 
     def test_valid_offsets_pass_through(self) -> None:
-        assert self.api_resource._validate_offset(0) == 0
         assert self.api_resource._validate_offset(175) == 175
+
+    def test_exact_boundary_ceiling_is_valid(self) -> None:
+        ceiling = api_resource_module.pagination_ceiling()
+        assert self.api_resource._validate_offset(ceiling) == ceiling
+
+    def test_max_plus_one_offset_rejected(self) -> None:
+        ceiling = api_resource_module.pagination_ceiling()
+        with pytest.raises(falcon.HTTPBadRequest) as exc_info:
+            self.api_resource._validate_offset(ceiling + 1)
+        assert exc_info.value.title == "Invalid Offset"
+        assert exc_info.value.description == f"Offset must be an integer between 0 and {ceiling}."
+
+    def test_negative_offset_rejected(self) -> None:
+        ceiling = api_resource_module.pagination_ceiling()
+        with pytest.raises(falcon.HTTPBadRequest) as exc_info:
+            self.api_resource._validate_offset(-1)
+        assert exc_info.value.title == "Invalid Offset"
+        assert exc_info.value.description == f"Offset must be an integer between 0 and {ceiling}."
+
+    @pytest.mark.parametrize("invalid_value", [True, False, "0", 175.5, [0], {"offset": 0}])
+    def test_non_integer_offset_rejected(self, invalid_value: Any) -> None:
+        with pytest.raises(falcon.HTTPBadRequest) as exc_info:
+            self.api_resource._validate_offset(invalid_value)
+        assert exc_info.value.title == "Invalid Offset"
+
+
+class TestSearchPaginationBounds:
+    """Search endpoint independently enforces annual ceiling bounds for limit and offset."""
+
+    @pytest.fixture(autouse=True)
+    def _api(self, stub_api_resource: APIResource) -> None:
+        self.api_resource = stub_api_resource
+        mock_engine = MagicMock()
+        mock_engine.size.return_value = 100
+        self.api_resource.app_context.engine = mock_engine
+
+    def test_search_accepts_zero_limit(self) -> None:
+        with patch.object(self.api_resource, "_search_engine", return_value={"cards": [], "total_cards": 100}):
+            result = self.api_resource._search(query="name:bolt", limit=0)
+            assert result["cards"] == []
+
+    def test_search_accepts_both_at_ceiling_independently(self) -> None:
+        ceiling = api_resource_module.pagination_ceiling()
+        with patch.object(self.api_resource, "_search_engine", return_value={"cards": [], "total_cards": 100}) as mock_engine:
+            self.api_resource._search(query="name:bolt", limit=ceiling, offset=ceiling)
+            mock_engine.assert_called_once()
+            call_kwargs = mock_engine.call_args[1]
+            assert call_kwargs["limit"] == ceiling
+            assert call_kwargs["offset"] == ceiling
+
+    def test_search_rejects_limit_above_ceiling(self) -> None:
+        ceiling = api_resource_module.pagination_ceiling()
+        with pytest.raises(falcon.HTTPBadRequest) as exc_info:
+            self.api_resource._search(query="name:bolt", limit=ceiling + 1)
+        assert exc_info.value.title == "Invalid Limit"
+
+    def test_search_rejects_offset_above_ceiling(self) -> None:
+        ceiling = api_resource_module.pagination_ceiling()
+        with pytest.raises(falcon.HTTPBadRequest) as exc_info:
+            self.api_resource._search(query="name:bolt", offset=ceiling + 1)
+        assert exc_info.value.title == "Invalid Offset"
 
 
 class TestIdentityLetters(unittest.TestCase):

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -608,23 +608,30 @@ class TestSearchResponseShape(TestBaseAPIResourceTest):
 
 
 class TestPaginationCeiling(unittest.TestCase):
-    """Annual pagination ceiling formula: (UTC current year - 2013) * 10,000."""
+    """The pagination ceiling grows continuously at approximately 10,000 per year."""
 
-    def test_annual_ceiling_formula_current_year(self) -> None:
-        ceiling = api_resource_module.pagination_ceiling()
-        current_year = api_resource_module.datetime.now(tz=api_resource_module.UTC).year
-        assert ceiling == (current_year - api_resource_module.PAGINATION_BASE_YEAR) * api_resource_module.PAGINATION_ANNUAL_STEP
+    def test_base_timestamp_starts_at_zero(self) -> None:
+        with patch("api.api_resource.time.time", return_value=api_resource_module.PAGINATION_BASE_TIMESTAMP):
+            assert api_resource_module.pagination_ceiling() == 0
 
-    def test_annual_ceiling_formula_historical_and_future_years(self) -> None:
-        with patch("api.api_resource.datetime") as mock_dt:
-            mock_dt.now.return_value.year = 2026
-            assert api_resource_module.pagination_ceiling() == 130_000
+    def test_ceiling_increases_once_per_growth_interval(self) -> None:
+        interval = api_resource_module.PAGINATION_GROWTH_INTERVAL_SECONDS
+        timestamp = api_resource_module.PAGINATION_BASE_TIMESTAMP + (120_000 * interval)
 
-            mock_dt.now.return_value.year = 2024
-            assert api_resource_module.pagination_ceiling() == 110_000
+        with patch("api.api_resource.time.time", return_value=timestamp + interval - 1):
+            assert api_resource_module.pagination_ceiling() == 120_000
 
-            mock_dt.now.return_value.year = 2030
-            assert api_resource_module.pagination_ceiling() == 170_000
+        with patch("api.api_resource.time.time", return_value=timestamp + interval):
+            assert api_resource_module.pagination_ceiling() == 120_001
+
+    def test_ceiling_is_an_integer(self) -> None:
+        timestamp = api_resource_module.PAGINATION_BASE_TIMESTAMP + (
+            120_000.5 * api_resource_module.PAGINATION_GROWTH_INTERVAL_SECONDS
+        )
+        with patch("api.api_resource.time.time", return_value=timestamp):
+            ceiling = api_resource_module.pagination_ceiling()
+        assert ceiling == 120_000
+        assert isinstance(ceiling, int)
 
 
 class TestLimitValidation(TestBaseAPIResourceTest):
@@ -699,7 +706,7 @@ class TestOffsetValidation(TestBaseAPIResourceTest):
 
 
 class TestSearchPaginationBounds:
-    """Search endpoint independently enforces annual ceiling bounds for limit and offset."""
+    """Search endpoint independently enforces the dynamic ceiling for limit and offset."""
 
     @pytest.fixture(autouse=True)
     def _api(self, stub_api_resource: APIResource) -> None:

--- a/api/tests/test_parsing_errors.py
+++ b/api/tests/test_parsing_errors.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import falcon
 import pytest
 
+import api.api_resource as api_resource_module
 from api.settings import settings
 from api.tests.helpers import search_kwargs
 from api.tests.support import override_attr
@@ -209,6 +210,18 @@ class TestSearchRouting:
         with pytest.raises(falcon.HTTPBadRequest) as exc_info:
             self.api_resource._search(query="name:opt", limit=-1)
         assert exc_info.value.title == "Invalid Limit"
+
+    def test_limit_above_ceiling_raises_bad_request(self) -> None:
+        ceiling = api_resource_module.pagination_ceiling()
+        with pytest.raises(falcon.HTTPBadRequest) as exc_info:
+            self.api_resource._search(query="name:opt", limit=ceiling + 1)
+        assert exc_info.value.title == "Invalid Limit"
+
+    def test_offset_above_ceiling_raises_bad_request(self) -> None:
+        ceiling = api_resource_module.pagination_ceiling()
+        with pytest.raises(falcon.HTTPBadRequest) as exc_info:
+            self.api_resource._search(query="name:opt", offset=ceiling + 1)
+        assert exc_info.value.title == "Invalid Offset"
 
     def test_raises_service_unavailable_when_setup_incomplete(self) -> None:
         override_attr(self.api_resource.app_context, "setup_complete", lambda: False)


### PR DESCRIPTION
## Summary

- Adds `pagination_ceiling()` for public `/search` pagination bounds: `floor((current Unix timestamp - 1_409_018_789) / 3_155)`, using `PAGINATION_BASE_TIMESTAMP = 1_409_018_789` (2014-08-26 UTC, ceiling `0` at that instant) and `PAGINATION_GROWTH_INTERVAL_SECONDS = 3_155` (~one step every 52m 35s, ~10,000 steps per calendar year).
- Validates `limit` and `offset` independently: each must be an integer with `0 <= value <= pagination_ceiling()`; violations return HTTP 400 (`Invalid Limit` / `Invalid Offset`) with the current ceiling in the message; non-integers (including booleans) are rejected the same way.
- Preserves existing behavior: default `limit=100` and `offset=0`, accepts `limit=0`, and `_validate_limit(None)` still passes `None` through for internal callers.
- Documents the `/search` query parameters and the continuously growing ceiling formula in `README.md` (replacing the earlier discrete annual `(year - 2013) * 10_000` approach from the first commit).

**Example (2026):** on 2026-08-25 the ceiling is ~**120,012** (it increases by one every 3,155 seconds rather than jumping once per year).

## Test plan

- `TestPaginationCeiling` in `api/tests/test_api_resource.py`: ceiling `0` at the base timestamp, +1 per growth interval, integer truncation.
- `TestLimitValidation` / `TestOffsetValidation`: `None`/`0`/defaults, exact ceiling boundary, `ceiling + 1`, negatives, and non-integer types.
- `TestSearchPaginationBounds`: `_search` accepts `limit=0`, accepts both `limit` and `offset` at the ceiling together, rejects either parameter above the ceiling.
- `TestSearchRouting` in `api/tests/test_parsing_errors.py`: routing-level HTTP 400 for `limit`/`offset` above the ceiling.
- [ ] `python -m pytest api/tests/test_api_resource.py api/tests/test_parsing_errors.py`
- [ ] `python -m ruff check .` and `python -m ruff format --check .`