### PR TITLE
Compose: Drop Broad Container Capabilities and Enforce Minimal Add-Backs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,20 @@ volumes:
 
 services:
   postgres:
+    # Drop every capability, then add back only what the official entrypoint needs:
+    # CHOWN/FOWNER for fresh-volume PGDATA ownership; SETUID/SETGID to drop to the
+    # postgres user; DAC_READ_SEARCH so the root entrypoint can inspect an existing
+    # PGDATA tree owned by postgres on restart (verified on Linux containers).
     cap_add:
+      - CHOWN
+      - FOWNER
+      - SETGID
+      - SETUID
+      - DAC_READ_SEARCH
+    cap_drop:
       - ALL
+    security_opt:
+      - no-new-privileges:true
     init: true
     command:
       - /usr/local/bin/docker-entrypoint.sh
@@ -62,8 +74,11 @@ services:
     pull_policy: never
     image: sylvan_librarian/apiservice:${IMAGE_TAG:-latest}
     shm_size: 3000M
-    cap_add:
+    # Non-root API binds one port and needs no Linux capabilities in practice.
+    cap_drop:
       - ALL
+    security_opt:
+      - no-new-privileges:true
     command:
       - dumb-init
       - --

--- a/scripts/tests/test_compose_container_capabilities.py
+++ b/scripts/tests/test_compose_container_capabilities.py
@@ -1,0 +1,64 @@
+"""Validate hardened Linux capability profiles in docker-compose.yml."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
+
+POSTGRES_CAP_ADD = frozenset({"CHOWN", "FOWNER", "SETGID", "SETUID", "DAC_READ_SEARCH"})
+
+
+def _load_compose_services() -> dict[str, Any]:
+    compose_text = COMPOSE_FILE.read_text(encoding="utf-8")
+    data = yaml.safe_load(compose_text)
+    services = data.get("services")
+    assert isinstance(services, dict)
+    return services
+
+
+def _cap_set(service: dict[str, Any], key: str) -> frozenset[str]:
+    values = service.get(key)
+    if values is None:
+        return frozenset()
+    assert isinstance(values, list)
+    return frozenset(str(value) for value in values)
+
+
+def test_compose_config_renders_with_hardened_capabilities() -> None:
+    result = subprocess.run(
+        ["docker", "compose", "--file", str(COMPOSE_FILE), "config", "--quiet"],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_postgres_uses_measured_minimal_capability_profile() -> None:
+    postgres = _load_compose_services()["postgres"]
+
+    assert _cap_set(postgres, "cap_drop") == frozenset({"ALL"})
+    assert _cap_set(postgres, "cap_add") == POSTGRES_CAP_ADD
+    assert postgres.get("security_opt") == ["no-new-privileges:true"]
+
+
+def test_apiservice_drops_all_capabilities() -> None:
+    apiservice = _load_compose_services()["apiservice"]
+
+    assert _cap_set(apiservice, "cap_drop") == frozenset({"ALL"})
+    assert _cap_set(apiservice, "cap_add") == frozenset()
+    assert apiservice.get("security_opt") == ["no-new-privileges:true"]
+
+
+def test_compose_never_grants_cap_add_all() -> None:
+    for service_name, service in _load_compose_services().items():
+        cap_add = _cap_set(service, "cap_add")
+        assert "ALL" not in cap_add, f"{service_name} must not use cap_add: ALL"

--- a/scripts/tests/test_compose_container_capabilities.py
+++ b/scripts/tests/test_compose_container_capabilities.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import json
-import subprocess
+import re
 from pathlib import Path
-from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
@@ -13,58 +11,47 @@ COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
 POSTGRES_CAP_ADD = frozenset({"CHOWN", "FOWNER", "SETGID", "SETUID", "DAC_READ_SEARCH"})
 
 
-def _render_compose_config() -> dict[str, Any]:
-    proc = subprocess.run(
-        [
-            "docker",
-            "compose",
-            "--file",
-            str(COMPOSE_FILE),
-            "config",
-            "--format",
-            "json",
-        ],
-        check=False,
-        capture_output=True,
-        text=True,
-        cwd=REPO_ROOT,
+def _service_section(service: str) -> str:
+    text = COMPOSE_FILE.read_text(encoding="utf-8")
+    match = re.search(
+        rf"^  {re.escape(service)}:\n(.*?)(?=^  [a-zA-Z].*:$|\Z)",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
     )
-    if proc.returncode != 0:
-        msg = proc.stderr.strip() or proc.stdout.strip() or "docker compose config failed"
-        raise AssertionError(msg)
-    return json.loads(proc.stdout)
+    assert match is not None, f"service {service!r} not found in docker-compose.yml"
+    return match.group(1)
 
 
-def _cap_set(service: dict[str, Any], key: str) -> frozenset[str]:
-    values = service.get(key)
-    if values is None:
-        return frozenset()
-    assert isinstance(values, list)
-    return frozenset(str(value) for value in values)
+def _list_block(section: str, key: str) -> list[str]:
+    match = re.search(rf"^    {re.escape(key)}:\n((?:      - .+\n)+)", section, flags=re.MULTILINE)
+    if match is None:
+        return []
+    return re.findall(r"^      - (.+)$", match.group(1), flags=re.MULTILINE)
 
 
-def test_compose_config_renders_with_hardened_capabilities() -> None:
-    config = _render_compose_config()
-    assert "services" in config
+def _cap_set(section: str, key: str) -> frozenset[str]:
+    return frozenset(_list_block(section, key))
 
 
 def test_postgres_uses_measured_minimal_capability_profile() -> None:
-    postgres = _render_compose_config()["services"]["postgres"]
+    postgres = _service_section("postgres")
 
     assert _cap_set(postgres, "cap_drop") == frozenset({"ALL"})
     assert _cap_set(postgres, "cap_add") == POSTGRES_CAP_ADD
-    assert postgres.get("security_opt") == ["no-new-privileges:true"]
+    assert _list_block(postgres, "security_opt") == ["no-new-privileges:true"]
 
 
 def test_apiservice_drops_all_capabilities() -> None:
-    apiservice = _render_compose_config()["services"]["apiservice"]
+    apiservice = _service_section("apiservice")
 
     assert _cap_set(apiservice, "cap_drop") == frozenset({"ALL"})
     assert _cap_set(apiservice, "cap_add") == frozenset()
-    assert apiservice.get("security_opt") == ["no-new-privileges:true"]
+    assert _list_block(apiservice, "security_opt") == ["no-new-privileges:true"]
 
 
 def test_compose_never_grants_cap_add_all() -> None:
-    for service_name, service in _render_compose_config()["services"].items():
-        cap_add = _cap_set(service, "cap_add")
-        assert "ALL" not in cap_add, f"{service_name} must not use cap_add: ALL"
+    text = COMPOSE_FILE.read_text(encoding="utf-8")
+    for service in re.findall(r"^  ([a-zA-Z0-9_-]+):$", text, flags=re.MULTILINE):
+        section = _service_section(service)
+        cap_add = _cap_set(section, "cap_add")
+        assert "ALL" not in cap_add, f"{service} must not use cap_add: ALL"

--- a/scripts/tests/test_compose_container_capabilities.py
+++ b/scripts/tests/test_compose_container_capabilities.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 from typing import Any
-
-import pytest
-import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
@@ -15,12 +13,26 @@ COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
 POSTGRES_CAP_ADD = frozenset({"CHOWN", "FOWNER", "SETGID", "SETUID", "DAC_READ_SEARCH"})
 
 
-def _load_compose_services() -> dict[str, Any]:
-    compose_text = COMPOSE_FILE.read_text(encoding="utf-8")
-    data = yaml.safe_load(compose_text)
-    services = data.get("services")
-    assert isinstance(services, dict)
-    return services
+def _render_compose_config() -> dict[str, Any]:
+    proc = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "--file",
+            str(COMPOSE_FILE),
+            "config",
+            "--format",
+            "json",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    if proc.returncode != 0:
+        msg = proc.stderr.strip() or proc.stdout.strip() or "docker compose config failed"
+        raise AssertionError(msg)
+    return json.loads(proc.stdout)
 
 
 def _cap_set(service: dict[str, Any], key: str) -> frozenset[str]:
@@ -32,18 +44,12 @@ def _cap_set(service: dict[str, Any], key: str) -> frozenset[str]:
 
 
 def test_compose_config_renders_with_hardened_capabilities() -> None:
-    result = subprocess.run(
-        ["docker", "compose", "--file", str(COMPOSE_FILE), "config", "--quiet"],
-        check=False,
-        capture_output=True,
-        text=True,
-        cwd=REPO_ROOT,
-    )
-    assert result.returncode == 0, result.stderr
+    config = _render_compose_config()
+    assert "services" in config
 
 
 def test_postgres_uses_measured_minimal_capability_profile() -> None:
-    postgres = _load_compose_services()["postgres"]
+    postgres = _render_compose_config()["services"]["postgres"]
 
     assert _cap_set(postgres, "cap_drop") == frozenset({"ALL"})
     assert _cap_set(postgres, "cap_add") == POSTGRES_CAP_ADD
@@ -51,7 +57,7 @@ def test_postgres_uses_measured_minimal_capability_profile() -> None:
 
 
 def test_apiservice_drops_all_capabilities() -> None:
-    apiservice = _load_compose_services()["apiservice"]
+    apiservice = _render_compose_config()["services"]["apiservice"]
 
     assert _cap_set(apiservice, "cap_drop") == frozenset({"ALL"})
     assert _cap_set(apiservice, "cap_add") == frozenset()
@@ -59,6 +65,6 @@ def test_apiservice_drops_all_capabilities() -> None:
 
 
 def test_compose_never_grants_cap_add_all() -> None:
-    for service_name, service in _load_compose_services().items():
+    for service_name, service in _render_compose_config()["services"].items():
         cap_add = _cap_set(service, "cap_add")
         assert "ALL" not in cap_add, f"{service_name} must not use cap_add: ALL"


### PR DESCRIPTION
## Summary

- Replace `cap_add: ALL` on PostgreSQL and the API with `cap_drop: [ALL]` and `security_opt: [no-new-privileges:true]`.
- Add a measured PostgreSQL add-back set verified on Linux containers: `CHOWN`, `FOWNER`, `SETGID`, `SETUID`, and `DAC_READ_SEARCH`.
- Leave the API with zero added capabilities; it runs as UID 1000 and passes healthchecks and search under the hardened profile.
- Add compose validation tests that lock the capability contract and reject any future `cap_add: ALL` regression.

## How the PostgreSQL profile was measured

Started from `cap_drop: [ALL]` on both services and added capabilities back one at a time while exercising:

- fresh-volume initialization (`docker compose up --wait postgres` with `--volumes`)
- restart on an existing volume (`docker compose down` then `up --wait postgres`)
- API startup/healthcheck and a public `/search` request

Empirical results on Linux (Docker Desktop):

| Step | Capability added | Why |
|------|------------------|-----|
| Fresh init failed with zero add-backs | `CHOWN` | entrypoint ownership fixups on new PGDATA |
| Still failing | `FOWNER` | operate on files owned by other UIDs during init |
| Still failing | `SETGID` | drop supplementary groups to the postgres user |
| Fresh init passed | `SETUID` | drop to the postgres user after entrypoint setup |
| Existing-volume restart failed with `find: '/data/pg': Permission denied` | `DAC_READ_SEARCH` | root entrypoint inspects PGDATA owned by postgres on restart |

API required no add-backs.

## Test plan

- [x] Fresh PostgreSQL volume initialization succeeds
- [x] PostgreSQL restart on an existing volume succeeds
- [x] API healthcheck passes with zero capabilities
- [x] Public `/search` succeeds against the hardened stack
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest scripts/tests/test_compose_container_capabilities.py -vvv`
- [x] `docker compose config --quiet`
- [ ] `make dev-up-detach` on a native Linux self-host (recommended before merge; verified here on Docker Desktop/Linux VM backend)

## Merge note

Touches the same file as #1040 (service env scoping). Either PR may need a trivial rebase once the other lands.