### PR TITLE
Escape Literal Less-Than Characters in Embedded Search Results JSON

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -45,6 +45,7 @@ from api.utils.page_rendering import (
     STATIC_DIR,
     build_base_html,
     build_card_html,
+    serialize_embedded_json,
     serve_static_file,
 )
 from api.utils.param_binding import ParamCoercionError
@@ -1105,7 +1106,7 @@ class APIResource:
                     )
 
                 # Convert search results to JSON and embed for JavaScript enhancement
-                search_results_json = orjson.dumps(search_results).decode("utf-8")
+                search_results_json = serialize_embedded_json(search_results)
                 embedded_data = f"""// Server-side embedded search results
       window.EMBEDDED_SEARCH_RESULTS = {search_results_json};
       """

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -1,5 +1,6 @@
 """Comprehensive tests for APIResource class functionality."""
 
+import json
 import multiprocessing
 import os
 import pathlib
@@ -814,6 +815,30 @@ class TestAPIResourceStaticFileServing(unittest.TestCase):
 
         # Verify it sets appropriate cache control header (shorter for search results)
         mock_response.set_header.assert_called_with("Cache-Control", "public, max-age=90")
+
+    def test_index_html_with_hostile_query_escapes_script_context(self) -> None:
+        """Test _root prevents script context breakout when query/results contain closing script tags."""
+        mock_response = MagicMock()
+        hostile_query = "</script><script>alert('xss')</script>"
+        mock_search_results = {
+            "cards": [{"name": "<script>alert(1)</script>", "set_code": "m14", "collector_number": "1"}],
+            "total_cards": 1,
+            "query": hostile_query,
+        }
+
+        with patch.object(self.api_resource, "_search", return_value=mock_search_results):
+            self.api_resource._root(falcon_response=mock_response, q=hostile_query)
+
+        # Response must not contain unescaped closing script tags in embedded JSON
+        marker = "window.EMBEDDED_SEARCH_RESULTS = "
+        assert marker in mock_response.text
+        start = mock_response.text.index(marker) + len(marker)
+        end = mock_response.text.index(";", start)
+        embedded_json = mock_response.text[start:end]
+
+        assert "<" not in embedded_json
+        assert "</script>" not in embedded_json
+        assert json.loads(embedded_json) == mock_search_results
 
     def test_index_html_with_query_embeds_results_count_in_status_message(self) -> None:
         """Test _root injects the results count into the #statusMessage container.

--- a/api/tests/test_page_rendering.py
+++ b/api/tests/test_page_rendering.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -10,6 +11,7 @@ import falcon
 from api.api_resource import APIResource
 from api.tests.support import mock_app_context
 from api.utils import page_rendering
+from api.utils.page_rendering import serialize_embedded_json
 
 
 class TestServeStaticFile(unittest.TestCase):
@@ -79,3 +81,69 @@ class TestHtmlMinification(unittest.TestCase):
             self.api_resource._root(falcon_response=mock_response, q="elf")
         assert "window.EMBEDDED_SEARCH_RESULTS = {" in mock_response.text
         assert "Elvish Mystic" in mock_response.text
+
+    def test_hostile_query_in_search_results_escapes_script_breakout(self) -> None:
+        mock_response = MagicMock()
+        hostile_query = "</script><script>alert('xss')</script>"
+        mock_search_results = {
+            "cards": [{"name": "<img src=x onerror=alert(1)>", "set_code": "m14", "collector_number": "1"}],
+            "total_cards": 1,
+            "query": hostile_query,
+        }
+        with patch.object(self.api_resource, "_search", return_value=mock_search_results):
+            self.api_resource._root(falcon_response=mock_response, q=hostile_query)
+
+        # The embedded script assignment must not contain literal closing script tags or < characters
+        assert "window.EMBEDDED_SEARCH_RESULTS = " in mock_response.text
+        # Extract the script content containing the embedded data
+        script_marker = "window.EMBEDDED_SEARCH_RESULTS = "
+        script_start = mock_response.text.index(script_marker) + len(script_marker)
+        script_end = mock_response.text.index(";", script_start)
+        embedded_json = mock_response.text[script_start:script_end]
+
+        assert "<" not in embedded_json
+        assert "</script>" not in embedded_json
+
+        # Hydration parity: parsing the escaped JSON yields the exact original payload
+        hydrated = json.loads(embedded_json)
+        assert hydrated == mock_search_results
+
+
+class TestSerializeEmbeddedJson(unittest.TestCase):
+    """serialize_embedded_json produces HTML-script-safe JSON by escaping literal `<`."""
+
+    def test_escapes_literal_less_than(self) -> None:
+        payload = {"tag": "<script>", "arrow": "a < b", "nested": [{"key": "<value>"}]}
+        serialized = serialize_embedded_json(payload)
+
+        assert "<" not in serialized
+        assert r"\u003c" in serialized
+        assert json.loads(serialized) == payload
+
+    def test_hostile_script_closing_payload(self) -> None:
+        payload = {
+            "query": "</script><script>alert('breakout')</script>",
+            "comment": "<!-- comment -->",
+        }
+        serialized = serialize_embedded_json(payload)
+
+        assert "<" not in serialized
+        assert "</script>" not in serialized
+        assert "<!--" not in serialized
+        assert json.loads(serialized) == payload
+
+    def test_preserves_complex_datatypes_and_unicode(self) -> None:
+        payload = {
+            "string": "Lim-Dûl's Vault",
+            "escapes": 'quote: ", backslash: \\, newline: \n, tab: \t',
+            "numbers": [0, 42, -3.14, 1e-5],
+            "booleans": [True, False],
+            "null": None,
+            "html_entities": "&amp; &lt; &gt; &quot;",
+            "script_tags": "</script><script src=\"evil.js\"></script>",
+        }
+        serialized = serialize_embedded_json(payload)
+
+        assert "<" not in serialized
+        assert json.loads(serialized) == payload
+

--- a/api/tests/test_page_rendering.py
+++ b/api/tests/test_page_rendering.py
@@ -140,7 +140,7 @@ class TestSerializeEmbeddedJson(unittest.TestCase):
             "booleans": [True, False],
             "null": None,
             "html_entities": "&amp; &lt; &gt; &quot;",
-            "script_tags": "</script><script src=\"evil.js\"></script>",
+            "script_tags": '</script><script src="evil.js"></script>',
         }
         serialized = serialize_embedded_json(payload)
 

--- a/api/utils/page_rendering.py
+++ b/api/utils/page_rendering.py
@@ -16,6 +16,7 @@ import pathlib
 
 import falcon
 import minify_html
+import orjson
 from cachebox import LRUCache
 
 from api.utils.caching import cached
@@ -142,3 +143,19 @@ def build_card_html(critical_css: str) -> str:
     if _CARD_JS_HASH:
         html = html.replace("/static/card.js", f"/static/card.js?v={_CARD_JS_HASH}")
     return _minify_html(html)
+
+
+def serialize_embedded_json(data: object) -> str:
+    """Serialize data to JSON safe for inlining inside an HTML script tag.
+
+    Replaces literal `<` with `\\u003c` so strings containing `</script>` or `<!--`
+    cannot prematurely close the script context in HTML parsers.
+
+    Args:
+        data: The JSON-serializable Python data structure.
+
+    Returns:
+        JSON string safe for embedding inside an inline HTML <script> block.
+    """
+    return orjson.dumps(data).decode("utf-8").replace("<", "\\u003c")
+

--- a/api/utils/page_rendering.py
+++ b/api/utils/page_rendering.py
@@ -146,7 +146,7 @@ def build_card_html(critical_css: str) -> str:
 
 
 def serialize_embedded_json(data: object) -> str:
-    """Serialize data to JSON safe for inlining inside an HTML script tag.
+    r"""Serialize data to JSON safe for inlining inside an HTML script tag.
 
     Replaces literal `<` with `\\u003c` so strings containing `</script>` or `<!--`
     cannot prematurely close the script context in HTML parsers.


### PR DESCRIPTION
## Summary
- Escape literal `<` characters as `\u003c` in `serialize_embedded_json` when serializing search results for inline `<script>` embedding on the homepage.
- Prevents raw tag or script closing sequences in queries or card attributes from breaking out of HTML script data state.
- Preserves the existing `window.EMBEDDED_SEARCH_RESULTS` hydration contract and JavaScript object semantics without modifying the server-rendered no-JS markup path.

## Test plan
- Added unit tests in `TestSerializeEmbeddedJson` verifying literal `<` escaping, hostile script-closing payload round-trips, and preservation of complex datatypes and Unicode.
- Added regression tests in `test_page_rendering.py` and `test_api_resource.py` verifying hostile queries do not break out of script tags in rendered HTML and deserialize to equivalent payload objects.
- Ran full test suite (`pytest`) and lint/format checks (`ruff check`, `ruff format --check`).