### PR TITLE
Parsing: dedupe compound AND/OR operands after regex budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ or `python3`, and falls back to `sysctl` where GNU `nproc` is absent.
    python -m ruff check
 
    # Test parser functionality including rarity search
-   python -c "from api.parsing import parse_search_query; print(parse_search_query('rarity>uncommon'))"
+   python -c "from api.parsing import parse_scryfall_query; print(parse_scryfall_query('rarity>uncommon'))"
    ```
 
 ### Development Workflows

--- a/api/parsing/__init__.py
+++ b/api/parsing/__init__.py
@@ -2,7 +2,8 @@
 
 from functools import partial
 
-from api.parsing.hand_parser import ParseError, parse_str_to_query
+from api.parsing import hand_parser
+from api.parsing.hand_parser import ParseError
 from api.parsing.nodes import (
     AndNode,
     AttributeNode,
@@ -23,8 +24,8 @@ from api.parsing.post_parse import finalize_query, parse_query
 from api.parsing.query_budget import QueryBudgetExceeded
 from api.parsing.sql_generation import generate_sql_query
 
-parse_scryfall_query = partial(parse_query, parser_fn=parse_str_to_query)
-parse_search_query = parse_scryfall_query
+parse_str_to_query = hand_parser.parse_str_to_query
+parse_scryfall_query = partial(parse_query, parser_fn=hand_parser.parse_str_to_query)
 
 __all__ = [
     "AndNode",
@@ -47,6 +48,5 @@ __all__ = [
     "generate_sql_query",
     "parse_query",
     "parse_scryfall_query",
-    "parse_search_query",
     "parse_str_to_query",
 ]

--- a/api/parsing/__init__.py
+++ b/api/parsing/__init__.py
@@ -24,7 +24,6 @@ from api.parsing.post_parse import finalize_query, parse_query
 from api.parsing.query_budget import QueryBudgetExceeded
 from api.parsing.sql_generation import generate_sql_query
 
-parse_str_to_query = hand_parser.parse_str_to_query
 parse_scryfall_query = partial(parse_query, parser_fn=hand_parser.parse_str_to_query)
 
 __all__ = [
@@ -48,5 +47,4 @@ __all__ = [
     "generate_sql_query",
     "parse_query",
     "parse_scryfall_query",
-    "parse_str_to_query",
 ]

--- a/api/parsing/__init__.py
+++ b/api/parsing/__init__.py
@@ -17,7 +17,8 @@ from api.parsing.nodes import (
     StringValueNode,
     TrueNode,
 )
-from api.parsing.parsing_f import balance_partial_query, parse_scryfall_query
+from api.parsing.parsing_f import balance_partial_query
+from api.parsing.post_parse import parse_scryfall_query
 from api.parsing.query_budget import QueryBudgetExceeded
 from api.parsing.sql_generation import generate_sql_query
 

--- a/api/parsing/__init__.py
+++ b/api/parsing/__init__.py
@@ -1,7 +1,7 @@
 """Query parsing and AST generation for Scryfall search queries."""
 
 from api.parsing.hand_parser import ParseError
-from api.parsing.hand_parser import parse_query as parse_search_query
+from api.parsing.hand_parser import parse_query as parse_query_raw
 from api.parsing.nodes import (
     AndNode,
     AttributeNode,
@@ -39,6 +39,10 @@ __all__ = [
     "TrueNode",
     "balance_partial_query",
     "generate_sql_query",
+    "parse_query_raw",
     "parse_scryfall_query",
     "parse_search_query",
 ]
+
+# Full production pipeline (hand parser → post-parse). Prefer ``parse_scryfall_query``.
+parse_search_query = parse_scryfall_query

--- a/api/parsing/__init__.py
+++ b/api/parsing/__init__.py
@@ -1,7 +1,8 @@
 """Query parsing and AST generation for Scryfall search queries."""
 
-from api.parsing.hand_parser import ParseError
-from api.parsing.hand_parser import parse_query as parse_query_raw
+from functools import partial
+
+from api.parsing.hand_parser import ParseError, parse_str_to_query
 from api.parsing.nodes import (
     AndNode,
     AttributeNode,
@@ -18,9 +19,12 @@ from api.parsing.nodes import (
     TrueNode,
 )
 from api.parsing.parsing_f import balance_partial_query
-from api.parsing.post_parse import parse_scryfall_query
+from api.parsing.post_parse import finalize_query, parse_query
 from api.parsing.query_budget import QueryBudgetExceeded
 from api.parsing.sql_generation import generate_sql_query
+
+parse_scryfall_query = partial(parse_query, parser_fn=parse_str_to_query)
+parse_search_query = parse_scryfall_query
 
 __all__ = [
     "AndNode",
@@ -39,11 +43,10 @@ __all__ = [
     "StringValueNode",
     "TrueNode",
     "balance_partial_query",
+    "finalize_query",
     "generate_sql_query",
-    "parse_query_raw",
+    "parse_query",
     "parse_scryfall_query",
     "parse_search_query",
+    "parse_str_to_query",
 ]
-
-# Full production pipeline (hand parser → post-parse). Prefer ``parse_scryfall_query``.
-parse_search_query = parse_scryfall_query

--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -816,12 +816,8 @@ class Parser:
 # ── entry point ───────────────────────────────────────────────────────────────
 
 
-def parse_query(src: str | None) -> Query:
-    """Parse a Scryfall query string into a Query AST.
-
-    Drop-in replacement for parse_search_query; handles implicit AND natively
-    without a separate preprocessing pass.
-    """
+def parse_str_to_query(src: str | None) -> Query:
+    """Parse a query string into a Query AST (lex + parse + flatten only)."""
     if not src or not src.strip():
         return Query(TrueNode())
     try:

--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -29,7 +29,7 @@ from api.parsing.nodes import (
     TrueNode,
     flatten_nested_operations,
 )
-from api.parsing.query_budget import MAX_GROUP_DEPTH, QueryBudgetExceeded, check_query_byte_length
+from api.parsing.query_budget import MAX_GROUP_DEPTH, QueryBudgetExceeded
 from api.parsing.spans import QUOTE_CHARS, brace_close_index, find_close_index, unescape
 
 # ── Alias → parser-class lookup ──────────────────────────────────────────────
@@ -824,7 +824,6 @@ def parse_query(src: str | None) -> Query:
     """
     if not src or not src.strip():
         return Query(TrueNode())
-    check_query_byte_length(src)
     try:
         tokens = tokenize(src)
     except LexError as exc:

--- a/api/parsing/parsing_f.py
+++ b/api/parsing/parsing_f.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from api.parsing.hand_parser import parse_query as _parse_query
+from api.parsing.post_parse import finalize_query
 from api.parsing.query_budget import check_query_byte_length
-from api.parsing.regex_budget import validate_regex_patterns
-from api.parsing.rewrite import rewrite_query
 from api.parsing.spans import QUOTE_CHARS, brace_close_index, find_close_index, opens_regex
 
 if TYPE_CHECKING:
@@ -105,7 +104,4 @@ def parse_scryfall_query(query: str | None) -> Query:
     """
     if query is not None:
         check_query_byte_length(query)
-    parsed = _parse_query(query)
-    rewritten = rewrite_query(parsed)
-    validate_regex_patterns(rewritten)
-    return rewritten
+    return finalize_query(_parse_query(query))

--- a/api/parsing/parsing_f.py
+++ b/api/parsing/parsing_f.py
@@ -1,16 +1,8 @@
-"""Public entry points for Scryfall query parsing."""
+"""Public entry points for Scryfall query parsing helpers."""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-from api.parsing.hand_parser import parse_query as _parse_query
-from api.parsing.post_parse import finalize_query
-from api.parsing.query_budget import check_query_byte_length
 from api.parsing.spans import QUOTE_CHARS, brace_close_index, find_close_index, opens_regex
-
-if TYPE_CHECKING:
-    from api.parsing.nodes import Query
 
 
 def _closer_for_partial_span(dangling_escape: bool, closer: str) -> str:
@@ -87,21 +79,3 @@ def balance_partial_query(query: str) -> str:
             open_parens -= 1
 
     return query + span_suffix + ")" * open_parens
-
-
-def parse_scryfall_query(query: str | None) -> Query:
-    """Parse a Scryfall search query into a card-specific AST.
-
-    Args:
-        query: The search query string to parse.
-
-    Returns:
-        A Scryfall-specific Query AST.
-
-    Raises:
-        QueryBudgetExceeded: When a regex leaf exceeds a public static bound.
-        InvalidRegexPatternError: When a regex leaf fails the stdlib parser.
-    """
-    if query is not None:
-        check_query_byte_length(query)
-    return finalize_query(_parse_query(query))

--- a/api/parsing/post_parse.py
+++ b/api/parsing/post_parse.py
@@ -17,6 +17,8 @@ from api.parsing.regex_budget import validate_regex_patterns
 from api.parsing.rewrite import flatten_and_deduplicate_compounds, rewrite_query
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from api.parsing.nodes import Query
 
 
@@ -27,18 +29,18 @@ def finalize_query(query: Query) -> Query:
     return flatten_and_deduplicate_compounds(query)
 
 
-def _check_public_query_length(query: str | None) -> None:
+def parse_query(query: str | None, parser_fn: Callable[[str | None], Query]) -> Query:
+    """Run *parser_fn* on *query*, then the shared post-parse pipeline."""
     if query is not None:
         check_query_byte_length(query)
+    return finalize_query(parser_fn(query))
 
 
 def parse_scryfall_query(query: str | None) -> Query:
     """Parse a search query with the production hand parser and post-parse pipeline."""
-    _check_public_query_length(query)
-    return finalize_query(parse_hand_query(query))
+    return parse_query(query, parse_hand_query)
 
 
 def parse_pyparsing_query(query: str | None) -> Query:
     """Same pipeline as ``parse_scryfall_query``, using the pyparsing front end (parity tests)."""
-    _check_public_query_length(query)
-    return finalize_query(parse_search_query_raw(query))
+    return parse_query(query, parse_search_query_raw)

--- a/api/parsing/post_parse.py
+++ b/api/parsing/post_parse.py
@@ -1,15 +1,18 @@
-"""Post-parse pipeline — the single AST seam every front-end parser must use.
+"""Post-parse pipeline — the single seam from query string to production AST.
 
-String parsing has two front ends (hand-rolled production parser, legacy pyparsing
-oracle for parity tests). They produce different pre-rewrite trees but must not
-diverge on rewrites, regex limits, or compound normalization. ``finalize_query``
-is that convergence point: raw ``Query`` in, production-ready ``Query`` out.
+Two string front ends (hand-rolled production parser, legacy pyparsing oracle for
+parity tests) produce different pre-rewrite trees. Both must pass through
+``finalize_query`` so rewrites, regex limits, and compound normalization stay
+identical. ``parse_scryfall_query`` is the only production entry point.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from api.parsing.hand_parser import parse_query as parse_hand_query
+from api.parsing.pyparsing_based import parse_search_query_raw
+from api.parsing.query_budget import check_query_byte_length
 from api.parsing.regex_budget import validate_regex_patterns
 from api.parsing.rewrite import flatten_and_deduplicate_compounds, rewrite_query
 
@@ -22,3 +25,20 @@ def finalize_query(query: Query) -> Query:
     query = rewrite_query(query)
     validate_regex_patterns(query)
     return flatten_and_deduplicate_compounds(query)
+
+
+def _check_public_query_length(query: str | None) -> None:
+    if query is not None:
+        check_query_byte_length(query)
+
+
+def parse_scryfall_query(query: str | None) -> Query:
+    """Parse a search query with the production hand parser and post-parse pipeline."""
+    _check_public_query_length(query)
+    return finalize_query(parse_hand_query(query))
+
+
+def parse_pyparsing_query(query: str | None) -> Query:
+    """Same pipeline as ``parse_scryfall_query``, using the pyparsing front end (parity tests)."""
+    _check_public_query_length(query)
+    return finalize_query(parse_search_query_raw(query))

--- a/api/parsing/post_parse.py
+++ b/api/parsing/post_parse.py
@@ -1,0 +1,24 @@
+"""Post-parse pipeline — the single AST seam every front-end parser must use.
+
+String parsing has two front ends (hand-rolled production parser, legacy pyparsing
+oracle for parity tests). They produce different pre-rewrite trees but must not
+diverge on rewrites, regex limits, or compound normalization. ``finalize_query``
+is that convergence point: raw ``Query`` in, production-ready ``Query`` out.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from api.parsing.regex_budget import validate_regex_patterns
+from api.parsing.rewrite import flatten_and_deduplicate_compounds, rewrite_query
+
+if TYPE_CHECKING:
+    from api.parsing.nodes import Query
+
+
+def finalize_query(query: Query) -> Query:
+    """Apply semantic rewrites, regex static limits, then flatten+dedupe normalization."""
+    query = rewrite_query(query)
+    validate_regex_patterns(query)
+    return flatten_and_deduplicate_compounds(query)

--- a/api/parsing/post_parse.py
+++ b/api/parsing/post_parse.py
@@ -1,17 +1,9 @@
-"""Post-parse pipeline — the single seam from query string to production AST.
-
-Two string front ends (hand-rolled production parser, legacy pyparsing oracle for
-parity tests) produce different pre-rewrite trees. Both must pass through
-``finalize_query`` so rewrites, regex limits, and compound normalization stay
-identical. ``parse_scryfall_query`` is the only production entry point.
-"""
+"""Post-parse pipeline — shared transforms after any front-end parser."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from api.parsing.hand_parser import parse_query as parse_hand_query
-from api.parsing.pyparsing_based import parse_search_query_raw
 from api.parsing.query_budget import check_query_byte_length
 from api.parsing.regex_budget import validate_regex_patterns
 from api.parsing.rewrite import flatten_and_deduplicate_compounds, rewrite_query
@@ -30,17 +22,11 @@ def finalize_query(query: Query) -> Query:
 
 
 def parse_query(query: str | None, parser_fn: Callable[[str | None], Query]) -> Query:
-    """Run *parser_fn* on *query*, then the shared post-parse pipeline."""
+    """Run *parser_fn* on *query*, then ``finalize_query``.
+
+    Front-end parsers (``hand_parser.parse_str_to_query``, ``pyparsing_based.parse_str_to_query``)
+    each turn a string into a raw AST; this is the single entry for the full public pipeline.
+    """
     if query is not None:
         check_query_byte_length(query)
     return finalize_query(parser_fn(query))
-
-
-def parse_scryfall_query(query: str | None) -> Query:
-    """Parse a search query with the production hand parser and post-parse pipeline."""
-    return parse_query(query, parse_hand_query)
-
-
-def parse_pyparsing_query(query: str | None) -> Query:
-    """Same pipeline as ``parse_scryfall_query``, using the pyparsing front end (parity tests)."""
-    return parse_query(query, parse_search_query_raw)

--- a/api/parsing/pyparsing_based.py
+++ b/api/parsing/pyparsing_based.py
@@ -44,7 +44,7 @@ from api.parsing.nodes import (
     TrueNode,
     flatten_nested_operations,
 )
-from api.parsing.rewrite import rewrite_query
+from api.parsing.post_parse import finalize_query
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -575,19 +575,8 @@ def get_parse_expr() -> ParserElement:  # noqa: PLR0915
     return expr
 
 
-def parse_search_query(query: str | None) -> Query:
-    """Parse a search query string into a Query AST using the pyparsing grammar.
-
-    Args:
-        query: The search query string to parse. Can be None or empty.
-
-    Returns:
-        Query: A Query AST node containing the parsed query structure.
-            For empty queries, returns a default query that is always true.
-
-    Raises:
-        ValueError: If parsing fails due to syntax errors or invalid operators.
-    """
+def parse_search_query_raw(query: str | None) -> Query:
+    """Parse with pyparsing only — no post-parse pipeline. For parity tests and AST diffs."""
     original_query = query
     if query is None or not query.strip():
         return Query(TrueNode())
@@ -597,17 +586,20 @@ def parse_search_query(query: str | None) -> Query:
 
     try:
         parsed = expr.parse_string(query, parse_all=True)
-        # parse => transform => rest, mirroring parse_scryfall_query so the whole rewrite pipeline
-        # applies identically to both parsers (kept in lockstep by test_parser_parity).
         if parsed:
-            return rewrite_query(to_card_query_ast(flatten_nested_operations(Query(parsed[0]))))
-        return rewrite_query(to_card_query_ast(Query(BinaryOperatorNode("name", ":", ""))))
+            return to_card_query_ast(flatten_nested_operations(Query(parsed[0])))
+        return to_card_query_ast(Query(BinaryOperatorNode("name", ":", "")))
     except (ValueError, TypeError, IndexError) as e:
         msg = "main query parsing"
         raise create_parsing_error(msg, e, query) from e
     except ParseException as e:
         msg = f'Failed to parse query: "{original_query}"'
         raise ValueError(msg) from e
+
+
+def parse_search_query(query: str | None) -> Query:
+    """Parse with pyparsing, then run the shared post-parse pipeline."""
+    return finalize_query(parse_search_query_raw(query))
 
 
 @cachebox.cached(cache={})

--- a/api/parsing/pyparsing_based.py
+++ b/api/parsing/pyparsing_based.py
@@ -574,8 +574,8 @@ def get_parse_expr() -> ParserElement:  # noqa: PLR0915
     return expr
 
 
-def parse_search_query_raw(query: str | None) -> Query:
-    """Parse with pyparsing only — no post-parse pipeline. For parity tests and AST diffs."""
+def parse_str_to_query(query: str | None) -> Query:
+    """Parse a query string into a Query AST (pyparsing front end, no post-parse pipeline)."""
     original_query = query
     if query is None or not query.strip():
         return Query(TrueNode())

--- a/api/parsing/pyparsing_based.py
+++ b/api/parsing/pyparsing_based.py
@@ -44,7 +44,6 @@ from api.parsing.nodes import (
     TrueNode,
     flatten_nested_operations,
 )
-from api.parsing.post_parse import finalize_query
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -595,11 +594,6 @@ def parse_search_query_raw(query: str | None) -> Query:
     except ParseException as e:
         msg = f'Failed to parse query: "{original_query}"'
         raise ValueError(msg) from e
-
-
-def parse_search_query(query: str | None) -> Query:
-    """Parse with pyparsing, then run the shared post-parse pipeline."""
-    return finalize_query(parse_search_query_raw(query))
 
 
 @cachebox.cached(cache={})

--- a/api/parsing/rewrite.py
+++ b/api/parsing/rewrite.py
@@ -306,12 +306,26 @@ def expand_derived_predicates(query: Query) -> Query:
     return flatten_nested_operations(Query(root))
 
 
+def _operand_dedup_key(node: QueryNode) -> tuple:
+    """Hashable key for order-insensitive dedup within one AND/OR operand list."""
+    cls = node.__class__
+    if cls is AndNode or cls is OrNode:
+        return (cls.__name__, frozenset(_operand_dedup_key(op) for op in node.operands))
+    if cls is NotNode:
+        return ("NotNode", _operand_dedup_key(node.operand))
+    return ("leaf", hash(node))
+
+
 def _deduplicate_operand_list(operands: list[QueryNode]) -> list[QueryNode]:
     """Drop duplicate operands, keeping the first (order-insensitive within one compound)."""
+    seen: set[tuple] = set()
     unique: list[QueryNode] = []
     for operand in operands:
-        if not any(operand == existing for existing in unique):
-            unique.append(operand)
+        key = _operand_dedup_key(operand)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(operand)
     return unique
 
 
@@ -346,17 +360,11 @@ def _normalize_compound_operands(node: QueryNode) -> tuple[QueryNode, bool]:
 def flatten_and_deduplicate_compounds(query: Query) -> Query:
     """Flatten nested AND/OR chains, drop duplicate operands, unwrap singleton compounds.
 
-    Runs after semantic rewrites and regex-budget checks. Child normalization can expose new
-    duplicates at the parent (``AND(AND(a,a), b)``), so iterate flatten+dedupe to a fixpoint.
+    A single bottom-up pass merges same-type children, dedupes with order-insensitive keys
+    (``AND(cmc<2, c=w)`` equals ``AND(c=w, cmc<2)`` under a shared OR), then unwraps.
     """
-    root = query.root
-    while True:
-        flattened = flatten_nested_operations(root)
-        normalized, changed = _normalize_compound_operands(flattened)
-        if not changed and normalized == flattened:
-            break
-        root = normalized
-    if root is query.root:
+    root, changed = _normalize_compound_operands(flatten_nested_operations(query.root))
+    if not changed:
         return query
     return Query(root)
 

--- a/api/parsing/rewrite.py
+++ b/api/parsing/rewrite.py
@@ -1,9 +1,9 @@
 """Post-parse query rewriting: expand derived predicates into subtrees of primitives.
 
-Applied once at the shared parse seam (`parse_scryfall_query`), so both the production
-hand parser and the legacy pyparsing parser get identical treatment: the transform
-operates on the common AST, after parsing and before SQL / Rust-engine serialization
-(`parse => transform => rest`). Nothing parser-specific lives here.
+Applied once at the shared post-parse seam (`post_parse.finalize_query`), so both the
+production hand parser and the legacy pyparsing parser get identical treatment: the
+transform operates on the common AST, after parsing and before SQL / Rust-engine
+serialization (`parse => finalize_query => rest`). Nothing parser-specific lives here.
 
 Each expansion is written as a DSL string and re-parsed with the production parser, so a
 definition is expressed in the same language it targets and stays correct by construction
@@ -316,6 +316,61 @@ def expand_derived_predicates(query: Query) -> Query:
     return flatten_nested_operations(Query(root))
 
 
+def _deduplicate_operand_list(operands: list[QueryNode]) -> list[QueryNode]:
+    """Drop duplicate operands, keeping the first (order-insensitive within one compound)."""
+    unique: list[QueryNode] = []
+    for operand in operands:
+        if not any(operand == existing for existing in unique):
+            unique.append(operand)
+    return unique
+
+
+def _normalize_compound_operands(node: QueryNode) -> tuple[QueryNode, bool]:
+    """Bottom-up flatten, dedupe, and unwrap singleton And/Or nodes."""
+    cls = node.__class__
+    if cls is AndNode or cls is OrNode:
+        changed = False
+        operands: list[QueryNode] = []
+        for operand in node.operands:
+            normalized, operand_changed = _normalize_compound_operands(operand)
+            changed |= operand_changed
+            if isinstance(normalized, cls):
+                operands.extend(normalized.operands)
+                changed = True
+            else:
+                operands.append(normalized)
+        deduped = _deduplicate_operand_list(operands)
+        if len(deduped) != len(operands):
+            changed = True
+        if len(deduped) <= 1:
+            return (deduped[0], True) if deduped else (node, changed)
+        if not changed:
+            return node, False
+        return cls(deduped), True
+    if cls is NotNode:
+        normalized, changed = _normalize_compound_operands(node.operand)
+        return (NotNode(normalized), True) if changed else (node, False)
+    return node, False
+
+
+def flatten_and_deduplicate_compounds(query: Query) -> Query:
+    """Flatten nested AND/OR chains, drop duplicate operands, unwrap singleton compounds.
+
+    Runs after semantic rewrites and regex-budget checks. Child normalization can expose new
+    duplicates at the parent (``AND(AND(a,a), b)``), so iterate flatten+dedupe to a fixpoint.
+    """
+    root = query.root
+    while True:
+        flattened = flatten_nested_operations(root)
+        normalized, changed = _normalize_compound_operands(flattened)
+        if not changed and normalized == flattened:
+            break
+        root = normalized
+    if root is query.root:
+        return query
+    return Query(root)
+
+
 # The post-parse rewrite pipeline, applied in order at the shared parse seam. Add future AST
 # rewrites to this tuple — both parsers call `rewrite_query`, so a new pass lands in exactly one
 # place and is guaranteed identical treatment across parsers (enforced by test_parser_parity).
@@ -330,6 +385,10 @@ def rewrite_query(query: Query) -> Query:
     `expand_derived_predicates` (a synonym may expand into a subtree that itself contains a
     regex or other rewritable leaf), then `lower_literal_regexes`, then any future pass
     appended to `_REWRITE_PASSES`.
+
+    ``flatten_and_deduplicate_compounds`` runs later in ``post_parse.finalize_query`` — after
+    regex-budget validation — so duplicate identical regex leaves still count toward the public
+    leaf limit.
     """
     for rewrite_pass in _REWRITE_PASSES:
         query = rewrite_pass(query)

--- a/api/parsing/rewrite.py
+++ b/api/parsing/rewrite.py
@@ -166,16 +166,6 @@ def _leaf_key(node: QueryNode) -> tuple[str, str] | None:
     return (alias, value.lower())
 
 
-def _parse_expansion(dsl: str) -> QueryNode:
-    """Parse an expansion DSL string into a subtree (the production parser's output root).
-
-    Uses the production hand parser directly (not the public ``parse_scryfall_query`` seam) so expansion of
-    a synonym does not recurse back through this transform; nesting is handled explicitly
-    by `_expand` re-walking the result.
-    """
-    return _parse_str_to_query(dsl).root
-
-
 def _expand(node: QueryNode, in_progress: frozenset[tuple[str, str]]) -> tuple[QueryNode, bool]:
     """Expand derived-predicate leaves in `node`; return `(node, changed)`.
 
@@ -197,9 +187,9 @@ def _expand(node: QueryNode, in_progress: frozenset[tuple[str, str]]) -> tuple[Q
         return (NotNode(new_op), True) if changed else (node, False)
     key = _leaf_key(node)
     if key is not None and key in _DERIVED_EXPANSIONS and key not in in_progress:
-        # Recurse into the expansion so a definition may itself reference another derived
-        # predicate; `in_progress` breaks any (mis)configured cycle (a -> ... -> a).
-        subtree, _ = _expand(_parse_expansion(_DERIVED_EXPANSIONS[key]), in_progress | {key})
+        # Parse the expansion with the hand parser only (not ``parse_scryfall_query``), so synonym
+        # expansion does not recurse through this transform; ``in_progress`` breaks any cycle.
+        subtree, _ = _expand(_parse_str_to_query(_DERIVED_EXPANSIONS[key]).root, in_progress | {key})
         return subtree, True
     return node, False
 

--- a/api/parsing/rewrite.py
+++ b/api/parsing/rewrite.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from api.parsing.card_query_nodes import CardAttributeNode
-from api.parsing.hand_parser import parse_query as _parse_query
+from api.parsing.hand_parser import parse_str_to_query as _parse_str_to_query
 from api.parsing.nodes import (
     AndNode,
     BinaryOperatorNode,
@@ -169,11 +169,11 @@ def _leaf_key(node: QueryNode) -> tuple[str, str] | None:
 def _parse_expansion(dsl: str) -> QueryNode:
     """Parse an expansion DSL string into a subtree (the production parser's output root).
 
-    Uses the production hand parser directly (not `parse_scryfall_query`) so expansion of
+    Uses the production hand parser directly (not the public ``parse_scryfall_query`` seam) so expansion of
     a synonym does not recurse back through this transform; nesting is handled explicitly
     by `_expand` re-walking the result.
     """
-    return _parse_query(dsl).root
+    return _parse_str_to_query(dsl).root
 
 
 def _expand(node: QueryNode, in_progress: frozenset[tuple[str, str]]) -> tuple[QueryNode, bool]:

--- a/api/parsing/tests/conftest.py
+++ b/api/parsing/tests/conftest.py
@@ -1,12 +1,17 @@
 """Shared fixtures for parsing tests."""
 
+from functools import partial
+
 import pytest
 
 from api.parsing import parse_scryfall_query
-from api.parsing.post_parse import parse_pyparsing_query
+from api.parsing.post_parse import parse_query as parse_with_pipeline
+from api.parsing.pyparsing_based import parse_str_to_query as pyparsing_parse_str_to_query
+
+parse_with_pyparsing = partial(parse_with_pipeline, parser_fn=pyparsing_parse_str_to_query)
 
 
-@pytest.fixture(params=[parse_scryfall_query, parse_pyparsing_query], ids=["hand_rolled", "pyparsing"])
+@pytest.fixture(params=[parse_scryfall_query, parse_with_pyparsing], ids=["hand_rolled", "pyparsing"])
 def parse_query(request):
     """Parametrized fixture that runs each test against both parser implementations."""
     return request.param

--- a/api/parsing/tests/conftest.py
+++ b/api/parsing/tests/conftest.py
@@ -3,10 +3,10 @@
 import pytest
 
 from api.parsing import parse_scryfall_query
-from api.parsing.pyparsing_based import parse_search_query
+from api.parsing.post_parse import parse_pyparsing_query
 
 
-@pytest.fixture(params=[parse_scryfall_query, parse_search_query], ids=["hand_rolled", "pyparsing"])
+@pytest.fixture(params=[parse_scryfall_query, parse_pyparsing_query], ids=["hand_rolled", "pyparsing"])
 def parse_query(request):
     """Parametrized fixture that runs each test against both parser implementations."""
     return request.param

--- a/api/parsing/tests/test_alias_spellings.py
+++ b/api/parsing/tests/test_alias_spellings.py
@@ -9,10 +9,14 @@ the rest. Each added spelling must resolve to the same field as its canonical
 form, in both parsers.
 """
 
+from functools import partial
+
 import pytest
 
-from api.parsing import generate_sql_query, parse_scryfall_query
-from api.parsing.post_parse import parse_pyparsing_query
+from api.parsing import generate_sql_query, parse_query, parse_scryfall_query
+from api.parsing.pyparsing_based import parse_str_to_query as pyparsing_parse_str_to_query
+
+parse_with_pyparsing = partial(parse_query, parser_fn=pyparsing_parse_str_to_query)
 
 # (alias spelling, the already-supported spelling it must match)
 TAG_ALIAS_CASES = [
@@ -31,7 +35,7 @@ TAG_ALIAS_CASES = [
 def test_tag_aliases_match_canonical(alias_query: str, canonical_query: str) -> None:
     """Each Scryfall tag-alias spelling produces identical SQL to its canonical form, in both parsers."""
     assert generate_sql_query(parse_scryfall_query(alias_query)) == generate_sql_query(parse_scryfall_query(canonical_query))
-    assert generate_sql_query(parse_pyparsing_query(alias_query)) == generate_sql_query(parse_pyparsing_query(canonical_query))
+    assert generate_sql_query(parse_with_pyparsing(alias_query)) == generate_sql_query(parse_with_pyparsing(canonical_query))
 
 
 CI_CASES = [
@@ -50,4 +54,4 @@ CI_CASES = [
 def test_ci_is_an_identity_alias(ci_query: str, id_query: str) -> None:
     """`ci` produces identical SQL to the established identity aliases, in both parsers."""
     assert generate_sql_query(parse_scryfall_query(ci_query)) == generate_sql_query(parse_scryfall_query(id_query))
-    assert generate_sql_query(parse_pyparsing_query(ci_query)) == generate_sql_query(parse_pyparsing_query(id_query))
+    assert generate_sql_query(parse_with_pyparsing(ci_query)) == generate_sql_query(parse_with_pyparsing(id_query))

--- a/api/parsing/tests/test_alias_spellings.py
+++ b/api/parsing/tests/test_alias_spellings.py
@@ -12,7 +12,7 @@ form, in both parsers.
 import pytest
 
 from api.parsing import generate_sql_query, parse_scryfall_query
-from api.parsing.pyparsing_based import parse_search_query
+from api.parsing.post_parse import parse_pyparsing_query
 
 # (alias spelling, the already-supported spelling it must match)
 TAG_ALIAS_CASES = [
@@ -31,7 +31,7 @@ TAG_ALIAS_CASES = [
 def test_tag_aliases_match_canonical(alias_query: str, canonical_query: str) -> None:
     """Each Scryfall tag-alias spelling produces identical SQL to its canonical form, in both parsers."""
     assert generate_sql_query(parse_scryfall_query(alias_query)) == generate_sql_query(parse_scryfall_query(canonical_query))
-    assert generate_sql_query(parse_search_query(alias_query)) == generate_sql_query(parse_search_query(canonical_query))
+    assert generate_sql_query(parse_pyparsing_query(alias_query)) == generate_sql_query(parse_pyparsing_query(canonical_query))
 
 
 CI_CASES = [
@@ -50,4 +50,4 @@ CI_CASES = [
 def test_ci_is_an_identity_alias(ci_query: str, id_query: str) -> None:
     """`ci` produces identical SQL to the established identity aliases, in both parsers."""
     assert generate_sql_query(parse_scryfall_query(ci_query)) == generate_sql_query(parse_scryfall_query(id_query))
-    assert generate_sql_query(parse_search_query(ci_query)) == generate_sql_query(parse_search_query(id_query))
+    assert generate_sql_query(parse_pyparsing_query(ci_query)) == generate_sql_query(parse_pyparsing_query(id_query))

--- a/api/parsing/tests/test_color_names.py
+++ b/api/parsing/tests/test_color_names.py
@@ -21,7 +21,7 @@ import pytest
 
 from api.parsing import generate_sql_query, parse_scryfall_query
 from api.parsing.colors import COLOR_ALIAS_TO_CODES
-from api.parsing.pyparsing_based import parse_search_query
+from api.parsing.post_parse import parse_pyparsing_query
 
 # (name query, the letter query it must mean). Every pair verified live before landing.
 COLOR_NAME_CASES = [
@@ -87,7 +87,7 @@ COLOR_NAME_CASES = [
 def test_color_name_matches_letters(query: str, canonical_query: str) -> None:
     """A colour name produces exactly the SQL its letter spelling does, in both parsers."""
     assert generate_sql_query(parse_scryfall_query(query)) == generate_sql_query(parse_scryfall_query(canonical_query))
-    assert generate_sql_query(parse_search_query(query)) == generate_sql_query(parse_search_query(canonical_query))
+    assert generate_sql_query(parse_pyparsing_query(query)) == generate_sql_query(parse_pyparsing_query(canonical_query))
 
 
 @pytest.mark.parametrize(

--- a/api/parsing/tests/test_color_names.py
+++ b/api/parsing/tests/test_color_names.py
@@ -17,11 +17,15 @@ later, verified the same way: `c:witherbloom` = `c:bg` = 606 corpus-wide, and so
 `college`, `colleges`, and `strixhaven` are rejected by Scryfall, same boundary-not-superset rule.
 """
 
+from functools import partial
+
 import pytest
 
-from api.parsing import generate_sql_query, parse_scryfall_query
+from api.parsing import generate_sql_query, parse_query, parse_scryfall_query
 from api.parsing.colors import COLOR_ALIAS_TO_CODES
-from api.parsing.post_parse import parse_pyparsing_query
+from api.parsing.pyparsing_based import parse_str_to_query as pyparsing_parse_str_to_query
+
+parse_with_pyparsing = partial(parse_query, parser_fn=pyparsing_parse_str_to_query)
 
 # (name query, the letter query it must mean). Every pair verified live before landing.
 COLOR_NAME_CASES = [
@@ -87,7 +91,7 @@ COLOR_NAME_CASES = [
 def test_color_name_matches_letters(query: str, canonical_query: str) -> None:
     """A colour name produces exactly the SQL its letter spelling does, in both parsers."""
     assert generate_sql_query(parse_scryfall_query(query)) == generate_sql_query(parse_scryfall_query(canonical_query))
-    assert generate_sql_query(parse_pyparsing_query(query)) == generate_sql_query(parse_pyparsing_query(canonical_query))
+    assert generate_sql_query(parse_with_pyparsing(query)) == generate_sql_query(parse_with_pyparsing(canonical_query))
 
 
 @pytest.mark.parametrize(

--- a/api/parsing/tests/test_dedupe_compounds.py
+++ b/api/parsing/tests/test_dedupe_compounds.py
@@ -1,0 +1,42 @@
+"""Tests for post-budget flatten+dedupe compound normalization."""
+
+from __future__ import annotations
+
+import pytest
+
+from api.parsing import generate_sql_query, parse_scryfall_query
+from api.parsing.query_budget import QueryBudgetExceeded
+from api.parsing.regex_budget import MAX_REGEX_LEAVES_PER_QUERY
+
+
+@pytest.mark.parametrize(
+    ("query", "canonical_query"),
+    [
+        ("color=g color=g", "color=g"),
+        ("color=g (color=g color=g)", "color=g"),
+        ("cmc<2 c=w cmc<2 color=w", "cmc<2 c=w"),
+        ("(cmc<2 c=w) (color=w cmc<2)", "cmc<2 c=w"),
+        ("t:creature or t:instant or t:creature", "t:creature or t:instant"),
+        ("is:dual is:dual", "is:dual"),
+    ],
+    ids=[
+        "duplicate_leaf",
+        "nested_duplicate_and",
+        "duplicate_mixed_aliases",
+        "order_insensitive_and_group",
+        "duplicate_or_disjunct",
+        "duplicate_derived_predicate",
+    ],
+)
+def test_deduplicate_compound_operands(parse_query, query: str, canonical_query: str) -> None:
+    """Duplicate AND/OR operands normalize to the same AST and SQL as the minimal form."""
+    assert parse_query(query) == parse_query(canonical_query)
+    assert generate_sql_query(parse_query(query)) == generate_sql_query(parse_query(canonical_query))
+
+
+def test_regex_budget_counts_duplicates_before_dedupe() -> None:
+    """Identical regex leaves still hit the leaf limit even though dedupe would collapse them."""
+    query = " ".join("o:/(?=.*draw)/" for _ in range(MAX_REGEX_LEAVES_PER_QUERY + 1))
+    with pytest.raises(QueryBudgetExceeded) as exc_info:
+        parse_scryfall_query(query)
+    assert exc_info.value.kind == "regex_leaves"

--- a/api/parsing/tests/test_dedupe_compounds.py
+++ b/api/parsing/tests/test_dedupe_compounds.py
@@ -10,14 +10,18 @@ from api.parsing.regex_budget import MAX_REGEX_LEAVES_PER_QUERY
 
 
 @pytest.mark.parametrize(
-    ("query", "canonical_query"),
-    [
+    argnames=["query", "canonical_query"],
+    argvalues=[
         ("color=g color=g", "color=g"),
         ("color=g (color=g color=g)", "color=g"),
         ("cmc<2 c=w cmc<2 color=w", "cmc<2 c=w"),
         ("(cmc<2 c=w) (color=w cmc<2)", "cmc<2 c=w"),
         ("t:creature or t:instant or t:creature", "t:creature or t:instant"),
         ("is:dual is:dual", "is:dual"),
+        (
+            "t:instant or (cmc<2 c=w) or (c=w cmc<2)",
+            "t:instant or (cmc<2 c=w)",
+        ),
     ],
     ids=[
         "duplicate_leaf",
@@ -26,6 +30,7 @@ from api.parsing.regex_budget import MAX_REGEX_LEAVES_PER_QUERY
         "order_insensitive_and_group",
         "duplicate_or_disjunct",
         "duplicate_derived_predicate",
+        "order_insensitive_and_under_or",
     ],
 )
 def test_deduplicate_compound_operands(parse_query, query: str, canonical_query: str) -> None:

--- a/api/parsing/tests/test_parser_parity.py
+++ b/api/parsing/tests/test_parser_parity.py
@@ -3,7 +3,7 @@
 import pytest
 
 from api.parsing import generate_sql_query, parse_scryfall_query
-from api.parsing.pyparsing_based import parse_search_query
+from api.parsing.post_parse import parse_pyparsing_query
 from api.parsing.tests.implicit_and_cases import TESTCASES
 
 
@@ -20,7 +20,7 @@ def assert_parsers_agree(query: str) -> None:
         hand_exc = exc
 
     try:
-        pyp_result = generate_sql_query(parse_search_query(query))
+        pyp_result = generate_sql_query(parse_pyparsing_query(query))
     except Exception as exc:  # noqa: BLE001
         pyp_exc = exc
 

--- a/api/parsing/tests/test_parser_parity.py
+++ b/api/parsing/tests/test_parser_parity.py
@@ -1,10 +1,14 @@
 """Tests that both parser implementations produce identical SQL for the same queries."""
 
+from functools import partial
+
 import pytest
 
-from api.parsing import generate_sql_query, parse_scryfall_query
-from api.parsing.post_parse import parse_pyparsing_query
+from api.parsing import generate_sql_query, parse_query, parse_scryfall_query
+from api.parsing.pyparsing_based import parse_str_to_query as pyparsing_parse_str_to_query
 from api.parsing.tests.implicit_and_cases import TESTCASES
+
+parse_with_pyparsing = partial(parse_query, parser_fn=pyparsing_parse_str_to_query)
 
 
 def assert_parsers_agree(query: str) -> None:
@@ -20,7 +24,7 @@ def assert_parsers_agree(query: str) -> None:
         hand_exc = exc
 
     try:
-        pyp_result = generate_sql_query(parse_pyparsing_query(query))
+        pyp_result = generate_sql_query(parse_with_pyparsing(query))
     except Exception as exc:  # noqa: BLE001
         pyp_exc = exc
 

--- a/api/parsing/tests/test_pyparsing_parser.py
+++ b/api/parsing/tests/test_pyparsing_parser.py
@@ -122,7 +122,7 @@ from api.parsing.db_info import ParserClass
 )
 def test_parse_to_nodes(test_input: str, expected_ast: QueryNode) -> None:
     """Test that queries parse into the expected AST structure."""
-    observed = parsing.parse_search_query(test_input).root
+    observed = parsing.parse_query_raw(test_input).root
 
     # Compare the full AST structure
     assert observed == expected_ast, f"\nExpected: {expected_ast}\nObserved: {observed}"
@@ -131,7 +131,7 @@ def test_parse_to_nodes(test_input: str, expected_ast: QueryNode) -> None:
 def test_parse_simple_condition() -> None:
     """Test parsing a simple condition."""
     query = "cmc:2"
-    result = parsing.parse_search_query(query)
+    result = parsing.parse_query_raw(query)
     expected = BinaryOperatorNode(CardAttributeNode("cmc", ParserClass.NUMERIC), ":", NumericValueNode(2))
     assert result.root == expected
 
@@ -139,7 +139,7 @@ def test_parse_simple_condition() -> None:
 def test_parse_and_operation() -> None:
     """Test parsing AND operations."""
     query = "a AND b"
-    result = parsing.parse_search_query(query).root
+    result = parsing.parse_query_raw(query).root
 
     assert result == AndNode(
         [
@@ -152,7 +152,7 @@ def test_parse_and_operation() -> None:
 def test_parse_or_operation() -> None:
     """Test parsing OR operations."""
     query = "a OR b"
-    result = parsing.parse_search_query(query).root
+    result = parsing.parse_query_raw(query).root
     assert result == OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("name", ParserClass.TEXT), ":", StringValueNode("a")),
@@ -164,7 +164,7 @@ def test_parse_or_operation() -> None:
 def test_parse_implicit_and() -> None:
     """Test parsing implicit AND operations."""
     query = "a b"
-    result = parsing.parse_search_query(query).root
+    result = parsing.parse_query_raw(query).root
     assert result == AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("name", ParserClass.TEXT), ":", StringValueNode("a")),
@@ -176,7 +176,7 @@ def test_parse_implicit_and() -> None:
 def test_parse_complex_nested() -> None:
     """Test parsing complex nested queries."""
     query = "cmc:2 AND (oracle:flying OR oracle:haste)"
-    result = parsing.parse_search_query(query)
+    result = parsing.parse_query_raw(query)
 
     assert isinstance(result, parsing.Query)
     assert isinstance(result.root, AndNode)
@@ -186,7 +186,7 @@ def test_parse_complex_nested() -> None:
 
     # Test with flavor text as well
     query2 = "cmc:3 AND (flavor:magic OR oracle:flying)"
-    result2 = parsing.parse_search_query(query2)
+    result2 = parsing.parse_query_raw(query2)
     assert isinstance(result2, parsing.Query)
     assert isinstance(result2.root, AndNode)
     assert len(result2.root.operands) == 2
@@ -195,7 +195,7 @@ def test_parse_complex_nested() -> None:
 def test_parse_quoted_strings() -> None:
     """Test parsing quoted strings."""
     query = 'name:"Lightning Bolt"'
-    observed_ast = parsing.parse_search_query(query)
+    observed_ast = parsing.parse_query_raw(query)
     expected_ast = BinaryOperatorNode(CardAttributeNode("name", ParserClass.TEXT), ":", StringValueNode("Lightning Bolt"))
     assert observed_ast.root == expected_ast
 
@@ -204,19 +204,19 @@ def test_parse_set_searches() -> None:
     """Test parsing set search queries."""
     # Test full 'set:' syntax
     query = "set:iko"
-    result = parsing.parse_search_query(query)
+    result = parsing.parse_query_raw(query)
     expected = BinaryOperatorNode(CardAttributeNode("set", ParserClass.TEXT), ":", StringValueNode("iko"))
     assert result.root == expected
 
     # Test 's:' shorthand
     query = "s:thb"
-    result = parsing.parse_search_query(query)
+    result = parsing.parse_query_raw(query)
     expected = BinaryOperatorNode(CardAttributeNode("s", ParserClass.TEXT), ":", StringValueNode("thb"))
     assert result.root == expected
 
     # Test case insensitivity
     query = "SET:m21"
-    result = parsing.parse_search_query(query)
+    result = parsing.parse_query_raw(query)
     expected = BinaryOperatorNode(CardAttributeNode("SET", ParserClass.TEXT), ":", StringValueNode("m21"))
     assert result.root == expected
 
@@ -227,7 +227,7 @@ def test_parse_different_operators() -> None:
 
     for op in operators:
         query = f"cmc{op}3"
-        result = parsing.parse_search_query(query)
+        result = parsing.parse_query_raw(query)
         expected = BinaryOperatorNode(CardAttributeNode("cmc", ParserClass.NUMERIC), op, NumericValueNode(3))
         assert result.root == expected
 
@@ -253,7 +253,7 @@ def _generate_pricing_operator_test_cases() -> list[tuple[str, BinaryOperatorNod
 )
 def test_parse_pricing_operators(test_input: str, expected_ast: BinaryOperatorNode) -> None:
     """Test parsing different comparison operators with pricing attributes."""
-    result = parsing.parse_search_query(test_input)
+    result = parsing.parse_query_raw(test_input)
     assert result.root == expected_ast, f"Failed for {test_input}"
 
 
@@ -261,7 +261,7 @@ def test_parse_combined_pricing_queries() -> None:
     """Test parsing combined queries with pricing attributes."""
     # Test combining pricing with other attributes
     query1 = "cmc<=3 usd<5"
-    result1 = parsing.parse_search_query(query1)
+    result1 = parsing.parse_query_raw(query1)
     expected1 = AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("cmc", ParserClass.NUMERIC), "<=", NumericValueNode(3)),
@@ -272,7 +272,7 @@ def test_parse_combined_pricing_queries() -> None:
 
     # Test combining multiple pricing attributes
     query2 = "usd>10 OR eur<5"
-    result2 = parsing.parse_search_query(query2)
+    result2 = parsing.parse_query_raw(query2)
     expected2 = OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("usd", ParserClass.NUMERIC), ">", NumericValueNode(10)),
@@ -288,7 +288,7 @@ def test_parse_combined_pricing_queries() -> None:
 )
 def test_parse_empty_query(query: str | None) -> None:
     """Test that empty/whitespace/None queries produce a TrueNode root."""
-    result = parsing.parse_search_query(query)
+    result = parsing.parse_query_raw(query)
     assert isinstance(result, parsing.Query)
     assert isinstance(result.root, parsing.TrueNode)
 
@@ -297,31 +297,31 @@ def test_name_vs_name_attribute() -> None:
     """Test that we can distinguish between the string 'name' and card names."""
     # This should create a BinaryOperatorNode for "name" (searching for cards with "name" in their name)
     query1 = "name"
-    result1 = parsing.parse_search_query(query1)
+    result1 = parsing.parse_query_raw(query1)
     expected = BinaryOperatorNode(CardAttributeNode("name", ParserClass.TEXT), ":", StringValueNode("name"))
     assert result1.root == expected
 
     # This should create a BinaryOperatorNode for name:value (same as bare word "value")
     query2 = "name:value"
-    result2 = parsing.parse_search_query(query2)
+    result2 = parsing.parse_query_raw(query2)
     expected = BinaryOperatorNode(CardAttributeNode("name", ParserClass.TEXT), ":", StringValueNode("value"))
     assert result2.root == expected
 
     # This should create a BinaryOperatorNode for cmc operations
     query3 = "cmc:3"
-    result3 = parsing.parse_search_query(query3)
+    result3 = parsing.parse_query_raw(query3)
     expected = BinaryOperatorNode(CardAttributeNode("cmc", ParserClass.NUMERIC), ":", NumericValueNode(3))
     assert result3.root == expected
 
     # This should create a BinaryOperatorNode for other attributes
     query4 = "oracle:flying"
-    result4 = parsing.parse_search_query(query4)
+    result4 = parsing.parse_query_raw(query4)
     expected = BinaryOperatorNode(CardAttributeNode("oracle", ParserClass.TEXT), ":", StringValueNode("flying"))
     assert result4.root == expected
 
     # Test flavor text search
     query5 = "flavor:magic"
-    result5 = parsing.parse_search_query(query5)
+    result5 = parsing.parse_query_raw(query5)
     expected = BinaryOperatorNode(CardAttributeNode("flavor", ParserClass.TEXT), ":", StringValueNode("magic"))
     assert result5.root == expected
 
@@ -336,8 +336,8 @@ def test_nary_operator_associativity(operator: str) -> None:
     query1 = f"a {operator} (b {operator} c)"
     query2 = f"(a {operator} b) {operator} c"
 
-    result1 = parsing.parse_search_query(query1)
-    result2 = parsing.parse_search_query(query2)
+    result1 = parsing.parse_query_raw(query1)
+    result2 = parsing.parse_query_raw(query2)
 
     # With n-ary operations, both should now create the same AST structure
     # Both should be: AndNode([a, b, c])
@@ -372,7 +372,7 @@ def test_arithmetic_vs_negation_ambiguity() -> None:
     ]
 
     for query, expected in arithmetic_cases:
-        result = parsing.parse_search_query(query)
+        result = parsing.parse_query_raw(query)
         assert result.root == expected, f"Failed for query: {query}"
 
     # These should be treated as negation (one side is not a known attribute)
@@ -409,7 +409,7 @@ def test_arithmetic_vs_negation_ambiguity() -> None:
     ]
 
     for query, expected in negation_cases:
-        result = parsing.parse_search_query(query)
+        result = parsing.parse_query_raw(query)
         assert result.root == expected, f"Failed for query: {query}"
 
 
@@ -458,7 +458,7 @@ def test_arithmetic_parser_consolidation(query: str, expected_ast: BinaryOperato
     This verifies that after removing redundant rules and consolidating into a single
     unified_numeric_comparison rule, all arithmetic parsing still works correctly.
     """
-    observed = parsing.parse_search_query(query).root
+    observed = parsing.parse_query_raw(query).root
     assert observed == expected_ast, f"Query '{query}' failed\nExpected: {expected_ast}\nObserved: {observed}"
 
 
@@ -547,7 +547,7 @@ def test_standalone_numeric_query_parses() -> None:
 )
 def test_parse_artist_searches(input_query: str, expected_ast: BinaryOperatorNode) -> None:
     """Test parsing artist search queries."""
-    result = parsing.parse_search_query(input_query)
+    result = parsing.parse_query_raw(input_query)
     assert result.root == expected_ast
 
 
@@ -555,7 +555,7 @@ def test_parse_combined_artist_queries() -> None:
     """Test parsing combined queries with artist attributes."""
     # Test combining artist with other attributes
     query1 = "cmc<=3 artist:moeller"
-    result1 = parsing.parse_search_query(query1)
+    result1 = parsing.parse_query_raw(query1)
     expected1 = AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("cmc", ParserClass.NUMERIC), "<=", NumericValueNode(3)),
@@ -566,7 +566,7 @@ def test_parse_combined_artist_queries() -> None:
 
     # Test combining multiple text attributes including artist
     query2 = "name:lightning OR artist:moeller"
-    result2 = parsing.parse_search_query(query2)
+    result2 = parsing.parse_query_raw(query2)
     expected2 = OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("name", ParserClass.TEXT), ":", StringValueNode("lightning")),
@@ -612,7 +612,7 @@ def test_parse_combined_artist_queries() -> None:
 )
 def test_parse_legality_searches(test_input: str, expected_ast: QueryNode) -> None:
     """Test that legality search queries parse to expected AST nodes."""
-    result = parsing.parse_search_query(test_input)
+    result = parsing.parse_query_raw(test_input)
     assert result.root == expected_ast
 
 
@@ -620,7 +620,7 @@ def test_parse_combined_legality_queries() -> None:
     """Test parsing of complex queries combining legality searches."""
     # Test AND combination
     query1 = "format:standard banned:modern"
-    result1 = parsing.parse_search_query(query1)
+    result1 = parsing.parse_query_raw(query1)
     expected1 = AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("format", ParserClass.LEGALITY), ":", StringValueNode("standard")),
@@ -631,7 +631,7 @@ def test_parse_combined_legality_queries() -> None:
 
     # Test OR combination
     query2 = "legal:legacy or restricted:vintage"
-    result2 = parsing.parse_search_query(query2)
+    result2 = parsing.parse_query_raw(query2)
     expected2 = OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("legal", ParserClass.LEGALITY), ":", StringValueNode("legacy")),
@@ -665,7 +665,7 @@ def test_parse_combined_legality_queries() -> None:
 )
 def test_parse_collector_number_searches(test_input: str, expected_ast: BinaryOperatorNode) -> None:
     """Test parsing of collector number searches with various aliases and formats."""
-    observed = parsing.parse_search_query(test_input)
+    observed = parsing.parse_query_raw(test_input)
     assert observed.root == expected_ast
 
 
@@ -673,7 +673,7 @@ def test_parse_combined_collector_number_queries() -> None:
     """Test parsing of complex queries combining collector number searches."""
     # Test AND combination
     query1 = "number:123 set:dom"
-    result1 = parsing.parse_search_query(query1)
+    result1 = parsing.parse_query_raw(query1)
     expected1 = AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("number", ParserClass.NUMERIC), ":", NumericValueNode(123)),
@@ -684,7 +684,7 @@ def test_parse_combined_collector_number_queries() -> None:
 
     # Test OR combination
     query2 = "cn:1 or cn:2"
-    result2 = parsing.parse_search_query(query2)
+    result2 = parsing.parse_query_raw(query2)
     expected2 = OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("cn", ParserClass.NUMERIC), ":", NumericValueNode(1)),
@@ -752,7 +752,7 @@ def test_parse_combined_collector_number_queries() -> None:
 )
 def test_parse_mixed_mana_notation(test_input: str, expected_ast: BinaryOperatorNode) -> None:
     """Test parsing mana cost searches with mixed notation (per Scryfall rules)."""
-    observed = parsing.parse_search_query(test_input)
+    observed = parsing.parse_query_raw(test_input)
     assert observed.root == expected_ast
 
 
@@ -760,7 +760,7 @@ def test_parse_combined_mana_queries() -> None:
     """Test parsing combined queries with mana cost searches."""
     # Test combining mana with other attributes
     query1 = "cmc<=3 mana:{1}{G}"
-    result1 = parsing.parse_search_query(query1)
+    result1 = parsing.parse_query_raw(query1)
     expected1 = parsing.AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("cmc", ParserClass.NUMERIC), "<=", NumericValueNode(3)),
@@ -771,7 +771,7 @@ def test_parse_combined_mana_queries() -> None:
 
     # Test combining multiple mana attributes
     query2 = "mana:{W} OR m:{U}"
-    result2 = parsing.parse_search_query(query2)
+    result2 = parsing.parse_query_raw(query2)
     expected2 = parsing.OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("mana", ParserClass.MANA), ":", parsing.ManaValueNode("{W}")),
@@ -783,7 +783,7 @@ def test_parse_combined_mana_queries() -> None:
 
 def test_parse_quoted_mana_value() -> None:
     """A quoted mana value validates the same as an unquoted one, not an opt-out of that check."""
-    observed = parsing.parse_search_query('mana:"2WW"')
+    observed = parsing.parse_query_raw('mana:"2WW"')
     expected = BinaryOperatorNode(CardAttributeNode("mana", ParserClass.MANA), ":", parsing.ManaValueNode("2WW"))
     assert observed.root == expected
 
@@ -791,20 +791,20 @@ def test_parse_quoted_mana_value() -> None:
 def test_quoted_invalid_mana_symbol_is_rejected() -> None:
     """'mana:"q"' used to skip validation entirely and resolve to an empty cost, matching every card."""
     with pytest.raises(ValueError, match="Failed to parse query"):
-        parsing.parse_search_query('mana:"q"')
+        parsing.parse_query_raw('mana:"q"')
 
 
 def test_mana_cost_with_comparison_operators() -> None:
     """Test that mana cost searches work with different operators."""
     # Test colon operator (most common)
     query1 = "mana:{1}{G}"
-    result1 = parsing.parse_search_query(query1)
+    result1 = parsing.parse_query_raw(query1)
     expected1 = BinaryOperatorNode(CardAttributeNode("mana", ParserClass.MANA), ":", parsing.ManaValueNode("{1}{G}"))
     assert result1.root == expected1
 
     # Test equals operator
     query2 = "m={W}{U}"
-    result2 = parsing.parse_search_query(query2)
+    result2 = parsing.parse_query_raw(query2)
     expected2 = BinaryOperatorNode(CardAttributeNode("m", ParserClass.MANA), "=", parsing.ManaValueNode("{W}{U}"))
     assert result2.root == expected2
 
@@ -820,8 +820,8 @@ def test_mana_cost_with_comparison_operators() -> None:
 )
 def test_mana_symbol_case_insensitivity(lowercase_query: str, uppercase_query: str) -> None:
     """Test that mana symbols like {x} and {X} parse to the same AST."""
-    lowercase_result = parsing.parse_search_query(lowercase_query)
-    uppercase_result = parsing.parse_search_query(uppercase_query)
+    lowercase_result = parsing.parse_query_raw(lowercase_query)
+    uppercase_result = parsing.parse_query_raw(uppercase_query)
 
     # Both should parse to the same AST structure
     assert lowercase_result == uppercase_result, (
@@ -836,25 +836,25 @@ def test_mana_cost_approximate_comparisons() -> None:
     """Test mana cost approximate comparisons with <, <=, >, >= operators."""
     # Test <= operator - use regular parser for AST structure validation
     query1 = "mana<={2}{R}{R}"
-    result1 = parsing.parse_search_query(query1)
+    result1 = parsing.parse_query_raw(query1)
     expected1 = BinaryOperatorNode(CardAttributeNode("mana", ParserClass.MANA), "<=", parsing.ManaValueNode("{2}{R}{R}"))
     assert result1.root == expected1
 
     # Test < operator
     query2 = "m<{1}{G}"
-    result2 = parsing.parse_search_query(query2)
+    result2 = parsing.parse_query_raw(query2)
     expected2 = BinaryOperatorNode(CardAttributeNode("m", ParserClass.MANA), "<", parsing.ManaValueNode("{1}{G}"))
     assert result2.root == expected2
 
     # Test >= operator (parsing test)
     query3 = "mana>={W}{U}"
-    result3 = parsing.parse_search_query(query3)
+    result3 = parsing.parse_query_raw(query3)
     expected3 = BinaryOperatorNode(CardAttributeNode("mana", ParserClass.MANA), ">=", parsing.ManaValueNode("{W}{U}"))
     assert result3.root == expected3
 
     # Test > operator
     query4 = "m>{0}"
-    result4 = parsing.parse_search_query(query4)
+    result4 = parsing.parse_query_raw(query4)
     expected4 = BinaryOperatorNode(CardAttributeNode("m", ParserClass.MANA), ">", parsing.ManaValueNode("{0}"))
     assert result4.root == expected4
 
@@ -1005,7 +1005,7 @@ def test_mana_cost_dict_conversion(mana_cost_str: str, expected_dict: dict) -> N
 )
 def test_parse_devotion_searches(test_input: str, expected_ast: BinaryOperatorNode) -> None:
     """Test parsing devotion searches with various operators."""
-    observed = parsing.parse_search_query(test_input)
+    observed = parsing.parse_query_raw(test_input)
     assert observed.root == expected_ast
 
 
@@ -1088,7 +1088,7 @@ def test_mana_cost_string_format_comparisons(query: str, description: str) -> No
 )
 def test_parse_produces_searches(test_input: str, expected_ast: BinaryOperatorNode) -> None:
     """Test parsing of produces searches for mana production."""
-    observed = parsing.parse_search_query(test_input)
+    observed = parsing.parse_query_raw(test_input)
     assert observed.root == expected_ast
 
 
@@ -1096,7 +1096,7 @@ def test_parse_combined_produces_queries() -> None:
     """Test parsing of complex queries combining produces searches."""
     # Test combining produces with other attributes
     query1 = "produces:g type:land"
-    result1 = parsing.parse_search_query(query1)
+    result1 = parsing.parse_query_raw(query1)
     expected1 = parsing.AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("produces", ParserClass.COLOR), ":", StringValueNode("g")),
@@ -1107,7 +1107,7 @@ def test_parse_combined_produces_queries() -> None:
 
     # Test OR with produces
     query2 = "produces:w OR produces:u"
-    result2 = parsing.parse_search_query(query2)
+    result2 = parsing.parse_query_raw(query2)
     expected2 = parsing.OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("produces", ParserClass.COLOR), ":", StringValueNode("w")),
@@ -1118,7 +1118,7 @@ def test_parse_combined_produces_queries() -> None:
 
     # Test produces with comparison operators
     query3 = "produces=wu"
-    result3 = parsing.parse_search_query(query3)
+    result3 = parsing.parse_query_raw(query3)
     expected3 = BinaryOperatorNode(CardAttributeNode("produces", ParserClass.COLOR), "=", StringValueNode("wu"))
     assert result3.root == expected3
 
@@ -1232,7 +1232,7 @@ def test_parse_hyphenated_words(test_input: str, expected_ast: QueryNode) -> Non
     - Complex hyphenated terms with multiple hyphens
     - Integration with other query features
     """
-    observed = parsing.parse_search_query(test_input).root
+    observed = parsing.parse_query_raw(test_input).root
 
     # Compare the full AST structure
     assert observed == expected_ast, f"\nExpected: {expected_ast}\nObserved: {observed}"
@@ -1256,4 +1256,4 @@ def test_hyphenated_words_edge_cases_fail(invalid_query: str) -> None:
       trailing hyphens since they use string_value_word which accepts any hyphen placement.
     """
     with pytest.raises(ValueError, match="Failed to parse query"):
-        parsing.parse_search_query(invalid_query)
+        parsing.parse_query_raw(invalid_query)

--- a/api/parsing/tests/test_pyparsing_parser.py
+++ b/api/parsing/tests/test_pyparsing_parser.py
@@ -122,7 +122,7 @@ from api.parsing.db_info import ParserClass
 )
 def test_parse_to_nodes(test_input: str, expected_ast: QueryNode) -> None:
     """Test that queries parse into the expected AST structure."""
-    observed = parsing.parse_query_raw(test_input).root
+    observed = parsing.parse_str_to_query(test_input).root
 
     # Compare the full AST structure
     assert observed == expected_ast, f"\nExpected: {expected_ast}\nObserved: {observed}"
@@ -131,7 +131,7 @@ def test_parse_to_nodes(test_input: str, expected_ast: QueryNode) -> None:
 def test_parse_simple_condition() -> None:
     """Test parsing a simple condition."""
     query = "cmc:2"
-    result = parsing.parse_query_raw(query)
+    result = parsing.parse_str_to_query(query)
     expected = BinaryOperatorNode(CardAttributeNode("cmc", ParserClass.NUMERIC), ":", NumericValueNode(2))
     assert result.root == expected
 
@@ -139,7 +139,7 @@ def test_parse_simple_condition() -> None:
 def test_parse_and_operation() -> None:
     """Test parsing AND operations."""
     query = "a AND b"
-    result = parsing.parse_query_raw(query).root
+    result = parsing.parse_str_to_query(query).root
 
     assert result == AndNode(
         [
@@ -152,7 +152,7 @@ def test_parse_and_operation() -> None:
 def test_parse_or_operation() -> None:
     """Test parsing OR operations."""
     query = "a OR b"
-    result = parsing.parse_query_raw(query).root
+    result = parsing.parse_str_to_query(query).root
     assert result == OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("name", ParserClass.TEXT), ":", StringValueNode("a")),
@@ -164,7 +164,7 @@ def test_parse_or_operation() -> None:
 def test_parse_implicit_and() -> None:
     """Test parsing implicit AND operations."""
     query = "a b"
-    result = parsing.parse_query_raw(query).root
+    result = parsing.parse_str_to_query(query).root
     assert result == AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("name", ParserClass.TEXT), ":", StringValueNode("a")),
@@ -176,7 +176,7 @@ def test_parse_implicit_and() -> None:
 def test_parse_complex_nested() -> None:
     """Test parsing complex nested queries."""
     query = "cmc:2 AND (oracle:flying OR oracle:haste)"
-    result = parsing.parse_query_raw(query)
+    result = parsing.parse_str_to_query(query)
 
     assert isinstance(result, parsing.Query)
     assert isinstance(result.root, AndNode)
@@ -186,7 +186,7 @@ def test_parse_complex_nested() -> None:
 
     # Test with flavor text as well
     query2 = "cmc:3 AND (flavor:magic OR oracle:flying)"
-    result2 = parsing.parse_query_raw(query2)
+    result2 = parsing.parse_str_to_query(query2)
     assert isinstance(result2, parsing.Query)
     assert isinstance(result2.root, AndNode)
     assert len(result2.root.operands) == 2
@@ -195,7 +195,7 @@ def test_parse_complex_nested() -> None:
 def test_parse_quoted_strings() -> None:
     """Test parsing quoted strings."""
     query = 'name:"Lightning Bolt"'
-    observed_ast = parsing.parse_query_raw(query)
+    observed_ast = parsing.parse_str_to_query(query)
     expected_ast = BinaryOperatorNode(CardAttributeNode("name", ParserClass.TEXT), ":", StringValueNode("Lightning Bolt"))
     assert observed_ast.root == expected_ast
 
@@ -204,19 +204,19 @@ def test_parse_set_searches() -> None:
     """Test parsing set search queries."""
     # Test full 'set:' syntax
     query = "set:iko"
-    result = parsing.parse_query_raw(query)
+    result = parsing.parse_str_to_query(query)
     expected = BinaryOperatorNode(CardAttributeNode("set", ParserClass.TEXT), ":", StringValueNode("iko"))
     assert result.root == expected
 
     # Test 's:' shorthand
     query = "s:thb"
-    result = parsing.parse_query_raw(query)
+    result = parsing.parse_str_to_query(query)
     expected = BinaryOperatorNode(CardAttributeNode("s", ParserClass.TEXT), ":", StringValueNode("thb"))
     assert result.root == expected
 
     # Test case insensitivity
     query = "SET:m21"
-    result = parsing.parse_query_raw(query)
+    result = parsing.parse_str_to_query(query)
     expected = BinaryOperatorNode(CardAttributeNode("SET", ParserClass.TEXT), ":", StringValueNode("m21"))
     assert result.root == expected
 
@@ -227,7 +227,7 @@ def test_parse_different_operators() -> None:
 
     for op in operators:
         query = f"cmc{op}3"
-        result = parsing.parse_query_raw(query)
+        result = parsing.parse_str_to_query(query)
         expected = BinaryOperatorNode(CardAttributeNode("cmc", ParserClass.NUMERIC), op, NumericValueNode(3))
         assert result.root == expected
 
@@ -253,7 +253,7 @@ def _generate_pricing_operator_test_cases() -> list[tuple[str, BinaryOperatorNod
 )
 def test_parse_pricing_operators(test_input: str, expected_ast: BinaryOperatorNode) -> None:
     """Test parsing different comparison operators with pricing attributes."""
-    result = parsing.parse_query_raw(test_input)
+    result = parsing.parse_str_to_query(test_input)
     assert result.root == expected_ast, f"Failed for {test_input}"
 
 
@@ -261,7 +261,7 @@ def test_parse_combined_pricing_queries() -> None:
     """Test parsing combined queries with pricing attributes."""
     # Test combining pricing with other attributes
     query1 = "cmc<=3 usd<5"
-    result1 = parsing.parse_query_raw(query1)
+    result1 = parsing.parse_str_to_query(query1)
     expected1 = AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("cmc", ParserClass.NUMERIC), "<=", NumericValueNode(3)),
@@ -272,7 +272,7 @@ def test_parse_combined_pricing_queries() -> None:
 
     # Test combining multiple pricing attributes
     query2 = "usd>10 OR eur<5"
-    result2 = parsing.parse_query_raw(query2)
+    result2 = parsing.parse_str_to_query(query2)
     expected2 = OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("usd", ParserClass.NUMERIC), ">", NumericValueNode(10)),
@@ -288,7 +288,7 @@ def test_parse_combined_pricing_queries() -> None:
 )
 def test_parse_empty_query(query: str | None) -> None:
     """Test that empty/whitespace/None queries produce a TrueNode root."""
-    result = parsing.parse_query_raw(query)
+    result = parsing.parse_str_to_query(query)
     assert isinstance(result, parsing.Query)
     assert isinstance(result.root, parsing.TrueNode)
 
@@ -297,31 +297,31 @@ def test_name_vs_name_attribute() -> None:
     """Test that we can distinguish between the string 'name' and card names."""
     # This should create a BinaryOperatorNode for "name" (searching for cards with "name" in their name)
     query1 = "name"
-    result1 = parsing.parse_query_raw(query1)
+    result1 = parsing.parse_str_to_query(query1)
     expected = BinaryOperatorNode(CardAttributeNode("name", ParserClass.TEXT), ":", StringValueNode("name"))
     assert result1.root == expected
 
     # This should create a BinaryOperatorNode for name:value (same as bare word "value")
     query2 = "name:value"
-    result2 = parsing.parse_query_raw(query2)
+    result2 = parsing.parse_str_to_query(query2)
     expected = BinaryOperatorNode(CardAttributeNode("name", ParserClass.TEXT), ":", StringValueNode("value"))
     assert result2.root == expected
 
     # This should create a BinaryOperatorNode for cmc operations
     query3 = "cmc:3"
-    result3 = parsing.parse_query_raw(query3)
+    result3 = parsing.parse_str_to_query(query3)
     expected = BinaryOperatorNode(CardAttributeNode("cmc", ParserClass.NUMERIC), ":", NumericValueNode(3))
     assert result3.root == expected
 
     # This should create a BinaryOperatorNode for other attributes
     query4 = "oracle:flying"
-    result4 = parsing.parse_query_raw(query4)
+    result4 = parsing.parse_str_to_query(query4)
     expected = BinaryOperatorNode(CardAttributeNode("oracle", ParserClass.TEXT), ":", StringValueNode("flying"))
     assert result4.root == expected
 
     # Test flavor text search
     query5 = "flavor:magic"
-    result5 = parsing.parse_query_raw(query5)
+    result5 = parsing.parse_str_to_query(query5)
     expected = BinaryOperatorNode(CardAttributeNode("flavor", ParserClass.TEXT), ":", StringValueNode("magic"))
     assert result5.root == expected
 
@@ -336,8 +336,8 @@ def test_nary_operator_associativity(operator: str) -> None:
     query1 = f"a {operator} (b {operator} c)"
     query2 = f"(a {operator} b) {operator} c"
 
-    result1 = parsing.parse_query_raw(query1)
-    result2 = parsing.parse_query_raw(query2)
+    result1 = parsing.parse_str_to_query(query1)
+    result2 = parsing.parse_str_to_query(query2)
 
     # With n-ary operations, both should now create the same AST structure
     # Both should be: AndNode([a, b, c])
@@ -372,7 +372,7 @@ def test_arithmetic_vs_negation_ambiguity() -> None:
     ]
 
     for query, expected in arithmetic_cases:
-        result = parsing.parse_query_raw(query)
+        result = parsing.parse_str_to_query(query)
         assert result.root == expected, f"Failed for query: {query}"
 
     # These should be treated as negation (one side is not a known attribute)
@@ -409,7 +409,7 @@ def test_arithmetic_vs_negation_ambiguity() -> None:
     ]
 
     for query, expected in negation_cases:
-        result = parsing.parse_query_raw(query)
+        result = parsing.parse_str_to_query(query)
         assert result.root == expected, f"Failed for query: {query}"
 
 
@@ -458,7 +458,7 @@ def test_arithmetic_parser_consolidation(query: str, expected_ast: BinaryOperato
     This verifies that after removing redundant rules and consolidating into a single
     unified_numeric_comparison rule, all arithmetic parsing still works correctly.
     """
-    observed = parsing.parse_query_raw(query).root
+    observed = parsing.parse_str_to_query(query).root
     assert observed == expected_ast, f"Query '{query}' failed\nExpected: {expected_ast}\nObserved: {observed}"
 
 
@@ -547,7 +547,7 @@ def test_standalone_numeric_query_parses() -> None:
 )
 def test_parse_artist_searches(input_query: str, expected_ast: BinaryOperatorNode) -> None:
     """Test parsing artist search queries."""
-    result = parsing.parse_query_raw(input_query)
+    result = parsing.parse_str_to_query(input_query)
     assert result.root == expected_ast
 
 
@@ -555,7 +555,7 @@ def test_parse_combined_artist_queries() -> None:
     """Test parsing combined queries with artist attributes."""
     # Test combining artist with other attributes
     query1 = "cmc<=3 artist:moeller"
-    result1 = parsing.parse_query_raw(query1)
+    result1 = parsing.parse_str_to_query(query1)
     expected1 = AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("cmc", ParserClass.NUMERIC), "<=", NumericValueNode(3)),
@@ -566,7 +566,7 @@ def test_parse_combined_artist_queries() -> None:
 
     # Test combining multiple text attributes including artist
     query2 = "name:lightning OR artist:moeller"
-    result2 = parsing.parse_query_raw(query2)
+    result2 = parsing.parse_str_to_query(query2)
     expected2 = OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("name", ParserClass.TEXT), ":", StringValueNode("lightning")),
@@ -612,7 +612,7 @@ def test_parse_combined_artist_queries() -> None:
 )
 def test_parse_legality_searches(test_input: str, expected_ast: QueryNode) -> None:
     """Test that legality search queries parse to expected AST nodes."""
-    result = parsing.parse_query_raw(test_input)
+    result = parsing.parse_str_to_query(test_input)
     assert result.root == expected_ast
 
 
@@ -620,7 +620,7 @@ def test_parse_combined_legality_queries() -> None:
     """Test parsing of complex queries combining legality searches."""
     # Test AND combination
     query1 = "format:standard banned:modern"
-    result1 = parsing.parse_query_raw(query1)
+    result1 = parsing.parse_str_to_query(query1)
     expected1 = AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("format", ParserClass.LEGALITY), ":", StringValueNode("standard")),
@@ -631,7 +631,7 @@ def test_parse_combined_legality_queries() -> None:
 
     # Test OR combination
     query2 = "legal:legacy or restricted:vintage"
-    result2 = parsing.parse_query_raw(query2)
+    result2 = parsing.parse_str_to_query(query2)
     expected2 = OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("legal", ParserClass.LEGALITY), ":", StringValueNode("legacy")),
@@ -665,7 +665,7 @@ def test_parse_combined_legality_queries() -> None:
 )
 def test_parse_collector_number_searches(test_input: str, expected_ast: BinaryOperatorNode) -> None:
     """Test parsing of collector number searches with various aliases and formats."""
-    observed = parsing.parse_query_raw(test_input)
+    observed = parsing.parse_str_to_query(test_input)
     assert observed.root == expected_ast
 
 
@@ -673,7 +673,7 @@ def test_parse_combined_collector_number_queries() -> None:
     """Test parsing of complex queries combining collector number searches."""
     # Test AND combination
     query1 = "number:123 set:dom"
-    result1 = parsing.parse_query_raw(query1)
+    result1 = parsing.parse_str_to_query(query1)
     expected1 = AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("number", ParserClass.NUMERIC), ":", NumericValueNode(123)),
@@ -684,7 +684,7 @@ def test_parse_combined_collector_number_queries() -> None:
 
     # Test OR combination
     query2 = "cn:1 or cn:2"
-    result2 = parsing.parse_query_raw(query2)
+    result2 = parsing.parse_str_to_query(query2)
     expected2 = OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("cn", ParserClass.NUMERIC), ":", NumericValueNode(1)),
@@ -752,7 +752,7 @@ def test_parse_combined_collector_number_queries() -> None:
 )
 def test_parse_mixed_mana_notation(test_input: str, expected_ast: BinaryOperatorNode) -> None:
     """Test parsing mana cost searches with mixed notation (per Scryfall rules)."""
-    observed = parsing.parse_query_raw(test_input)
+    observed = parsing.parse_str_to_query(test_input)
     assert observed.root == expected_ast
 
 
@@ -760,7 +760,7 @@ def test_parse_combined_mana_queries() -> None:
     """Test parsing combined queries with mana cost searches."""
     # Test combining mana with other attributes
     query1 = "cmc<=3 mana:{1}{G}"
-    result1 = parsing.parse_query_raw(query1)
+    result1 = parsing.parse_str_to_query(query1)
     expected1 = parsing.AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("cmc", ParserClass.NUMERIC), "<=", NumericValueNode(3)),
@@ -771,7 +771,7 @@ def test_parse_combined_mana_queries() -> None:
 
     # Test combining multiple mana attributes
     query2 = "mana:{W} OR m:{U}"
-    result2 = parsing.parse_query_raw(query2)
+    result2 = parsing.parse_str_to_query(query2)
     expected2 = parsing.OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("mana", ParserClass.MANA), ":", parsing.ManaValueNode("{W}")),
@@ -783,7 +783,7 @@ def test_parse_combined_mana_queries() -> None:
 
 def test_parse_quoted_mana_value() -> None:
     """A quoted mana value validates the same as an unquoted one, not an opt-out of that check."""
-    observed = parsing.parse_query_raw('mana:"2WW"')
+    observed = parsing.parse_str_to_query('mana:"2WW"')
     expected = BinaryOperatorNode(CardAttributeNode("mana", ParserClass.MANA), ":", parsing.ManaValueNode("2WW"))
     assert observed.root == expected
 
@@ -791,20 +791,20 @@ def test_parse_quoted_mana_value() -> None:
 def test_quoted_invalid_mana_symbol_is_rejected() -> None:
     """'mana:"q"' used to skip validation entirely and resolve to an empty cost, matching every card."""
     with pytest.raises(ValueError, match="Failed to parse query"):
-        parsing.parse_query_raw('mana:"q"')
+        parsing.parse_str_to_query('mana:"q"')
 
 
 def test_mana_cost_with_comparison_operators() -> None:
     """Test that mana cost searches work with different operators."""
     # Test colon operator (most common)
     query1 = "mana:{1}{G}"
-    result1 = parsing.parse_query_raw(query1)
+    result1 = parsing.parse_str_to_query(query1)
     expected1 = BinaryOperatorNode(CardAttributeNode("mana", ParserClass.MANA), ":", parsing.ManaValueNode("{1}{G}"))
     assert result1.root == expected1
 
     # Test equals operator
     query2 = "m={W}{U}"
-    result2 = parsing.parse_query_raw(query2)
+    result2 = parsing.parse_str_to_query(query2)
     expected2 = BinaryOperatorNode(CardAttributeNode("m", ParserClass.MANA), "=", parsing.ManaValueNode("{W}{U}"))
     assert result2.root == expected2
 
@@ -820,8 +820,8 @@ def test_mana_cost_with_comparison_operators() -> None:
 )
 def test_mana_symbol_case_insensitivity(lowercase_query: str, uppercase_query: str) -> None:
     """Test that mana symbols like {x} and {X} parse to the same AST."""
-    lowercase_result = parsing.parse_query_raw(lowercase_query)
-    uppercase_result = parsing.parse_query_raw(uppercase_query)
+    lowercase_result = parsing.parse_str_to_query(lowercase_query)
+    uppercase_result = parsing.parse_str_to_query(uppercase_query)
 
     # Both should parse to the same AST structure
     assert lowercase_result == uppercase_result, (
@@ -836,25 +836,25 @@ def test_mana_cost_approximate_comparisons() -> None:
     """Test mana cost approximate comparisons with <, <=, >, >= operators."""
     # Test <= operator - use regular parser for AST structure validation
     query1 = "mana<={2}{R}{R}"
-    result1 = parsing.parse_query_raw(query1)
+    result1 = parsing.parse_str_to_query(query1)
     expected1 = BinaryOperatorNode(CardAttributeNode("mana", ParserClass.MANA), "<=", parsing.ManaValueNode("{2}{R}{R}"))
     assert result1.root == expected1
 
     # Test < operator
     query2 = "m<{1}{G}"
-    result2 = parsing.parse_query_raw(query2)
+    result2 = parsing.parse_str_to_query(query2)
     expected2 = BinaryOperatorNode(CardAttributeNode("m", ParserClass.MANA), "<", parsing.ManaValueNode("{1}{G}"))
     assert result2.root == expected2
 
     # Test >= operator (parsing test)
     query3 = "mana>={W}{U}"
-    result3 = parsing.parse_query_raw(query3)
+    result3 = parsing.parse_str_to_query(query3)
     expected3 = BinaryOperatorNode(CardAttributeNode("mana", ParserClass.MANA), ">=", parsing.ManaValueNode("{W}{U}"))
     assert result3.root == expected3
 
     # Test > operator
     query4 = "m>{0}"
-    result4 = parsing.parse_query_raw(query4)
+    result4 = parsing.parse_str_to_query(query4)
     expected4 = BinaryOperatorNode(CardAttributeNode("m", ParserClass.MANA), ">", parsing.ManaValueNode("{0}"))
     assert result4.root == expected4
 
@@ -1005,7 +1005,7 @@ def test_mana_cost_dict_conversion(mana_cost_str: str, expected_dict: dict) -> N
 )
 def test_parse_devotion_searches(test_input: str, expected_ast: BinaryOperatorNode) -> None:
     """Test parsing devotion searches with various operators."""
-    observed = parsing.parse_query_raw(test_input)
+    observed = parsing.parse_str_to_query(test_input)
     assert observed.root == expected_ast
 
 
@@ -1088,7 +1088,7 @@ def test_mana_cost_string_format_comparisons(query: str, description: str) -> No
 )
 def test_parse_produces_searches(test_input: str, expected_ast: BinaryOperatorNode) -> None:
     """Test parsing of produces searches for mana production."""
-    observed = parsing.parse_query_raw(test_input)
+    observed = parsing.parse_str_to_query(test_input)
     assert observed.root == expected_ast
 
 
@@ -1096,7 +1096,7 @@ def test_parse_combined_produces_queries() -> None:
     """Test parsing of complex queries combining produces searches."""
     # Test combining produces with other attributes
     query1 = "produces:g type:land"
-    result1 = parsing.parse_query_raw(query1)
+    result1 = parsing.parse_str_to_query(query1)
     expected1 = parsing.AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("produces", ParserClass.COLOR), ":", StringValueNode("g")),
@@ -1107,7 +1107,7 @@ def test_parse_combined_produces_queries() -> None:
 
     # Test OR with produces
     query2 = "produces:w OR produces:u"
-    result2 = parsing.parse_query_raw(query2)
+    result2 = parsing.parse_str_to_query(query2)
     expected2 = parsing.OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("produces", ParserClass.COLOR), ":", StringValueNode("w")),
@@ -1118,7 +1118,7 @@ def test_parse_combined_produces_queries() -> None:
 
     # Test produces with comparison operators
     query3 = "produces=wu"
-    result3 = parsing.parse_query_raw(query3)
+    result3 = parsing.parse_str_to_query(query3)
     expected3 = BinaryOperatorNode(CardAttributeNode("produces", ParserClass.COLOR), "=", StringValueNode("wu"))
     assert result3.root == expected3
 
@@ -1232,7 +1232,7 @@ def test_parse_hyphenated_words(test_input: str, expected_ast: QueryNode) -> Non
     - Complex hyphenated terms with multiple hyphens
     - Integration with other query features
     """
-    observed = parsing.parse_query_raw(test_input).root
+    observed = parsing.parse_str_to_query(test_input).root
 
     # Compare the full AST structure
     assert observed == expected_ast, f"\nExpected: {expected_ast}\nObserved: {observed}"
@@ -1256,4 +1256,4 @@ def test_hyphenated_words_edge_cases_fail(invalid_query: str) -> None:
       trailing hyphens since they use string_value_word which accepts any hyphen placement.
     """
     with pytest.raises(ValueError, match="Failed to parse query"):
-        parsing.parse_query_raw(invalid_query)
+        parsing.parse_str_to_query(invalid_query)

--- a/api/parsing/tests/test_pyparsing_parser.py
+++ b/api/parsing/tests/test_pyparsing_parser.py
@@ -3,7 +3,6 @@
 import pytest
 
 from api import parsing
-from api.parsing import hand_parser
 from api.parsing import (
     AndNode,
     AttributeNode,
@@ -13,6 +12,7 @@ from api.parsing import (
     QueryContext,
     QueryNode,
     StringValueNode,
+    hand_parser,
 )
 from api.parsing.card_query_nodes import CardAttributeNode, calculate_cmc, mana_cost_str_to_dict
 from api.parsing.card_query_nodes import CardBinaryOperatorNode as BinaryOperatorNode

--- a/api/parsing/tests/test_pyparsing_parser.py
+++ b/api/parsing/tests/test_pyparsing_parser.py
@@ -3,6 +3,7 @@
 import pytest
 
 from api import parsing
+from api.parsing import hand_parser
 from api.parsing import (
     AndNode,
     AttributeNode,
@@ -122,7 +123,7 @@ from api.parsing.db_info import ParserClass
 )
 def test_parse_to_nodes(test_input: str, expected_ast: QueryNode) -> None:
     """Test that queries parse into the expected AST structure."""
-    observed = parsing.parse_str_to_query(test_input).root
+    observed = hand_parser.parse_str_to_query(test_input).root
 
     # Compare the full AST structure
     assert observed == expected_ast, f"\nExpected: {expected_ast}\nObserved: {observed}"
@@ -131,7 +132,7 @@ def test_parse_to_nodes(test_input: str, expected_ast: QueryNode) -> None:
 def test_parse_simple_condition() -> None:
     """Test parsing a simple condition."""
     query = "cmc:2"
-    result = parsing.parse_str_to_query(query)
+    result = hand_parser.parse_str_to_query(query)
     expected = BinaryOperatorNode(CardAttributeNode("cmc", ParserClass.NUMERIC), ":", NumericValueNode(2))
     assert result.root == expected
 
@@ -139,7 +140,7 @@ def test_parse_simple_condition() -> None:
 def test_parse_and_operation() -> None:
     """Test parsing AND operations."""
     query = "a AND b"
-    result = parsing.parse_str_to_query(query).root
+    result = hand_parser.parse_str_to_query(query).root
 
     assert result == AndNode(
         [
@@ -152,7 +153,7 @@ def test_parse_and_operation() -> None:
 def test_parse_or_operation() -> None:
     """Test parsing OR operations."""
     query = "a OR b"
-    result = parsing.parse_str_to_query(query).root
+    result = hand_parser.parse_str_to_query(query).root
     assert result == OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("name", ParserClass.TEXT), ":", StringValueNode("a")),
@@ -164,7 +165,7 @@ def test_parse_or_operation() -> None:
 def test_parse_implicit_and() -> None:
     """Test parsing implicit AND operations."""
     query = "a b"
-    result = parsing.parse_str_to_query(query).root
+    result = hand_parser.parse_str_to_query(query).root
     assert result == AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("name", ParserClass.TEXT), ":", StringValueNode("a")),
@@ -176,7 +177,7 @@ def test_parse_implicit_and() -> None:
 def test_parse_complex_nested() -> None:
     """Test parsing complex nested queries."""
     query = "cmc:2 AND (oracle:flying OR oracle:haste)"
-    result = parsing.parse_str_to_query(query)
+    result = hand_parser.parse_str_to_query(query)
 
     assert isinstance(result, parsing.Query)
     assert isinstance(result.root, AndNode)
@@ -186,7 +187,7 @@ def test_parse_complex_nested() -> None:
 
     # Test with flavor text as well
     query2 = "cmc:3 AND (flavor:magic OR oracle:flying)"
-    result2 = parsing.parse_str_to_query(query2)
+    result2 = hand_parser.parse_str_to_query(query2)
     assert isinstance(result2, parsing.Query)
     assert isinstance(result2.root, AndNode)
     assert len(result2.root.operands) == 2
@@ -195,7 +196,7 @@ def test_parse_complex_nested() -> None:
 def test_parse_quoted_strings() -> None:
     """Test parsing quoted strings."""
     query = 'name:"Lightning Bolt"'
-    observed_ast = parsing.parse_str_to_query(query)
+    observed_ast = hand_parser.parse_str_to_query(query)
     expected_ast = BinaryOperatorNode(CardAttributeNode("name", ParserClass.TEXT), ":", StringValueNode("Lightning Bolt"))
     assert observed_ast.root == expected_ast
 
@@ -204,19 +205,19 @@ def test_parse_set_searches() -> None:
     """Test parsing set search queries."""
     # Test full 'set:' syntax
     query = "set:iko"
-    result = parsing.parse_str_to_query(query)
+    result = hand_parser.parse_str_to_query(query)
     expected = BinaryOperatorNode(CardAttributeNode("set", ParserClass.TEXT), ":", StringValueNode("iko"))
     assert result.root == expected
 
     # Test 's:' shorthand
     query = "s:thb"
-    result = parsing.parse_str_to_query(query)
+    result = hand_parser.parse_str_to_query(query)
     expected = BinaryOperatorNode(CardAttributeNode("s", ParserClass.TEXT), ":", StringValueNode("thb"))
     assert result.root == expected
 
     # Test case insensitivity
     query = "SET:m21"
-    result = parsing.parse_str_to_query(query)
+    result = hand_parser.parse_str_to_query(query)
     expected = BinaryOperatorNode(CardAttributeNode("SET", ParserClass.TEXT), ":", StringValueNode("m21"))
     assert result.root == expected
 
@@ -227,7 +228,7 @@ def test_parse_different_operators() -> None:
 
     for op in operators:
         query = f"cmc{op}3"
-        result = parsing.parse_str_to_query(query)
+        result = hand_parser.parse_str_to_query(query)
         expected = BinaryOperatorNode(CardAttributeNode("cmc", ParserClass.NUMERIC), op, NumericValueNode(3))
         assert result.root == expected
 
@@ -253,7 +254,7 @@ def _generate_pricing_operator_test_cases() -> list[tuple[str, BinaryOperatorNod
 )
 def test_parse_pricing_operators(test_input: str, expected_ast: BinaryOperatorNode) -> None:
     """Test parsing different comparison operators with pricing attributes."""
-    result = parsing.parse_str_to_query(test_input)
+    result = hand_parser.parse_str_to_query(test_input)
     assert result.root == expected_ast, f"Failed for {test_input}"
 
 
@@ -261,7 +262,7 @@ def test_parse_combined_pricing_queries() -> None:
     """Test parsing combined queries with pricing attributes."""
     # Test combining pricing with other attributes
     query1 = "cmc<=3 usd<5"
-    result1 = parsing.parse_str_to_query(query1)
+    result1 = hand_parser.parse_str_to_query(query1)
     expected1 = AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("cmc", ParserClass.NUMERIC), "<=", NumericValueNode(3)),
@@ -272,7 +273,7 @@ def test_parse_combined_pricing_queries() -> None:
 
     # Test combining multiple pricing attributes
     query2 = "usd>10 OR eur<5"
-    result2 = parsing.parse_str_to_query(query2)
+    result2 = hand_parser.parse_str_to_query(query2)
     expected2 = OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("usd", ParserClass.NUMERIC), ">", NumericValueNode(10)),
@@ -288,7 +289,7 @@ def test_parse_combined_pricing_queries() -> None:
 )
 def test_parse_empty_query(query: str | None) -> None:
     """Test that empty/whitespace/None queries produce a TrueNode root."""
-    result = parsing.parse_str_to_query(query)
+    result = hand_parser.parse_str_to_query(query)
     assert isinstance(result, parsing.Query)
     assert isinstance(result.root, parsing.TrueNode)
 
@@ -297,31 +298,31 @@ def test_name_vs_name_attribute() -> None:
     """Test that we can distinguish between the string 'name' and card names."""
     # This should create a BinaryOperatorNode for "name" (searching for cards with "name" in their name)
     query1 = "name"
-    result1 = parsing.parse_str_to_query(query1)
+    result1 = hand_parser.parse_str_to_query(query1)
     expected = BinaryOperatorNode(CardAttributeNode("name", ParserClass.TEXT), ":", StringValueNode("name"))
     assert result1.root == expected
 
     # This should create a BinaryOperatorNode for name:value (same as bare word "value")
     query2 = "name:value"
-    result2 = parsing.parse_str_to_query(query2)
+    result2 = hand_parser.parse_str_to_query(query2)
     expected = BinaryOperatorNode(CardAttributeNode("name", ParserClass.TEXT), ":", StringValueNode("value"))
     assert result2.root == expected
 
     # This should create a BinaryOperatorNode for cmc operations
     query3 = "cmc:3"
-    result3 = parsing.parse_str_to_query(query3)
+    result3 = hand_parser.parse_str_to_query(query3)
     expected = BinaryOperatorNode(CardAttributeNode("cmc", ParserClass.NUMERIC), ":", NumericValueNode(3))
     assert result3.root == expected
 
     # This should create a BinaryOperatorNode for other attributes
     query4 = "oracle:flying"
-    result4 = parsing.parse_str_to_query(query4)
+    result4 = hand_parser.parse_str_to_query(query4)
     expected = BinaryOperatorNode(CardAttributeNode("oracle", ParserClass.TEXT), ":", StringValueNode("flying"))
     assert result4.root == expected
 
     # Test flavor text search
     query5 = "flavor:magic"
-    result5 = parsing.parse_str_to_query(query5)
+    result5 = hand_parser.parse_str_to_query(query5)
     expected = BinaryOperatorNode(CardAttributeNode("flavor", ParserClass.TEXT), ":", StringValueNode("magic"))
     assert result5.root == expected
 
@@ -336,8 +337,8 @@ def test_nary_operator_associativity(operator: str) -> None:
     query1 = f"a {operator} (b {operator} c)"
     query2 = f"(a {operator} b) {operator} c"
 
-    result1 = parsing.parse_str_to_query(query1)
-    result2 = parsing.parse_str_to_query(query2)
+    result1 = hand_parser.parse_str_to_query(query1)
+    result2 = hand_parser.parse_str_to_query(query2)
 
     # With n-ary operations, both should now create the same AST structure
     # Both should be: AndNode([a, b, c])
@@ -372,7 +373,7 @@ def test_arithmetic_vs_negation_ambiguity() -> None:
     ]
 
     for query, expected in arithmetic_cases:
-        result = parsing.parse_str_to_query(query)
+        result = hand_parser.parse_str_to_query(query)
         assert result.root == expected, f"Failed for query: {query}"
 
     # These should be treated as negation (one side is not a known attribute)
@@ -409,7 +410,7 @@ def test_arithmetic_vs_negation_ambiguity() -> None:
     ]
 
     for query, expected in negation_cases:
-        result = parsing.parse_str_to_query(query)
+        result = hand_parser.parse_str_to_query(query)
         assert result.root == expected, f"Failed for query: {query}"
 
 
@@ -458,7 +459,7 @@ def test_arithmetic_parser_consolidation(query: str, expected_ast: BinaryOperato
     This verifies that after removing redundant rules and consolidating into a single
     unified_numeric_comparison rule, all arithmetic parsing still works correctly.
     """
-    observed = parsing.parse_str_to_query(query).root
+    observed = hand_parser.parse_str_to_query(query).root
     assert observed == expected_ast, f"Query '{query}' failed\nExpected: {expected_ast}\nObserved: {observed}"
 
 
@@ -547,7 +548,7 @@ def test_standalone_numeric_query_parses() -> None:
 )
 def test_parse_artist_searches(input_query: str, expected_ast: BinaryOperatorNode) -> None:
     """Test parsing artist search queries."""
-    result = parsing.parse_str_to_query(input_query)
+    result = hand_parser.parse_str_to_query(input_query)
     assert result.root == expected_ast
 
 
@@ -555,7 +556,7 @@ def test_parse_combined_artist_queries() -> None:
     """Test parsing combined queries with artist attributes."""
     # Test combining artist with other attributes
     query1 = "cmc<=3 artist:moeller"
-    result1 = parsing.parse_str_to_query(query1)
+    result1 = hand_parser.parse_str_to_query(query1)
     expected1 = AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("cmc", ParserClass.NUMERIC), "<=", NumericValueNode(3)),
@@ -566,7 +567,7 @@ def test_parse_combined_artist_queries() -> None:
 
     # Test combining multiple text attributes including artist
     query2 = "name:lightning OR artist:moeller"
-    result2 = parsing.parse_str_to_query(query2)
+    result2 = hand_parser.parse_str_to_query(query2)
     expected2 = OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("name", ParserClass.TEXT), ":", StringValueNode("lightning")),
@@ -612,7 +613,7 @@ def test_parse_combined_artist_queries() -> None:
 )
 def test_parse_legality_searches(test_input: str, expected_ast: QueryNode) -> None:
     """Test that legality search queries parse to expected AST nodes."""
-    result = parsing.parse_str_to_query(test_input)
+    result = hand_parser.parse_str_to_query(test_input)
     assert result.root == expected_ast
 
 
@@ -620,7 +621,7 @@ def test_parse_combined_legality_queries() -> None:
     """Test parsing of complex queries combining legality searches."""
     # Test AND combination
     query1 = "format:standard banned:modern"
-    result1 = parsing.parse_str_to_query(query1)
+    result1 = hand_parser.parse_str_to_query(query1)
     expected1 = AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("format", ParserClass.LEGALITY), ":", StringValueNode("standard")),
@@ -631,7 +632,7 @@ def test_parse_combined_legality_queries() -> None:
 
     # Test OR combination
     query2 = "legal:legacy or restricted:vintage"
-    result2 = parsing.parse_str_to_query(query2)
+    result2 = hand_parser.parse_str_to_query(query2)
     expected2 = OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("legal", ParserClass.LEGALITY), ":", StringValueNode("legacy")),
@@ -665,7 +666,7 @@ def test_parse_combined_legality_queries() -> None:
 )
 def test_parse_collector_number_searches(test_input: str, expected_ast: BinaryOperatorNode) -> None:
     """Test parsing of collector number searches with various aliases and formats."""
-    observed = parsing.parse_str_to_query(test_input)
+    observed = hand_parser.parse_str_to_query(test_input)
     assert observed.root == expected_ast
 
 
@@ -673,7 +674,7 @@ def test_parse_combined_collector_number_queries() -> None:
     """Test parsing of complex queries combining collector number searches."""
     # Test AND combination
     query1 = "number:123 set:dom"
-    result1 = parsing.parse_str_to_query(query1)
+    result1 = hand_parser.parse_str_to_query(query1)
     expected1 = AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("number", ParserClass.NUMERIC), ":", NumericValueNode(123)),
@@ -684,7 +685,7 @@ def test_parse_combined_collector_number_queries() -> None:
 
     # Test OR combination
     query2 = "cn:1 or cn:2"
-    result2 = parsing.parse_str_to_query(query2)
+    result2 = hand_parser.parse_str_to_query(query2)
     expected2 = OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("cn", ParserClass.NUMERIC), ":", NumericValueNode(1)),
@@ -752,7 +753,7 @@ def test_parse_combined_collector_number_queries() -> None:
 )
 def test_parse_mixed_mana_notation(test_input: str, expected_ast: BinaryOperatorNode) -> None:
     """Test parsing mana cost searches with mixed notation (per Scryfall rules)."""
-    observed = parsing.parse_str_to_query(test_input)
+    observed = hand_parser.parse_str_to_query(test_input)
     assert observed.root == expected_ast
 
 
@@ -760,7 +761,7 @@ def test_parse_combined_mana_queries() -> None:
     """Test parsing combined queries with mana cost searches."""
     # Test combining mana with other attributes
     query1 = "cmc<=3 mana:{1}{G}"
-    result1 = parsing.parse_str_to_query(query1)
+    result1 = hand_parser.parse_str_to_query(query1)
     expected1 = parsing.AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("cmc", ParserClass.NUMERIC), "<=", NumericValueNode(3)),
@@ -771,7 +772,7 @@ def test_parse_combined_mana_queries() -> None:
 
     # Test combining multiple mana attributes
     query2 = "mana:{W} OR m:{U}"
-    result2 = parsing.parse_str_to_query(query2)
+    result2 = hand_parser.parse_str_to_query(query2)
     expected2 = parsing.OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("mana", ParserClass.MANA), ":", parsing.ManaValueNode("{W}")),
@@ -783,7 +784,7 @@ def test_parse_combined_mana_queries() -> None:
 
 def test_parse_quoted_mana_value() -> None:
     """A quoted mana value validates the same as an unquoted one, not an opt-out of that check."""
-    observed = parsing.parse_str_to_query('mana:"2WW"')
+    observed = hand_parser.parse_str_to_query('mana:"2WW"')
     expected = BinaryOperatorNode(CardAttributeNode("mana", ParserClass.MANA), ":", parsing.ManaValueNode("2WW"))
     assert observed.root == expected
 
@@ -791,20 +792,20 @@ def test_parse_quoted_mana_value() -> None:
 def test_quoted_invalid_mana_symbol_is_rejected() -> None:
     """'mana:"q"' used to skip validation entirely and resolve to an empty cost, matching every card."""
     with pytest.raises(ValueError, match="Failed to parse query"):
-        parsing.parse_str_to_query('mana:"q"')
+        hand_parser.parse_str_to_query('mana:"q"')
 
 
 def test_mana_cost_with_comparison_operators() -> None:
     """Test that mana cost searches work with different operators."""
     # Test colon operator (most common)
     query1 = "mana:{1}{G}"
-    result1 = parsing.parse_str_to_query(query1)
+    result1 = hand_parser.parse_str_to_query(query1)
     expected1 = BinaryOperatorNode(CardAttributeNode("mana", ParserClass.MANA), ":", parsing.ManaValueNode("{1}{G}"))
     assert result1.root == expected1
 
     # Test equals operator
     query2 = "m={W}{U}"
-    result2 = parsing.parse_str_to_query(query2)
+    result2 = hand_parser.parse_str_to_query(query2)
     expected2 = BinaryOperatorNode(CardAttributeNode("m", ParserClass.MANA), "=", parsing.ManaValueNode("{W}{U}"))
     assert result2.root == expected2
 
@@ -820,8 +821,8 @@ def test_mana_cost_with_comparison_operators() -> None:
 )
 def test_mana_symbol_case_insensitivity(lowercase_query: str, uppercase_query: str) -> None:
     """Test that mana symbols like {x} and {X} parse to the same AST."""
-    lowercase_result = parsing.parse_str_to_query(lowercase_query)
-    uppercase_result = parsing.parse_str_to_query(uppercase_query)
+    lowercase_result = hand_parser.parse_str_to_query(lowercase_query)
+    uppercase_result = hand_parser.parse_str_to_query(uppercase_query)
 
     # Both should parse to the same AST structure
     assert lowercase_result == uppercase_result, (
@@ -836,25 +837,25 @@ def test_mana_cost_approximate_comparisons() -> None:
     """Test mana cost approximate comparisons with <, <=, >, >= operators."""
     # Test <= operator - use regular parser for AST structure validation
     query1 = "mana<={2}{R}{R}"
-    result1 = parsing.parse_str_to_query(query1)
+    result1 = hand_parser.parse_str_to_query(query1)
     expected1 = BinaryOperatorNode(CardAttributeNode("mana", ParserClass.MANA), "<=", parsing.ManaValueNode("{2}{R}{R}"))
     assert result1.root == expected1
 
     # Test < operator
     query2 = "m<{1}{G}"
-    result2 = parsing.parse_str_to_query(query2)
+    result2 = hand_parser.parse_str_to_query(query2)
     expected2 = BinaryOperatorNode(CardAttributeNode("m", ParserClass.MANA), "<", parsing.ManaValueNode("{1}{G}"))
     assert result2.root == expected2
 
     # Test >= operator (parsing test)
     query3 = "mana>={W}{U}"
-    result3 = parsing.parse_str_to_query(query3)
+    result3 = hand_parser.parse_str_to_query(query3)
     expected3 = BinaryOperatorNode(CardAttributeNode("mana", ParserClass.MANA), ">=", parsing.ManaValueNode("{W}{U}"))
     assert result3.root == expected3
 
     # Test > operator
     query4 = "m>{0}"
-    result4 = parsing.parse_str_to_query(query4)
+    result4 = hand_parser.parse_str_to_query(query4)
     expected4 = BinaryOperatorNode(CardAttributeNode("m", ParserClass.MANA), ">", parsing.ManaValueNode("{0}"))
     assert result4.root == expected4
 
@@ -1005,7 +1006,7 @@ def test_mana_cost_dict_conversion(mana_cost_str: str, expected_dict: dict) -> N
 )
 def test_parse_devotion_searches(test_input: str, expected_ast: BinaryOperatorNode) -> None:
     """Test parsing devotion searches with various operators."""
-    observed = parsing.parse_str_to_query(test_input)
+    observed = hand_parser.parse_str_to_query(test_input)
     assert observed.root == expected_ast
 
 
@@ -1088,7 +1089,7 @@ def test_mana_cost_string_format_comparisons(query: str, description: str) -> No
 )
 def test_parse_produces_searches(test_input: str, expected_ast: BinaryOperatorNode) -> None:
     """Test parsing of produces searches for mana production."""
-    observed = parsing.parse_str_to_query(test_input)
+    observed = hand_parser.parse_str_to_query(test_input)
     assert observed.root == expected_ast
 
 
@@ -1096,7 +1097,7 @@ def test_parse_combined_produces_queries() -> None:
     """Test parsing of complex queries combining produces searches."""
     # Test combining produces with other attributes
     query1 = "produces:g type:land"
-    result1 = parsing.parse_str_to_query(query1)
+    result1 = hand_parser.parse_str_to_query(query1)
     expected1 = parsing.AndNode(
         [
             BinaryOperatorNode(CardAttributeNode("produces", ParserClass.COLOR), ":", StringValueNode("g")),
@@ -1107,7 +1108,7 @@ def test_parse_combined_produces_queries() -> None:
 
     # Test OR with produces
     query2 = "produces:w OR produces:u"
-    result2 = parsing.parse_str_to_query(query2)
+    result2 = hand_parser.parse_str_to_query(query2)
     expected2 = parsing.OrNode(
         [
             BinaryOperatorNode(CardAttributeNode("produces", ParserClass.COLOR), ":", StringValueNode("w")),
@@ -1118,7 +1119,7 @@ def test_parse_combined_produces_queries() -> None:
 
     # Test produces with comparison operators
     query3 = "produces=wu"
-    result3 = parsing.parse_str_to_query(query3)
+    result3 = hand_parser.parse_str_to_query(query3)
     expected3 = BinaryOperatorNode(CardAttributeNode("produces", ParserClass.COLOR), "=", StringValueNode("wu"))
     assert result3.root == expected3
 
@@ -1232,7 +1233,7 @@ def test_parse_hyphenated_words(test_input: str, expected_ast: QueryNode) -> Non
     - Complex hyphenated terms with multiple hyphens
     - Integration with other query features
     """
-    observed = parsing.parse_str_to_query(test_input).root
+    observed = hand_parser.parse_str_to_query(test_input).root
 
     # Compare the full AST structure
     assert observed == expected_ast, f"\nExpected: {expected_ast}\nObserved: {observed}"
@@ -1256,4 +1257,4 @@ def test_hyphenated_words_edge_cases_fail(invalid_query: str) -> None:
       trailing hyphens since they use string_value_word which accepts any hyphen placement.
     """
     with pytest.raises(ValueError, match="Failed to parse query"):
-        parsing.parse_str_to_query(invalid_query)
+        hand_parser.parse_str_to_query(invalid_query)


### PR DESCRIPTION
## Summary
- Add a flatten+dedupe pass that collapses duplicate AND/OR operands (order-insensitive, alias-aware via structural `==`) and unwraps singleton compounds.
- Introduce `post_parse.finalize_query` as the single AST seam: semantic rewrites → regex static limits → flatten+dedupe.
- Route both the hand parser and pyparsing oracle through that seam; export `parse_query_raw` for tests that need pre-pipeline AST.

## Pipeline order
1. Semantic rewrites (`is:dual`, `not:`, plain-literal regex lowering)
2. Regex complexity checks (duplicate identical regex leaves still count before dedupe)
3. Flatten + dedupe fixpoint

## Test plan
- [x] `make lint`
- [x] `python -m pytest api/parsing/tests/` (2355 passed)
- [x] New cases in `test_dedupe_compounds.py` for nested/order-insensitive duplicates and regex-budget ordering