### PR TITLE
Enforce public search query complexity bounds

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -29,7 +29,8 @@ from api.app_context import AppContext
 from api.enums import CardOrdering, PreferOrder, ResponseShape, SortDirection, UniqueOn
 from api.middlewares.timing import record_span
 from api.noscript_helpers import generate_results_count_html, generate_results_html
-from api.parsing import generate_sql_query, parse_scryfall_query
+from api.parsing import QueryBudgetExceeded, generate_sql_query, parse_scryfall_query
+from api.parsing.query_budget import bounded_query_log_context
 from api.settings import settings
 from api.utils import db_utils, error_monitoring
 from api.utils.css_utils import build_critical_css
@@ -622,7 +623,7 @@ class APIResource:
             )
         return limit
 
-    def _search(  # noqa: PLR0913
+    def _search(  # noqa: PLR0912, PLR0913
         self,
         *,
         direction: SortDirection = SortDirection.ASC,
@@ -660,6 +661,18 @@ class APIResource:
         try:
             with timer("parse"):
                 parsed_query = parse_scryfall_query(query)
+        except QueryBudgetExceeded as err:
+            log_ctx = bounded_query_log_context(query)
+            logger.info(
+                "Query budget exceeded (%s) preview=%r digest=%s",
+                err.kind,
+                log_ctx["query_preview"],
+                log_ctx["query_digest"],
+            )
+            raise falcon.HTTPBadRequest(
+                title="Invalid Search Query",
+                description=err.user_message,
+            ) from err
         except ValueError as err:
             _raise_query_bad_request(exc_name="ValueError", query=query, description=f'Failed to parse query: "{query}"', err=err)
 

--- a/api/api_worker.py
+++ b/api/api_worker.py
@@ -128,7 +128,7 @@ class ApiWorker(multiprocessing.Process):
             middleware=[
                 TimingMiddleware(),
                 AdminAuthMiddleware(),  # ahead of caching: a rejected admin request must never hit the cache
-                SearchBudgetMiddleware(),  # ahead of logging/caching: reject over-budget /search early
+                SearchBudgetMiddleware(),  # ahead of logging/caching: skip parser/handler on over-budget /search
                 QueryLogMiddleware(),  # process_response fires before TimingMiddleware's
                 CachingMiddleware(cache=shared_cache),
                 CompressionMiddleware(),

--- a/api/api_worker.py
+++ b/api/api_worker.py
@@ -108,6 +108,7 @@ class ApiWorker(multiprocessing.Process):
             CompressionMiddleware,
             CORSMiddleware,
             QueryLogMiddleware,
+            SearchBudgetMiddleware,
             SecurityHeadersMiddleware,
             TimingMiddleware,
         )
@@ -127,6 +128,7 @@ class ApiWorker(multiprocessing.Process):
             middleware=[
                 TimingMiddleware(),
                 AdminAuthMiddleware(),  # ahead of caching: a rejected admin request must never hit the cache
+                SearchBudgetMiddleware(),  # ahead of logging/caching: reject over-budget /search early
                 QueryLogMiddleware(),  # process_response fires before TimingMiddleware's
                 CachingMiddleware(cache=shared_cache),
                 CompressionMiddleware(),

--- a/api/middlewares/__init__.py
+++ b/api/middlewares/__init__.py
@@ -14,6 +14,7 @@ from api.middlewares.compression import CompressionMiddleware
 from api.middlewares.cors_middleware import CORSMiddleware
 from api.middlewares.logging_middleware import LoggingMiddleware
 from api.middlewares.query_log_middleware import QueryLogMiddleware
+from api.middlewares.search_budget_middleware import SearchBudgetMiddleware
 from api.middlewares.security_headers import SecurityHeadersMiddleware
 from api.middlewares.timing import ProfilingMiddleware, TimingMiddleware
 
@@ -25,6 +26,7 @@ __all__ = [
     "LoggingMiddleware",
     "ProfilingMiddleware",
     "QueryLogMiddleware",
+    "SearchBudgetMiddleware",
     "SecurityHeadersMiddleware",
     "TimingMiddleware",
 ]

--- a/api/middlewares/search_budget_middleware.py
+++ b/api/middlewares/search_budget_middleware.py
@@ -1,0 +1,49 @@
+"""Early rejection for /search queries that exceed measured complexity bounds."""
+
+from __future__ import annotations
+
+import logging
+
+import falcon
+
+from api.parsing.query_budget import (
+    QueryBudgetExceeded,
+    bounded_query_log_context,
+    check_search_param_lengths,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SearchBudgetMiddleware:
+    """Reject over-budget /search requests before query logging or caching.
+
+    Runs ahead of QueryLogMiddleware and CachingMiddleware so rejected requests
+    never allocate cache keys, log rows, or parser work.
+    """
+
+    def process_request(self, req: falcon.Request, resp: falcon.Response) -> None:
+        """Validate ``q`` and ``query`` byte lengths for /search requests."""
+        if req.path.strip("/") != "search":
+            return
+        try:
+            check_search_param_lengths(req.params)
+        except QueryBudgetExceeded as exc:
+            q_value = req.params.get("q")
+            query_value = req.params.get("query")
+            sample = q_value if q_value is not None else query_value if query_value is not None else ""
+            if isinstance(sample, list):
+                sample = sample[0] if sample else ""
+            log_ctx = bounded_query_log_context(str(sample))
+            logger.info(
+                "Search budget rejected request (%s) preview=%r digest=%s",
+                exc.kind,
+                log_ctx["query_preview"],
+                log_ctx["query_digest"],
+            )
+            resp.status = falcon.HTTP_400
+            resp.media = {
+                "title": "Invalid Search Query",
+                "description": exc.user_message,
+            }
+            resp.complete = True

--- a/api/middlewares/search_budget_middleware.py
+++ b/api/middlewares/search_budget_middleware.py
@@ -16,10 +16,11 @@ logger = logging.getLogger(__name__)
 
 
 class SearchBudgetMiddleware:
-    """Reject over-budget /search requests before query logging or caching.
+    """Reject over-budget ``/search`` byte lengths before parsing or the search handler.
 
-    Runs ahead of QueryLogMiddleware and CachingMiddleware so rejected requests
-    never allocate cache keys, log rows, or parser work.
+    Runs ahead of ``QueryLogMiddleware`` and ``CachingMiddleware`` so rejected requests
+    skip parsing and never reach ``_search``. Downstream ``process_response`` hooks may
+    still record or cache the 400.
     """
 
     def process_request(self, req: falcon.Request, resp: falcon.Response) -> None:

--- a/api/middlewares/search_budget_middleware.py
+++ b/api/middlewares/search_budget_middleware.py
@@ -1,4 +1,4 @@
-"""Early rejection for /search queries that exceed measured complexity bounds."""
+"""Early rejection for /search queries that exceed public size or nesting bounds."""
 
 from __future__ import annotations
 

--- a/api/middlewares/tests/test_search_budget_middleware.py
+++ b/api/middlewares/tests/test_search_budget_middleware.py
@@ -1,0 +1,65 @@
+"""Tests for /search complexity middleware."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import falcon
+import falcon.testing
+import pytest
+
+from api.api_resource import APIResource
+from api.middlewares.caching_middleware import CachingMiddleware
+from api.middlewares.search_budget_middleware import SearchBudgetMiddleware
+from api.parsing.query_budget import MAX_QUERY_UTF8_BYTES, QUERY_TOO_LONG_MESSAGE
+from api.tests.support import mock_app_context
+
+
+def _oversized_query() -> str:
+    return "a" * (MAX_QUERY_UTF8_BYTES + 1)
+
+
+@pytest.fixture(name="resource")
+def resource_fixture() -> APIResource:
+    return APIResource(app_context=mock_app_context(reader_pool=MagicMock(), writer_pool=MagicMock()))
+
+
+def _client(resource: APIResource, *, cache: dict | None = None) -> falcon.testing.TestClient:
+    app = falcon.App(
+        middleware=[
+            SearchBudgetMiddleware(),
+            CachingMiddleware(cache=cache if cache is not None else {}),
+        ],
+    )
+    app.add_sink(resource._handle, prefix="/")
+    return falcon.testing.TestClient(app)
+
+
+class TestSearchBudgetMiddleware:
+    def test_rejects_oversized_q_before_handler(self, resource: APIResource) -> None:
+        client = _client(resource)
+        result = client.simulate_get("/search", params={"q": _oversized_query()})
+        assert result.status == falcon.HTTP_400
+        assert result.json["description"] == QUERY_TOO_LONG_MESSAGE
+
+    def test_rejects_oversized_unused_query_alias(self, resource: APIResource) -> None:
+        client = _client(resource)
+        result = client.simulate_get(
+            "/search",
+            params={"q": "bolt", "query": _oversized_query()},
+        )
+        assert result.status == falcon.HTTP_400
+        assert result.json["description"] == QUERY_TOO_LONG_MESSAGE
+
+    def test_accepts_query_at_byte_limit(self, resource: APIResource) -> None:
+        with patch.object(APIResource, "_search", return_value={"cards": [], "total_cards": 0, "query": "x"}):
+            client = _client(resource)
+            result = client.simulate_get("/search", params={"q": "a" * MAX_QUERY_UTF8_BYTES})
+        assert result.status == falcon.HTTP_200
+
+    def test_budget_rejection_never_reaches_search_handler(self, resource: APIResource) -> None:
+        with patch.object(resource, "_search") as mock_search:
+            client = _client(resource)
+            result = client.simulate_get("/search", params={"q": _oversized_query()})
+        assert result.status == falcon.HTTP_400
+        mock_search.assert_not_called()

--- a/api/parsing/__init__.py
+++ b/api/parsing/__init__.py
@@ -18,6 +18,7 @@ from api.parsing.nodes import (
     TrueNode,
 )
 from api.parsing.parsing_f import balance_partial_query, parse_scryfall_query
+from api.parsing.query_budget import QueryBudgetExceeded
 from api.parsing.sql_generation import generate_sql_query
 
 __all__ = [
@@ -30,6 +31,7 @@ __all__ = [
     "OrNode",
     "ParseError",
     "Query",
+    "QueryBudgetExceeded",
     "QueryContext",
     "QueryNode",
     "RegexValueNode",

--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -29,6 +29,12 @@ from api.parsing.nodes import (
     TrueNode,
     flatten_nested_operations,
 )
+from api.parsing.query_budget import (
+    MAX_GROUP_DEPTH,
+    MAX_QUERY_TOKENS,
+    QueryBudgetExceeded,
+    check_query_byte_length,
+)
 from api.parsing.spans import QUOTE_CHARS, brace_close_index, find_close_index, unescape
 
 # ── Alias → parser-class lookup ──────────────────────────────────────────────
@@ -321,6 +327,8 @@ def tokenize(src: str) -> list[Token]:  # noqa: C901, PLR0912, PLR0915
         msg = f"Unexpected character {c!r} at position {pos}"
         raise LexError(msg)
 
+    if len(tokens) > MAX_QUERY_TOKENS:
+        raise QueryBudgetExceeded(kind="complexity")
     tokens.append(Token(TT.EOF, "", n, space_before))
     return tokens
 
@@ -339,12 +347,13 @@ def _name_node(value: str) -> CardBinaryOperatorNode:
 class Parser:
     """Recursive descent parser for Scryfall query syntax."""
 
-    __slots__ = ("pos", "tokens")
+    __slots__ = ("group_depth", "pos", "tokens")
 
     def __init__(self, tokens: list[Token]) -> None:
         """Initialise the parser with the token list produced by tokenize()."""
         self.tokens = tokens
         self.pos = 0
+        self.group_depth = 0
 
     # ── token access ─────────────────────────────────────────────────────────
 
@@ -456,13 +465,19 @@ class Parser:
 
     def parse_group(self) -> QueryNode:
         """Parse a parenthesised sub-expression."""
-        self.consume()  # LPAREN
-        if self.peek().type == TT.RPAREN:
-            msg = "Empty parentheses are not allowed"
-            raise ParseError(msg)
-        inner = self.parse_expr()
-        self.expect(TT.RPAREN)
-        return inner
+        if self.group_depth >= MAX_GROUP_DEPTH:
+            raise QueryBudgetExceeded(kind="complexity")
+        self.group_depth += 1
+        try:
+            self.consume()  # LPAREN
+            if self.peek().type == TT.RPAREN:
+                msg = "Empty parentheses are not allowed"
+                raise ParseError(msg)
+            inner = self.parse_expr()
+            self.expect(TT.RPAREN)
+            return inner
+        finally:
+            self.group_depth -= 1
 
     def parse_exact_name(self) -> QueryNode:
         """Parse an exact-name expression: !word or !"quoted string"."""
@@ -816,13 +831,18 @@ def parse_query(src: str | None) -> Query:
     """
     if not src or not src.strip():
         return Query(TrueNode())
+    check_query_byte_length(src)
     try:
         tokens = tokenize(src)
     except LexError as exc:
         msg = f'Failed to lex query: "{src}"'
         raise ValueError(msg) from exc
+    except QueryBudgetExceeded:
+        raise
     try:
         result = Parser(tokens).parse()
+    except QueryBudgetExceeded:
+        raise
     except ParseError as exc:
         msg = f'Failed to parse query: "{src}"'
         raise ValueError(msg) from exc

--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -29,12 +29,7 @@ from api.parsing.nodes import (
     TrueNode,
     flatten_nested_operations,
 )
-from api.parsing.query_budget import (
-    MAX_GROUP_DEPTH,
-    MAX_QUERY_TOKENS,
-    QueryBudgetExceeded,
-    check_query_byte_length,
-)
+from api.parsing.query_budget import MAX_GROUP_DEPTH, QueryBudgetExceeded, check_query_byte_length
 from api.parsing.spans import QUOTE_CHARS, brace_close_index, find_close_index, unescape
 
 # ── Alias → parser-class lookup ──────────────────────────────────────────────
@@ -327,8 +322,6 @@ def tokenize(src: str) -> list[Token]:  # noqa: C901, PLR0912, PLR0915
         msg = f"Unexpected character {c!r} at position {pos}"
         raise LexError(msg)
 
-    if len(tokens) > MAX_QUERY_TOKENS:
-        raise QueryBudgetExceeded(kind="complexity")
     tokens.append(Token(TT.EOF, "", n, space_before))
     return tokens
 
@@ -466,7 +459,7 @@ class Parser:
     def parse_group(self) -> QueryNode:
         """Parse a parenthesised sub-expression."""
         if self.group_depth >= MAX_GROUP_DEPTH:
-            raise QueryBudgetExceeded(kind="complexity")
+            raise QueryBudgetExceeded(kind="depth")
         self.group_depth += 1
         try:
             self.consume()  # LPAREN

--- a/api/parsing/parsing_f.py
+++ b/api/parsing/parsing_f.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from api.parsing.hand_parser import parse_query as _parse_query
-from api.parsing.query_budget import check_ast_budget, check_query_byte_length
+from api.parsing.query_budget import check_query_byte_length
 from api.parsing.rewrite import rewrite_query
 from api.parsing.spans import QUOTE_CHARS, brace_close_index, find_close_index, opens_regex
 
@@ -101,8 +101,4 @@ def parse_scryfall_query(query: str) -> Query:
     check_query_byte_length(query)
     # parse => transform => rest: the whole rewrite pipeline runs on the common AST at this shared
     # seam, so it applies identically regardless of which parser _parse_query is.
-    parsed = _parse_query(query)
-    check_ast_budget(parsed)
-    result = rewrite_query(parsed)
-    check_ast_budget(result)
-    return result
+    return rewrite_query(_parse_query(query))

--- a/api/parsing/parsing_f.py
+++ b/api/parsing/parsing_f.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from api.parsing.hand_parser import parse_query as _parse_query
+from api.parsing.query_budget import check_ast_budget, check_query_byte_length
 from api.parsing.rewrite import rewrite_query
 from api.parsing.spans import QUOTE_CHARS, brace_close_index, find_close_index, opens_regex
 
@@ -97,6 +98,11 @@ def parse_scryfall_query(query: str) -> Query:
     Returns:
         A Scryfall-specific Query AST.
     """
+    check_query_byte_length(query)
     # parse => transform => rest: the whole rewrite pipeline runs on the common AST at this shared
     # seam, so it applies identically regardless of which parser _parse_query is.
-    return rewrite_query(_parse_query(query))
+    parsed = _parse_query(query)
+    check_ast_budget(parsed)
+    result = rewrite_query(parsed)
+    check_ast_budget(result)
+    return result

--- a/api/parsing/parsing_f.py
+++ b/api/parsing/parsing_f.py
@@ -89,7 +89,7 @@ def balance_partial_query(query: str) -> str:
     return query + span_suffix + ")" * open_parens
 
 
-def parse_scryfall_query(query: str) -> Query:
+def parse_scryfall_query(query: str | None) -> Query:
     """Parse a Scryfall search query into a card-specific AST.
 
     Args:
@@ -98,7 +98,8 @@ def parse_scryfall_query(query: str) -> Query:
     Returns:
         A Scryfall-specific Query AST.
     """
-    check_query_byte_length(query)
+    if query is not None:
+        check_query_byte_length(query)
     # parse => transform => rest: the whole rewrite pipeline runs on the common AST at this shared
     # seam, so it applies identically regardless of which parser _parse_query is.
     return rewrite_query(_parse_query(query))

--- a/api/parsing/query_budget.py
+++ b/api/parsing/query_budget.py
@@ -1,0 +1,107 @@
+"""Measured complexity bounds for public search queries."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING, Literal
+
+from api.parsing.nodes import AndNode, BinaryOperatorNode, NotNode, OrNode, Query
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from api.parsing.nodes import QueryNode
+
+MAX_QUERY_UTF8_BYTES = 1024
+MAX_QUERY_TOKENS = 256
+MAX_AST_NODES = 128
+MAX_BOOLEAN_CLAUSES = 32
+MAX_GROUP_DEPTH = 32
+MAX_QUERY_LOG_PREVIEW_CHARS = 80
+
+QUERY_TOO_LONG_MESSAGE = "Search query exceeds the maximum allowed length."
+QUERY_TOO_COMPLEX_MESSAGE = "Search query exceeds the maximum allowed complexity."
+
+
+class QueryBudgetExceeded(ValueError):  # noqa: N818
+    """Raised when a query exceeds a measured public complexity bound."""
+
+    def __init__(self, *, kind: Literal["length", "complexity"]) -> None:
+        """Initialize with a stable, non-disclosing user message."""
+        self.kind = kind
+        self.user_message = QUERY_TOO_LONG_MESSAGE if kind == "length" else QUERY_TOO_COMPLEX_MESSAGE
+        super().__init__(self.user_message)
+
+
+def utf8_byte_length(text: str) -> int:
+    """Return the UTF-8 byte length of *text*."""
+    return len(text.encode("utf-8"))
+
+
+def check_query_byte_length(query: str) -> None:
+    """Reject *query* when it exceeds the public byte limit."""
+    if utf8_byte_length(query) > MAX_QUERY_UTF8_BYTES:
+        raise QueryBudgetExceeded(kind="length")
+
+
+def check_search_param_lengths(params: Mapping[str, object]) -> None:
+    """Reject when either ``q`` or ``query`` exceeds the byte limit.
+
+    Both aliases are checked independently so an oversized unused alias cannot
+    reach cache-key construction or downstream parsing.
+    """
+    for key in ("q", "query"):
+        value = params.get(key)
+        if value is None:
+            continue
+        if isinstance(value, list):
+            for item in value:
+                check_query_byte_length(str(item))
+        else:
+            check_query_byte_length(str(value))
+
+
+def bounded_query_log_context(query: str) -> dict[str, str]:
+    """Return a bounded preview and digest suitable for rejection logs."""
+    preview_limit = MAX_QUERY_LOG_PREVIEW_CHARS
+    preview = query if len(query) <= preview_limit else f"{query[:preview_limit]}…"
+    digest = hashlib.sha256(query.encode("utf-8")).hexdigest()[:16]
+    return {"query_preview": preview, "query_digest": digest}
+
+
+def _measure_node(node: QueryNode, *, depth: int) -> tuple[int, int, int]:
+    """Return ``(node_count, boolean_clauses, max_depth)`` for *node*."""
+    node_count = 1
+    boolean_clauses = 0
+    max_depth = depth
+
+    if isinstance(node, Query):
+        child_nodes, child_clauses, child_depth = _measure_node(node.root, depth=depth + 1)
+        return node_count + child_nodes, boolean_clauses + child_clauses, max(max_depth, child_depth)
+    if isinstance(node, (AndNode, OrNode)):
+        boolean_clauses += len(node.operands)
+        for operand in node.operands:
+            child_nodes, child_clauses, child_depth = _measure_node(operand, depth=depth + 1)
+            node_count += child_nodes
+            boolean_clauses += child_clauses
+            max_depth = max(max_depth, child_depth)
+        return node_count, boolean_clauses, max_depth
+    if isinstance(node, NotNode):
+        child_nodes, child_clauses, child_depth = _measure_node(node.operand, depth=depth + 1)
+        return node_count + child_nodes, boolean_clauses + child_clauses, max(max_depth, child_depth)
+    if isinstance(node, BinaryOperatorNode):
+        lhs_nodes, lhs_clauses, lhs_depth = _measure_node(node.lhs, depth=depth + 1)
+        rhs_nodes, rhs_clauses, rhs_depth = _measure_node(node.rhs, depth=depth + 1)
+        return (
+            node_count + lhs_nodes + rhs_nodes,
+            boolean_clauses + lhs_clauses + rhs_clauses,
+            max(max_depth, lhs_depth, rhs_depth),
+        )
+    return node_count, boolean_clauses, max_depth
+
+
+def check_ast_budget(query: Query) -> None:
+    """Reject *query* when its AST exceeds node, clause, or depth limits."""
+    node_count, boolean_clauses, max_depth = _measure_node(query, depth=1)
+    if node_count > MAX_AST_NODES or boolean_clauses > MAX_BOOLEAN_CLAUSES or max_depth > MAX_GROUP_DEPTH:
+        raise QueryBudgetExceeded(kind="complexity")

--- a/api/parsing/query_budget.py
+++ b/api/parsing/query_budget.py
@@ -3,13 +3,13 @@
 Limits are calibrated on distinct ``magic.cards`` names from the blue database
 (``scripts/measure_decklist_query_budget.py``):
 
-* **3500 UTF-8 bytes** — 100k random 100-card decklist queries in the shape
-  ``(!"…" OR …) f:commander`` landed at p99.9 ≈ 2547 B and max ≈ 2631 B; a
-  real cEDH reference list (MTGTop8 Witherbloom) was ≈ 2655 B. The limit adds
+* **3500 UTF-8 bytes** - 100k random 100-card decklist queries in the shape
+  ``(!"…" OR …) f:commander`` landed at p99.9 ~2547 B and max ~2631 B; a
+  real cEDH reference list (MTGTop8 Witherbloom) was ~2655 B. The limit adds
   headroom for longer names and trailing filters.
-* **10 parenthesis nesting levels** — maximum ``( … ( … ) … )`` depth during
+* **10 parenthesis nesting levels** - maximum ``( … ( … ) … )`` depth during
   parse (sibling ``(a) (b)`` groups do not accumulate). Legitimate Scryfall
-  syntax is almost always depth 0–3; depth 10 was verified cheap in parse/SQL
+  syntax is almost always depth 0-3; depth 10 was verified cheap in parse/SQL
   benchmarks; unbounded nesting hits ``RecursionError`` around depth 200.
 """
 

--- a/api/parsing/query_budget.py
+++ b/api/parsing/query_budget.py
@@ -1,35 +1,40 @@
-"""Measured complexity bounds for public search queries."""
+"""Public search query size and parenthesis-nesting bounds.
+
+Limits are calibrated on distinct ``magic.cards`` names from the blue database
+(``scripts/measure_decklist_query_budget.py``):
+
+* **3500 UTF-8 bytes** — 100k random 100-card decklist queries in the shape
+  ``(!"…" OR …) f:commander`` landed at p99.9 ≈ 2547 B and max ≈ 2631 B; a
+  real cEDH reference list (MTGTop8 Witherbloom) was ≈ 2655 B. The limit adds
+  headroom for longer names and trailing filters.
+* **10 parenthesis nesting levels** — maximum ``( … ( … ) … )`` depth during
+  parse (sibling ``(a) (b)`` groups do not accumulate). Legitimate Scryfall
+  syntax is almost always depth 0–3; depth 10 was verified cheap in parse/SQL
+  benchmarks; unbounded nesting hits ``RecursionError`` around depth 200.
+"""
 
 from __future__ import annotations
 
 import hashlib
 from typing import TYPE_CHECKING, Literal
 
-from api.parsing.nodes import AndNode, BinaryOperatorNode, NotNode, OrNode, Query
-
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from api.parsing.nodes import QueryNode
-
-MAX_QUERY_UTF8_BYTES = 1024
-MAX_QUERY_TOKENS = 256
-MAX_AST_NODES = 128
-MAX_BOOLEAN_CLAUSES = 32
-MAX_GROUP_DEPTH = 32
+MAX_QUERY_UTF8_BYTES = 3500
+MAX_GROUP_DEPTH = 10
 MAX_QUERY_LOG_PREVIEW_CHARS = 80
 
 QUERY_TOO_LONG_MESSAGE = "Search query exceeds the maximum allowed length."
-QUERY_TOO_COMPLEX_MESSAGE = "Search query exceeds the maximum allowed complexity."
 
 
 class QueryBudgetExceeded(ValueError):  # noqa: N818
-    """Raised when a query exceeds a measured public complexity bound."""
+    """Raised when a query exceeds a measured public bound."""
 
-    def __init__(self, *, kind: Literal["length", "complexity"]) -> None:
+    def __init__(self, *, kind: Literal["length", "depth"]) -> None:
         """Initialize with a stable, non-disclosing user message."""
         self.kind = kind
-        self.user_message = QUERY_TOO_LONG_MESSAGE if kind == "length" else QUERY_TOO_COMPLEX_MESSAGE
+        self.user_message = QUERY_TOO_LONG_MESSAGE
         super().__init__(self.user_message)
 
 
@@ -67,41 +72,3 @@ def bounded_query_log_context(query: str) -> dict[str, str]:
     preview = query if len(query) <= preview_limit else f"{query[:preview_limit]}…"
     digest = hashlib.sha256(query.encode("utf-8")).hexdigest()[:16]
     return {"query_preview": preview, "query_digest": digest}
-
-
-def _measure_node(node: QueryNode, *, depth: int) -> tuple[int, int, int]:
-    """Return ``(node_count, boolean_clauses, max_depth)`` for *node*."""
-    node_count = 1
-    boolean_clauses = 0
-    max_depth = depth
-
-    if isinstance(node, Query):
-        child_nodes, child_clauses, child_depth = _measure_node(node.root, depth=depth + 1)
-        return node_count + child_nodes, boolean_clauses + child_clauses, max(max_depth, child_depth)
-    if isinstance(node, (AndNode, OrNode)):
-        boolean_clauses += len(node.operands)
-        for operand in node.operands:
-            child_nodes, child_clauses, child_depth = _measure_node(operand, depth=depth + 1)
-            node_count += child_nodes
-            boolean_clauses += child_clauses
-            max_depth = max(max_depth, child_depth)
-        return node_count, boolean_clauses, max_depth
-    if isinstance(node, NotNode):
-        child_nodes, child_clauses, child_depth = _measure_node(node.operand, depth=depth + 1)
-        return node_count + child_nodes, boolean_clauses + child_clauses, max(max_depth, child_depth)
-    if isinstance(node, BinaryOperatorNode):
-        lhs_nodes, lhs_clauses, lhs_depth = _measure_node(node.lhs, depth=depth + 1)
-        rhs_nodes, rhs_clauses, rhs_depth = _measure_node(node.rhs, depth=depth + 1)
-        return (
-            node_count + lhs_nodes + rhs_nodes,
-            boolean_clauses + lhs_clauses + rhs_clauses,
-            max(max_depth, lhs_depth, rhs_depth),
-        )
-    return node_count, boolean_clauses, max_depth
-
-
-def check_ast_budget(query: Query) -> None:
-    """Reject *query* when its AST exceeds node, clause, or depth limits."""
-    node_count, boolean_clauses, max_depth = _measure_node(query, depth=1)
-    if node_count > MAX_AST_NODES or boolean_clauses > MAX_BOOLEAN_CLAUSES or max_depth > MAX_GROUP_DEPTH:
-        raise QueryBudgetExceeded(kind="complexity")

--- a/api/parsing/tests/test_query_budget.py
+++ b/api/parsing/tests/test_query_budget.py
@@ -5,16 +5,11 @@ from __future__ import annotations
 import pytest
 
 from api.parsing import parse_scryfall_query
-from api.parsing.hand_parser import TT, tokenize
 from api.parsing.query_budget import (
-    MAX_BOOLEAN_CLAUSES,
     MAX_GROUP_DEPTH,
-    MAX_QUERY_TOKENS,
     MAX_QUERY_UTF8_BYTES,
-    QUERY_TOO_COMPLEX_MESSAGE,
     QUERY_TOO_LONG_MESSAGE,
     QueryBudgetExceeded,
-    check_ast_budget,
     check_query_byte_length,
     check_search_param_lengths,
 )
@@ -40,55 +35,31 @@ class TestQueryByteLimits:
             check_search_param_lengths({"q": "bolt", "query": _exact_byte_query(MAX_QUERY_UTF8_BYTES + 1)})
 
 
-def _arithmetic_token_query(*, token_target: int) -> str:
-    """Build a single-clause arithmetic query with exactly ``token_target`` lexer tokens."""
-    for prefix, base_tokens in (("cmc=1", 3), ("cmc>=1", 4)):
-        remaining = token_target - base_tokens
-        if remaining >= 0 and remaining % 2 == 0:
-            return prefix + "+1" * (remaining // 2)
-    msg = f"cannot build arithmetic query with exactly {token_target} tokens"
-    raise ValueError(msg)
+class TestGroupDepthLimit:
+    def test_accepts_query_at_max_nesting_depth(self) -> None:
+        query = "(" * MAX_GROUP_DEPTH + "name:a" + ")" * MAX_GROUP_DEPTH
+        parse_scryfall_query(query)
 
-
-class TestTokenAndDepthLimits:
-    def test_rejects_query_with_too_many_tokens(self) -> None:
-        query = _arithmetic_token_query(token_target=MAX_QUERY_TOKENS + 1)
-        with pytest.raises(QueryBudgetExceeded) as exc_info:
-            parse_scryfall_query(query)
-        assert exc_info.value.kind == "complexity"
-        assert exc_info.value.user_message == QUERY_TOO_COMPLEX_MESSAGE
-
-    def test_accepts_lexer_at_token_limit(self) -> None:
-        # 255 is the largest single-clause arithmetic query that hits an odd token budget.
-        query = _arithmetic_token_query(token_target=MAX_QUERY_TOKENS - 1)
-        tokens = tokenize(query)
-        assert len([token for token in tokens if token.type != TT.EOF]) == MAX_QUERY_TOKENS - 1
-
-    def test_rejects_query_with_excessive_group_depth(self) -> None:
+    def test_rejects_query_one_level_over_max_nesting_depth(self) -> None:
         query = "(" * (MAX_GROUP_DEPTH + 1) + "name:a" + ")" * (MAX_GROUP_DEPTH + 1)
         with pytest.raises(QueryBudgetExceeded) as exc_info:
             parse_scryfall_query(query)
-        assert exc_info.value.kind == "complexity"
+        assert exc_info.value.kind == "depth"
+        assert exc_info.value.user_message == QUERY_TOO_LONG_MESSAGE
+
+    def test_sibling_groups_do_not_accumulate_nesting_depth(self) -> None:
+        query = " ".join(f"(name:n{i})" for i in range(40))
+        parse_scryfall_query(query)
 
 
-class TestAstBudget:
-    def test_rejects_too_many_boolean_clauses(self) -> None:
-        query = " or ".join(f"name:n{i}" for i in range(MAX_BOOLEAN_CLAUSES + 1))
-        with pytest.raises(QueryBudgetExceeded) as exc_info:
-            parse_scryfall_query(query)
-        assert exc_info.value.kind == "complexity"
+class TestDecklistShape:
+    def test_accepts_long_flat_or_chain_within_byte_limit(self) -> None:
+        query = " or ".join(f'name:n{i}' for i in range(80))
+        assert len(query.encode("utf-8")) <= MAX_QUERY_UTF8_BYTES
+        parse_scryfall_query(query)
 
-    def test_rejects_derived_predicate_expansion_over_clause_limit(self) -> None:
-        query = " or ".join(["is:permanent"] * 6)
-        with pytest.raises(QueryBudgetExceeded) as exc_info:
-            parse_scryfall_query(query)
-        assert exc_info.value.kind == "complexity"
-
-    def test_accepts_small_derived_predicate_before_rewrite(self) -> None:
-        parsed = parse_scryfall_query("is:split")
-        check_ast_budget(parsed)
-
-    def test_rejects_ast_with_too_many_nodes(self) -> None:
-        query = " ".join(f"name:n{i}" for i in range(43))
-        with pytest.raises(QueryBudgetExceeded):
-            parse_scryfall_query(query)
+    def test_accepts_parenthesized_or_chain_with_format_filter(self) -> None:
+        body = " or ".join(f'!"Card {i}"' for i in range(60))
+        query = f"({body}) f:commander"
+        assert len(query.encode("utf-8")) <= MAX_QUERY_UTF8_BYTES
+        parse_scryfall_query(query)

--- a/api/parsing/tests/test_query_budget.py
+++ b/api/parsing/tests/test_query_budget.py
@@ -1,0 +1,94 @@
+"""Tests for public search query complexity bounds."""
+
+from __future__ import annotations
+
+import pytest
+
+from api.parsing import parse_scryfall_query
+from api.parsing.hand_parser import TT, tokenize
+from api.parsing.query_budget import (
+    MAX_BOOLEAN_CLAUSES,
+    MAX_GROUP_DEPTH,
+    MAX_QUERY_TOKENS,
+    MAX_QUERY_UTF8_BYTES,
+    QUERY_TOO_COMPLEX_MESSAGE,
+    QUERY_TOO_LONG_MESSAGE,
+    QueryBudgetExceeded,
+    check_ast_budget,
+    check_query_byte_length,
+    check_search_param_lengths,
+)
+
+
+def _exact_byte_query(num_bytes: int) -> str:
+    assert num_bytes >= 1
+    return "a" * num_bytes
+
+
+class TestQueryByteLimits:
+    def test_accepts_query_at_byte_limit(self) -> None:
+        check_query_byte_length(_exact_byte_query(MAX_QUERY_UTF8_BYTES))
+
+    def test_rejects_query_one_byte_over_limit(self) -> None:
+        with pytest.raises(QueryBudgetExceeded) as exc_info:
+            check_query_byte_length(_exact_byte_query(MAX_QUERY_UTF8_BYTES + 1))
+        assert exc_info.value.kind == "length"
+        assert exc_info.value.user_message == QUERY_TOO_LONG_MESSAGE
+
+    def test_rejects_oversized_unused_query_alias(self) -> None:
+        with pytest.raises(QueryBudgetExceeded):
+            check_search_param_lengths({"q": "bolt", "query": _exact_byte_query(MAX_QUERY_UTF8_BYTES + 1)})
+
+
+def _arithmetic_token_query(*, token_target: int) -> str:
+    """Build a single-clause arithmetic query with exactly ``token_target`` lexer tokens."""
+    for prefix, base_tokens in (("cmc=1", 3), ("cmc>=1", 4)):
+        remaining = token_target - base_tokens
+        if remaining >= 0 and remaining % 2 == 0:
+            return prefix + "+1" * (remaining // 2)
+    msg = f"cannot build arithmetic query with exactly {token_target} tokens"
+    raise ValueError(msg)
+
+
+class TestTokenAndDepthLimits:
+    def test_rejects_query_with_too_many_tokens(self) -> None:
+        query = _arithmetic_token_query(token_target=MAX_QUERY_TOKENS + 1)
+        with pytest.raises(QueryBudgetExceeded) as exc_info:
+            parse_scryfall_query(query)
+        assert exc_info.value.kind == "complexity"
+        assert exc_info.value.user_message == QUERY_TOO_COMPLEX_MESSAGE
+
+    def test_accepts_lexer_at_token_limit(self) -> None:
+        # 255 is the largest single-clause arithmetic query that hits an odd token budget.
+        query = _arithmetic_token_query(token_target=MAX_QUERY_TOKENS - 1)
+        tokens = tokenize(query)
+        assert len([token for token in tokens if token.type != TT.EOF]) == MAX_QUERY_TOKENS - 1
+
+    def test_rejects_query_with_excessive_group_depth(self) -> None:
+        query = "(" * (MAX_GROUP_DEPTH + 1) + "name:a" + ")" * (MAX_GROUP_DEPTH + 1)
+        with pytest.raises(QueryBudgetExceeded) as exc_info:
+            parse_scryfall_query(query)
+        assert exc_info.value.kind == "complexity"
+
+
+class TestAstBudget:
+    def test_rejects_too_many_boolean_clauses(self) -> None:
+        query = " or ".join(f"name:n{i}" for i in range(MAX_BOOLEAN_CLAUSES + 1))
+        with pytest.raises(QueryBudgetExceeded) as exc_info:
+            parse_scryfall_query(query)
+        assert exc_info.value.kind == "complexity"
+
+    def test_rejects_derived_predicate_expansion_over_clause_limit(self) -> None:
+        query = " or ".join(["is:permanent"] * 6)
+        with pytest.raises(QueryBudgetExceeded) as exc_info:
+            parse_scryfall_query(query)
+        assert exc_info.value.kind == "complexity"
+
+    def test_accepts_small_derived_predicate_before_rewrite(self) -> None:
+        parsed = parse_scryfall_query("is:split")
+        check_ast_budget(parsed)
+
+    def test_rejects_ast_with_too_many_nodes(self) -> None:
+        query = " ".join(f"name:n{i}" for i in range(43))
+        with pytest.raises(QueryBudgetExceeded):
+            parse_scryfall_query(query)

--- a/api/parsing/tests/test_query_budget.py
+++ b/api/parsing/tests/test_query_budget.py
@@ -54,7 +54,7 @@ class TestGroupDepthLimit:
 
 class TestDecklistShape:
     def test_accepts_long_flat_or_chain_within_byte_limit(self) -> None:
-        query = " or ".join(f'name:n{i}' for i in range(80))
+        query = " or ".join(f"name:n{i}" for i in range(80))
         assert len(query.encode("utf-8")) <= MAX_QUERY_UTF8_BYTES
         parse_scryfall_query(query)
 

--- a/api/static/app.js
+++ b/api/static/app.js
@@ -1,6 +1,8 @@
 const UNIQUE_PRINTING = 'printing';
 const DWELL_MS = 2500; // milliseconds user must stay on results before adding a history entry
 const MAX_EXPLANATION_LENGTH = 140; // truncate very long query explanations (e.g. giant OR chains)
+const MAX_QUERY_UTF8_BYTES = 1024;
+const QUERY_TOO_LONG_MESSAGE = 'Search query exceeds the maximum allowed length.';
 
 // Hoisted so escapeHtml() doesn't allocate a new RegExp or callback on every call.
 const HTML_ESCAPE_RE = /[&<>"]/g;
@@ -721,12 +723,20 @@ class CardSearch {
     return out;
   }
 
+  queryUtf8ByteLength(query) {
+    return new TextEncoder().encode(query).length;
+  }
+
   // Returns an error string if the query is structurally invalid, or null if it looks ok.
   // alreadyBalanced lets a caller that just ran scanSpans itself (and knows the answer was not
   // null) skip a second identical scan here, rather than re-discovering what it already knows.
   // blanked lets that same caller pass the scan's blanked-span output straight through too, rather
   // than making blankOpaqueSpans re-walk the whole string to find the same span boundaries again.
   validateQuery(query, { alreadyBalanced = false, blanked = null } = {}) {
+    if (this.queryUtf8ByteLength(query) > MAX_QUERY_UTF8_BYTES) {
+      return QUERY_TOO_LONG_MESSAGE;
+    }
+
     // A closing paren with no matching opener can't be balanced away.
     if (!alreadyBalanced && this.balanceSuffix(query) === null) {
       return `Failed to parse query: "${query}"`;

--- a/api/static/app.js
+++ b/api/static/app.js
@@ -1,7 +1,7 @@
 const UNIQUE_PRINTING = 'printing';
 const DWELL_MS = 2500; // milliseconds user must stay on results before adding a history entry
 const MAX_EXPLANATION_LENGTH = 140; // truncate very long query explanations (e.g. giant OR chains)
-const MAX_QUERY_UTF8_BYTES = 1024;
+const MAX_QUERY_UTF8_BYTES = 3500;
 const QUERY_TOO_LONG_MESSAGE = 'Search query exceeds the maximum allowed length.';
 
 // Hoisted so escapeHtml() doesn't allocate a new RegExp or callback on every call.

--- a/api/static/app.test.js
+++ b/api/static/app.test.js
@@ -512,7 +512,7 @@ describe('CardSearch createCardHTML no-JS parity', () => {
 
 describe('CardSearch validateQuery', () => {
   it('rejects queries over the UTF-8 byte limit without echoing them', () => {
-    const overLimit = 'a'.repeat(1025);
+    const overLimit = 'a'.repeat(3501);
     expect(search.validateQuery(overLimit)).toBe('Search query exceeds the maximum allowed length.');
     expect(search.validateQuery(overLimit)).not.toContain(overLimit);
   });
@@ -555,7 +555,7 @@ describe('CardSearch performSearch', () => {
   it('shows an error and skips the http request for over-limit queries', async () => {
     global.fetch.mockClear();
 
-    await search.performSearch('a'.repeat(1025));
+    await search.performSearch('a'.repeat(3501));
 
     expect(search.showError).toHaveBeenCalledWith(
       expect.stringContaining('Search query exceeds the maximum allowed length.')

--- a/api/static/app.test.js
+++ b/api/static/app.test.js
@@ -5,6 +5,9 @@
 
 const fs = require('fs');
 const path = require('path');
+const { TextEncoder } = require('util');
+
+global.TextEncoder = TextEncoder;
 
 // ---------------------------------------------------------------------------
 // Load CardSearch class
@@ -508,6 +511,12 @@ describe('CardSearch createCardHTML no-JS parity', () => {
 });
 
 describe('CardSearch validateQuery', () => {
+  it('rejects queries over the UTF-8 byte limit without echoing them', () => {
+    const overLimit = 'a'.repeat(1025);
+    expect(search.validateQuery(overLimit)).toBe('Search query exceeds the maximum allowed length.');
+    expect(search.validateQuery(overLimit)).not.toContain(overLimit);
+  });
+
   it('rejects queries with an unmatched closing parenthesis', () => {
     expect(search.validateQuery('hello)(')).toBe('Failed to parse query: "hello)("');
     expect(search.validateQuery('hello)')).toBe('Failed to parse query: "hello)"');
@@ -543,6 +552,17 @@ describe('CardSearch accepts every shared accepted query', () => {
 });
 
 describe('CardSearch performSearch', () => {
+  it('shows an error and skips the http request for over-limit queries', async () => {
+    global.fetch.mockClear();
+
+    await search.performSearch('a'.repeat(1025));
+
+    expect(search.showError).toHaveBeenCalledWith(
+      expect.stringContaining('Search query exceeds the maximum allowed length.')
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   it('shows an error and skips the http request for unbalance-able queries', async () => {
     global.fetch.mockClear();
 

--- a/api/tests/test_search_query_budget.py
+++ b/api/tests/test_search_query_budget.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import falcon
 import pytest
 
-from api.parsing.query_budget import MAX_QUERY_UTF8_BYTES, QUERY_TOO_COMPLEX_MESSAGE, QUERY_TOO_LONG_MESSAGE
+from api.parsing.query_budget import MAX_GROUP_DEPTH, MAX_QUERY_UTF8_BYTES, QUERY_TOO_LONG_MESSAGE
 
 if TYPE_CHECKING:
     from api.api_resource import APIResource
@@ -34,15 +34,15 @@ class TestSearchQueryBudget:
         mock_engine.assert_not_called()
         mock_sql.assert_not_called()
 
-    def test_rejects_derived_predicate_expansion_without_engine_or_sql(self) -> None:
-        query = " or ".join(["is:permanent"] * 6)
+    def test_rejects_excessive_nesting_without_engine_or_sql(self) -> None:
+        query = "(" * (MAX_GROUP_DEPTH + 1) + "name:a" + ")" * (MAX_GROUP_DEPTH + 1)
         with (
             patch.object(self.api_resource, "_search_engine") as mock_engine,
             patch.object(self.api_resource, "_search_sql") as mock_sql,
             pytest.raises(falcon.HTTPBadRequest) as exc_info,
         ):
             self.api_resource._search(query=query, limit=10)
-        assert exc_info.value.description == QUERY_TOO_COMPLEX_MESSAGE
+        assert exc_info.value.description == QUERY_TOO_LONG_MESSAGE
         mock_engine.assert_not_called()
         mock_sql.assert_not_called()
 

--- a/api/tests/test_search_query_budget.py
+++ b/api/tests/test_search_query_budget.py
@@ -1,0 +1,53 @@
+"""Integration tests for query budget enforcement in _search."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import falcon
+import pytest
+
+from api.parsing.query_budget import MAX_QUERY_UTF8_BYTES, QUERY_TOO_COMPLEX_MESSAGE, QUERY_TOO_LONG_MESSAGE
+
+if TYPE_CHECKING:
+    from api.api_resource import APIResource
+
+
+@pytest.mark.usefixtures("engine_enabled")
+class TestSearchQueryBudget:
+    @pytest.fixture(autouse=True)
+    def _api(self, stub_api_resource: APIResource) -> None:
+        self.api_resource = stub_api_resource
+        self.api_resource.app_context.engine = MagicMock()
+        self.api_resource.app_context.engine.size.return_value = 87
+
+    def test_rejects_oversized_query_without_engine_or_sql(self) -> None:
+        query = "a" * (MAX_QUERY_UTF8_BYTES + 1)
+        with (
+            patch.object(self.api_resource, "_search_engine") as mock_engine,
+            patch.object(self.api_resource, "_search_sql") as mock_sql,
+            pytest.raises(falcon.HTTPBadRequest) as exc_info,
+        ):
+            self.api_resource._search(query=query, limit=10)
+        assert exc_info.value.description == QUERY_TOO_LONG_MESSAGE
+        mock_engine.assert_not_called()
+        mock_sql.assert_not_called()
+
+    def test_rejects_derived_predicate_expansion_without_engine_or_sql(self) -> None:
+        query = " or ".join(["is:permanent"] * 6)
+        with (
+            patch.object(self.api_resource, "_search_engine") as mock_engine,
+            patch.object(self.api_resource, "_search_sql") as mock_sql,
+            pytest.raises(falcon.HTTPBadRequest) as exc_info,
+        ):
+            self.api_resource._search(query=query, limit=10)
+        assert exc_info.value.description == QUERY_TOO_COMPLEX_MESSAGE
+        mock_engine.assert_not_called()
+        mock_sql.assert_not_called()
+
+    def test_stable_message_does_not_echo_hostile_query(self) -> None:
+        hostile = "a" * (MAX_QUERY_UTF8_BYTES + 1)
+        with pytest.raises(falcon.HTTPBadRequest) as exc_info:
+            self.api_resource._search(query=hostile, limit=10)
+        assert hostile not in exc_info.value.description

--- a/scripts/measure_decklist_query_budget.py
+++ b/scripts/measure_decklist_query_budget.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Measure decklist-style search query sizes from the card-name corpus.
+
+Pulls distinct ``card_name`` values from blue Postgres (or a cached export),
+builds simulated commander decklist queries in the shape:
+
+    (!"Card One" OR !"Card Two" OR …) f:commander
+
+and reports UTF-8 byte-length percentiles over many random 100-card decks.
+
+Usage:
+    python scripts/measure_decklist_query_budget.py
+    python scripts/measure_decklist_query_budget.py --samples 100000 --seed 0
+    python scripts/measure_decklist_query_budget.py --names /tmp/names.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing.hand_parser import _is_word_cont, _is_word_start  # noqa: E402
+
+DB_CONTAINER = "sylvan_blue-postgres-1"
+DB_USER = "foouser"
+DB_NAME = "magic"
+DEFAULT_SAMPLES = 100_000
+DEFAULT_DECK_SIZE = 100
+DEFAULT_FORMAT = "commander"
+DEFAULT_OUT = REPO_ROOT / "benchmarks" / "decklist_query_budget.json"
+
+HISTOGRAM_SQL = """
+WITH distinct_card_names AS (
+    SELECT card_name
+    FROM magic.cards
+    GROUP BY card_name
+)
+SELECT
+    char_length(card_name) AS name_chars,
+    octet_length(card_name) AS name_bytes,
+    count(*) AS name_frequency
+FROM distinct_card_names
+GROUP BY 1, 2
+ORDER BY 1, 2;
+"""
+
+NAMES_SQL = """
+SELECT card_name
+FROM magic.cards
+GROUP BY card_name
+ORDER BY card_name;
+"""
+
+FRAGMENT_STATS_SQL = """
+WITH distinct_card_names AS (
+    SELECT card_name FROM magic.cards GROUP BY card_name
+),
+encoded AS (
+    SELECT
+        card_name,
+        octet_length(card_name) AS name_bytes,
+        octet_length(
+            CASE
+                WHEN card_name ~ '^[^ \\t",()]+$' THEN '!' || card_name
+                ELSE '!"' || replace(card_name, '"', E'\\\\"') || '"'
+            END
+        ) AS fragment_bytes
+    FROM distinct_card_names
+)
+SELECT
+    percentile_cont(ARRAY[0.5, 0.95, 0.99, 0.999])
+        WITHIN GROUP (ORDER BY fragment_bytes) AS fragment_byte_percentiles,
+    max(fragment_bytes) AS max_fragment_bytes,
+    count(*) AS distinct_names
+FROM encoded;
+"""
+
+
+def _is_single_word_token(name: str) -> bool:
+    """True when ``!name`` lexes as one exact-name word token (hand_parser rules)."""
+    if not name:
+        return False
+    if not _is_word_start(name[0]):
+        return False
+    return all(_is_word_cont(ch) for ch in name[1:])
+
+
+def exact_name_fragment(name: str) -> str:
+    """Return the Scryfall-style exact-name fragment for *name*."""
+    if _is_single_word_token(name):
+        return f"!{name}"
+    return f'!"{name}"'
+
+
+def decklist_query(names: list[str], *, fmt: str = DEFAULT_FORMAT) -> str:
+    """Build a parenthesized OR chain with a trailing format filter."""
+    body = " OR ".join(exact_name_fragment(name) for name in names)
+    return f"({body}) f:{fmt}"
+
+
+def _run_psql(sql: str, *, csv: bool = False) -> str:
+    cmd = [
+        "docker",
+        "exec",
+        "-i",
+        DB_CONTAINER,
+        "psql",
+        "-U",
+        DB_USER,
+        "-d",
+        DB_NAME,
+        "-v",
+        "ON_ERROR_STOP=1",
+        "-X",
+    ]
+    if csv:
+        cmd.append("--csv")
+    else:
+        cmd.extend(["-At", "-F", "\t"])
+    cmd.extend(["-c", sql])
+    proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    if proc.returncode != 0:
+        msg = f"psql failed:\n{proc.stderr}"
+        raise SystemExit(msg)
+    return proc.stdout
+
+
+def fetch_names_from_db() -> list[str]:
+    """Load distinct card names from blue Postgres."""
+    raw = _run_psql(NAMES_SQL)
+    names = [line.strip() for line in raw.splitlines() if line.strip()]
+    if not names:
+        raise SystemExit("No card names returned from database.")
+    return names
+
+
+def load_names(path: Path) -> list[str]:
+    """Load one card name per line from *path*."""
+    return [line.strip() for line in path.read_text().splitlines() if line.strip()]
+
+
+def percentile(sorted_values: list[int], p: float) -> float:
+    """Linear-interpolation percentile on a sorted list."""
+    if not sorted_values:
+        return 0.0
+    if p <= 0:
+        return float(sorted_values[0])
+    if p >= 1:
+        return float(sorted_values[-1])
+    idx = (len(sorted_values) - 1) * p
+    lo = int(idx)
+    hi = min(lo + 1, len(sorted_values) - 1)
+    weight = idx - lo
+    return sorted_values[lo] * (1 - weight) + sorted_values[hi] * weight
+
+
+def simulate_deck_queries(
+    names: list[str],
+    *,
+    samples: int,
+    deck_size: int,
+    fmt: str,
+    seed: int,
+) -> list[int]:
+    """Return UTF-8 byte lengths for *samples* random decklist queries."""
+    if deck_size > len(names):
+        msg = f"deck_size={deck_size} exceeds distinct name count={len(names)}"
+        raise SystemExit(msg)
+    rng = random.Random(seed)
+    out: list[int] = []
+    for _ in range(samples):
+        deck = rng.sample(names, deck_size)
+        query = decklist_query(deck, fmt=fmt)
+        out.append(len(query.encode("utf-8")))
+    return out
+
+
+def parse_histogram(raw: str) -> list[dict[str, int]]:
+    rows: list[dict[str, int]] = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) != 3:
+            continue
+        rows.append(
+            {
+                "name_chars": int(parts[0]),
+                "name_bytes": int(parts[1]),
+                "name_frequency": int(parts[2]),
+            }
+        )
+    return rows
+
+
+def summarize_bytes(values: list[int]) -> dict[str, float | int]:
+    sorted_values = sorted(values)
+    return {
+        "count": len(sorted_values),
+        "min": sorted_values[0],
+        "max": sorted_values[-1],
+        "mean": statistics.fmean(sorted_values),
+        "p50": percentile(sorted_values, 0.50),
+        "p95": percentile(sorted_values, 0.95),
+        "p99": percentile(sorted_values, 0.99),
+        "p999": percentile(sorted_values, 0.999),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--names", type=Path, help="Optional file of distinct card names (one per line).")
+    parser.add_argument("--samples", type=int, default=DEFAULT_SAMPLES)
+    parser.add_argument("--deck-size", type=int, default=DEFAULT_DECK_SIZE)
+    parser.add_argument("--format", default=DEFAULT_FORMAT)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--skip-db-stats", action="store_true", help="Skip histogram SQL against blue.")
+    args = parser.parse_args()
+
+    names = load_names(args.names) if args.names else fetch_names_from_db()
+    print(f"Loaded {len(names):,} distinct card names")
+
+    histogram: list[dict[str, int]] = []
+    fragment_stats: dict[str, object] = {}
+    if not args.skip_db_stats and args.names is None:
+        print("Running name-length histogram query…")
+        histogram = parse_histogram(_run_psql(HISTOGRAM_SQL))
+        frag_raw = _run_psql(FRAGMENT_STATS_SQL).strip()
+        if frag_raw:
+            parts = frag_raw.split("\t")
+            perc = [float(x.strip('"')) for x in parts[0].strip("{}").split(",")]
+            fragment_stats = {
+                "distinct_names": int(parts[2]),
+                "fragment_bytes_p50": perc[0],
+                "fragment_bytes_p95": perc[1],
+                "fragment_bytes_p99": perc[2],
+                "fragment_bytes_p999": perc[3],
+                "fragment_bytes_max": int(parts[1]),
+            }
+
+    print(f"Simulating {args.samples:,} random {args.deck_size}-card decklist queries…")
+    byte_lengths = simulate_deck_queries(
+        names,
+        samples=args.samples,
+        deck_size=args.deck_size,
+        fmt=args.format,
+        seed=args.seed,
+    )
+    deck_stats = summarize_bytes(byte_lengths)
+
+    quoted_names = sum(1 for name in names if not _is_single_word_token(name))
+    result = {
+        "source": str(args.names) if args.names else f"docker:{DB_CONTAINER}",
+        "distinct_names": len(names),
+        "quoted_fragment_names": quoted_names,
+        "unquoted_fragment_names": len(names) - quoted_names,
+        "simulation": {
+            "samples": args.samples,
+            "deck_size": args.deck_size,
+            "format_filter": args.format,
+            "seed": args.seed,
+            "query_shape": '(!"…" OR …) f:{format}',
+            "utf8_bytes": deck_stats,
+        },
+        "name_length_histogram": histogram,
+        "exact_fragment_byte_percentiles_sql": fragment_stats,
+        "adopted_limits": {
+            "max_query_utf8_bytes": 3500,
+            "max_group_depth": 10,
+        },
+    }
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(result, indent=2) + "\n")
+    print(json.dumps(result, indent=2))
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/measure_decklist_query_budget.py
+++ b/scripts/measure_decklist_query_budget.py
@@ -36,6 +36,7 @@ DEFAULT_SAMPLES = 100_000
 DEFAULT_DECK_SIZE = 100
 DEFAULT_FORMAT = "commander"
 DEFAULT_OUT = REPO_ROOT / "benchmarks" / "decklist_query_budget.json"
+HISTOGRAM_COLUMN_COUNT = 3
 
 HISTOGRAM_SQL = """
 WITH distinct_card_names AS (
@@ -138,7 +139,8 @@ def fetch_names_from_db() -> list[str]:
     raw = _run_psql(NAMES_SQL)
     names = [line.strip() for line in raw.splitlines() if line.strip()]
     if not names:
-        raise SystemExit("No card names returned from database.")
+        msg = "No card names returned from database."
+        raise SystemExit(msg)
     return names
 
 
@@ -184,12 +186,13 @@ def simulate_deck_queries(
 
 
 def parse_histogram(raw: str) -> list[dict[str, int]]:
+    """Parse tab-separated histogram rows from psql output."""
     rows: list[dict[str, int]] = []
     for line in raw.splitlines():
         if not line.strip():
             continue
         parts = line.split("\t")
-        if len(parts) != 3:
+        if len(parts) != HISTOGRAM_COLUMN_COUNT:
             continue
         rows.append(
             {
@@ -202,6 +205,7 @@ def parse_histogram(raw: str) -> list[dict[str, int]]:
 
 
 def summarize_bytes(values: list[int]) -> dict[str, float | int]:
+    """Return count/min/max/mean/percentiles for UTF-8 byte lengths."""
     sorted_values = sorted(values)
     return {
         "count": len(sorted_values),
@@ -216,6 +220,7 @@ def summarize_bytes(values: list[int]) -> dict[str, float | int]:
 
 
 def main() -> None:
+    """Load card names, simulate decklist queries, and write summary JSON."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--names", type=Path, help="Optional file of distinct card names (one per line).")
     parser.add_argument("--samples", type=int, default=DEFAULT_SAMPLES)


### PR DESCRIPTION
## Summary

- Enforce two public search bounds: **3500 UTF-8 bytes** and **10 parenthesis nesting levels** (sibling `(a) (b)` groups do not accumulate depth).
- Reject over-limit requests in `SearchBudgetMiddleware` before query logging or caching; mirror the byte guard in the frontend autocomplete path.
- Drop token/AST/clause caps — a flat 100-card decklist OR chain is structurally simple and must remain Scryfall-compatible.

## How the limits were chosen

Measured on **31,728 distinct card names** from the blue database (`scripts/measure_decklist_query_budget.py`):

1. Sample **100,000** random **100-card** decks without replacement.
2. Encode each query as `(!"…" OR …) f:commander` (exact-name fragments per `hand_parser` quoting rules).
3. Record UTF-8 byte length percentiles.

Results (100k simulation, seed 0):

| Percentile | Bytes |
|------------|------:|
| min | 2,112 |
| p99 | 2,494 |
| p99.9 | 2,547 |
| max | 2,631 |

A real cEDH reference deck (MTGTop8 Witherbloom) encoded to **2,655 bytes**. **3500 bytes** adds ~850 bytes of headroom over the simulation max while covering full commander decklist sharing and r/metamagic-style `(…) f:format` archetype links (~30 cards).

**Nesting depth 10** was verified cheap in parse/SQL benchmarks (sub-millisecond at depth 10; unbounded nesting hits `RecursionError` around depth 200). Legitimate Scryfall syntax is almost always depth 0–3.

## Test plan

- [x] `python -m pytest api/parsing/tests/test_query_budget.py api/middlewares/tests/test_search_budget_middleware.py api/tests/test_search_query_budget.py`
- [x] `npx jest api/static/app.test.js --testNamePattern="validateQuery|performSearch"`
- [ ] `make test-unit` (full suite)