### PR TITLE
Document intentional wildcard CORS public API contract

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -62,7 +62,9 @@ npx prettier --write <changed .html/.js files>
 - `api/parsing/` — query parser: `parsing_f.py` (grammar), `nodes.py` / `card_query_nodes.py`
   (AST nodes), `db_info.py` (field → DB column mapping); unit tests in `api/parsing/tests/`
 - `api/api_resource.py` — all HTTP routing (Falcon sink), search logic, AST → SQL generation
-- `api/middlewares/` — timing, caching, compression, security headers, CORS (applied in that order)
+- `api/middlewares/` — timing, caching, compression, security headers, CORS (applied in that order);
+  `CORSMiddleware` always sets `Access-Control-Allow-Origin: *` (Scryfall-compatible public API;
+  not env-configurable today; revisit if cookie/session auth is added)
 - `api/entrypoint.py` + `api/api_worker.py` — multi-process server startup
 - `api/db/` — PostgreSQL schema and migration SQL files
 - `api/static/` — frontend (`app.js`, minified `app.min.js`, `card.html`, …)

--- a/README.md
+++ b/README.md
@@ -304,9 +304,9 @@ applies every time that stack starts; exporting one in the shell overrides the f
   - Set to `true`, `1`, or `yes` to enable caching
   - Improves performance for repeated queries
   - Can be set in docker-compose.yml or exported before starting services
-- `ENVIRONMENT` - Environment mode (default: `dev`)
-  - Set to `prod` for production mode with restricted CORS
-  - Controlled per environment in `envs/dev` / `envs/blue` / `envs/green`
+- `ENVIRONMENT` - Deployment label for logging and monitoring (default: `dev`)
+  - Set to `prod` for production deployments (`envs/blue` and `envs/green` use this)
+  - Does not change CORS behavior; see **CORS** below
 - `PREFER_SCORE_BACKFILL_TIMEOUT_MS` - Statement timeout for the prefer-score backfill (default: `120000`)
   - The backfill rescores the whole corpus in one UPDATE, so its runtime tracks disk speed
   - Raise it if an import dies in `backfill_prefer_scores` on slow storage (a virtualized
@@ -316,10 +316,11 @@ applies every time that stack starts; exporting one in the shell overrides the f
   - Override to use a different CDN provider
   - Used in Content-Security-Policy headers
   - Format: `https://your-cdn-domain.com`
-- `CORS_ALLOWED_ORIGINS` - Additional CORS allowed origins (optional)
-  - Comma-separated list of origins to allow
-  - Example: `https://example.com,https://app.example.com`
-  - Supplements environment-specific defaults
+- **CORS** — The public search API intentionally sets `Access-Control-Allow-Origin: *` on every
+  response (Scryfall-compatible, browser-readable from any origin). `CORSMiddleware` always emits
+  the wildcard; neither `ENVIRONMENT` nor any env var currently restricts origins. Operator-configurable
+  origin allowlists may be added in a future release but are **not implemented today**. Introducing
+  cookie- or session-based authentication would require revisiting this policy.
 - `ADMIN_PASSWORD` - Shared secret required to reach any `_admin/` route (see [Admin Endpoints](#admin-endpoints))
   - Generated automatically into `env.json` on first boot; never overwrites an existing value
   - Retrieve it with `jq -r .ADMIN_PASSWORD env.json`
@@ -456,7 +457,10 @@ Not approved/endorsed by Wizards of the Coast.
 
 ### Security
 
-All user input reaches the database only via parameterized queries; HTTP responses include CSP, X-Frame-Options, and CORS headers. See [docs/security/security_best_practices.md](docs/security/security_best_practices.md) for development guidelines. To report a vulnerability, see [SECURITY.md](SECURITY.md).
+All user input reaches the database only via parameterized queries; HTTP responses include CSP,
+X-Frame-Options, and `Access-Control-Allow-Origin: *` (intentional public API contract). See
+[docs/security/security_best_practices.md](docs/security/security_best_practices.md) for development
+guidelines. To report a vulnerability, see [SECURITY.md](SECURITY.md).
 
 ### Legal Compliance
 

--- a/api/middlewares/tests/test_cors_middleware.py
+++ b/api/middlewares/tests/test_cors_middleware.py
@@ -1,4 +1,8 @@
-"""Tests for CORS middleware."""
+"""Tests for CORS middleware.
+
+Public API contract: every response must carry Access-Control-Allow-Origin: * (Scryfall-compatible).
+Do not narrow origins without an explicit, documented contract change.
+"""
 
 from __future__ import annotations
 

--- a/docs/security/security_best_practices.md
+++ b/docs/security/security_best_practices.md
@@ -202,27 +202,25 @@ The application implements the following security headers via `SecurityHeadersMi
 
 ### CORS Configuration
 
-**✅ DO:**
-- Restrict origins to known domains in production
-- Use environment-specific configurations
-- Log unauthorized CORS requests
+Sylvan Librarian's public search API intentionally responds with `Access-Control-Allow-Origin: *`
+on every response, matching Scryfall's browser-readable API contract. `CORSMiddleware` always sets
+the wildcard; neither `ENVIRONMENT` nor `CORS_ALLOWED_ORIGINS` currently changes this behavior.
 
-```python
-# Good: Production CORS
-allowed_origins = [
-    "https://sylvan-librarian.com",
-    "https://www.sylvan-librarian.com"
-]
-```
+**Current contract:**
+- Public, read-only JSON API with no cookies or session credentials sent cross-origin
+- Wildcard origin allows third-party sites and browser tools to call the API directly
 
-**❌ DON'T:**
-- Don't use wildcard `*` in production
-- Don't allow untrusted origins
+**If you add cookie or session authentication:**
+- Revisit CORS before shipping — wildcard origins are incompatible with credentialed cross-origin
+  requests
 
-```python
-# Bad: Too permissive
-Access-Control-Allow-Origin: *
-```
+**Future (not implemented):**
+- Operator-configurable origin allowlists may be added later for deployments that need tighter
+  boundaries
+
+**When changing CORS middleware:**
+- Preserve the wildcard unless deliberately changing the public API contract
+- Document any contract change in README and this file
 
 ---
 
@@ -404,7 +402,7 @@ Before merging any PR, verify:
 - [ ] HTML output is properly escaped
 - [ ] No hardcoded secrets in code
 - [ ] Security headers remain configured
-- [ ] CORS is properly restricted
+- [ ] CORS behavior matches the documented wildcard public API contract (or any deliberate change is documented)
 - [ ] Dependencies scanned for vulnerabilities
 - [ ] Tests cover security-critical paths
 - [ ] Code passes security linting


### PR DESCRIPTION
## Summary
- Remove false README claims that `ENVIRONMENT=prod` restricts CORS and that `CORS_ALLOWED_ORIGINS` is honored
- Document the intentional Scryfall-compatible `Access-Control-Allow-Origin: *` public API contract in README and security docs
- Note that cookie/session auth would require revisiting CORS, and that operator-configurable origin allowlists are not implemented yet
- Add a test-module comment locking the wildcard invariant; no middleware or settings changes

## Test plan
- [x] Documentation-only PR; runtime CORS behavior unchanged
- [ ] `python -m pytest api/middlewares/tests/test_cors_middleware.py` (existing wildcard assertions still apply)