### PR TITLE
Show mana symbols in all color query explanations

### DIFF
--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -191,6 +191,14 @@ _COLOR_BITS: dict[str, int] = {"W": 16, "U": 8, "B": 4, "R": 2, "G": 1}
 _CANONICAL_COLOR_ORDER = "wubrgc"
 
 
+def _color_codes_to_explanation(color_codes: str, *, name: str | None = None) -> str:
+    """Format color letter codes with {W}-style tokens for the search feedback UI."""
+    tokens = "".join(f"{{{c.upper()}}}" for c in color_codes)
+    if name is None:
+        name = "/".join(COLOR_CODE_TO_NAME[c].capitalize() for c in color_codes)
+    return f"{name} ({tokens})"
+
+
 def _color_dict_to_mask(color_dict: dict[str, bool]) -> int:
     return sum(bit for color, bit in _COLOR_BITS.items() if color_dict.get(color))
 
@@ -694,31 +702,31 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
             if db_column_name in ("card_colors", "card_color_identity"):
                 # A color NAME ('temur', 'azorius', 'blue', 'colorless') spells a letter set
                 # via COLOR_ALIAS_TO_CODES. Single-letter spellings expand the same as bare
-                # letter codes below ('blue' -> 'Blue'); multi-letter names show the letters
-                # alongside the name as {G}{U}{R}-style bracket tokens so the reader isn't left
-                # to memorize which colors a guild/shard/wedge name means (#990). The frontend's
-                # showResults() runs the whole message through convertManaSymbols() after
-                # escaping, which turns exactly these tokens into real mana-font icons -- so
-                # this is the one spot in the string a server response is allowed to steer
-                # frontend HTML, and only ever with this fixed A-Z/digit token vocabulary.
+                # letter codes below ('blue' -> 'Blue ({U})'); multi-letter names show the
+                # letters alongside the name as {G}{U}{R}-style bracket tokens so the reader
+                # isn't left to memorize which colors a guild/shard/wedge name means (#990).
+                # The frontend's showResults() runs the whole message through
+                # convertManaSymbols() after escaping, which turns exactly these tokens into
+                # real mana-font icons -- so this is the one spot in the string a server
+                # response is allowed to steer frontend HTML, and only ever with this fixed
+                # A-Z/digit token vocabulary.
                 alias_codes = COLOR_ALIAS_TO_CODES.get(value.lower())
                 if alias_codes is not None:
                     if len(alias_codes) == 1:
-                        return COLOR_CODE_TO_NAME[alias_codes].capitalize()
-                    tokens = "".join(f"{{{c.upper()}}}" for c in alias_codes)
-                    return f"{value.capitalize()} ({tokens})"
+                        return _color_codes_to_explanation(alias_codes)
+                    return _color_codes_to_explanation(alias_codes, name=value.capitalize())
                 # Try to expand single-letter color codes
                 if len(value) == 1 and value.lower() in COLOR_CODE_TO_NAME:
-                    return COLOR_CODE_TO_NAME[value.lower()].capitalize()
-                # Try to expand multi-letter color codes (e.g., "ug" -> "Blue/Green"), deduped
-                # and in canonical WUBRG(C) order so a repeated/scrambled letter string like
-                # "brgb" reads as "Black/Red/Green" rather than echoing every input letter in
-                # input order ("Black/Red/Green/Black").
+                    return _color_codes_to_explanation(value.lower())
+                # Try to expand multi-letter color codes (e.g., "ug" -> "Blue/Green ({U}{G})"),
+                # deduped and in canonical WUBRG(C) order so a repeated/scrambled letter string
+                # like "brgb" reads as "Black/Red/Green ({B}{R}{G})" rather than echoing every
+                # input letter in input order ("Black/Red/Green/Black").
                 max_colors = 5
                 if len(value) <= max_colors and all(c.lower() in COLOR_CODE_TO_NAME for c in value):
                     present = {c.lower() for c in value}
-                    color_names = [COLOR_CODE_TO_NAME[c].capitalize() for c in _CANONICAL_COLOR_ORDER if c in present]
-                    return "/".join(color_names)
+                    color_codes = "".join(c for c in _CANONICAL_COLOR_ORDER if c in present)
+                    return _color_codes_to_explanation(color_codes)
 
             # If context is a format-related attribute, try to expand format codes
             if db_column_name == "card_legalities" and value.lower() in FORMAT_CODE_TO_NAME:

--- a/api/parsing/tests/test_explanation.py
+++ b/api/parsing/tests/test_explanation.py
@@ -12,9 +12,9 @@ import pytest
         ("cmc=3", "the mana value is 3"),
         ("mv=3", "the mana value is 3"),
         # Color identity
-        ("id=g", "the color identity is Green"),
-        ("id=u", "the color identity is Blue"),
-        ("id=ug", "the color identity is Blue/Green"),
+        ("id=g", "the color identity is Green ({G})"),
+        ("id=u", "the color identity is Blue ({U})"),
+        ("id=ug", "the color identity is Blue/Green ({U}{G})"),
         # Format
         ("f=m", "it's legal in Modern"),
         ("f=s", "it's legal in Standard"),
@@ -31,14 +31,14 @@ import pytest
         # Complex query from the issue - with parens around each AND group
         (
             "(power>3 or toughness>3) and id=g f=m",
-            "(the power > 3 or the toughness > 3) and the color identity is Green and it's legal in Modern",
+            "(the power > 3 or the toughness > 3) and the color identity is Green ({G}) and it's legal in Modern",
         ),
         # Another complex query
-        ("power>3 and (id=g or id=u)", "the power > 3 and (the color identity is Green or the color identity is Blue)"),
+        ("power>3 and (id=g or id=u)", "the power > 3 and (the color identity is Green ({G}) or the color identity is Blue ({U}))"),
         # Complex OR with AND groups - matches ((...) or (...)) pattern
         (
             "(id=g and t:bird) or (id=r and t:goblin)",
-            "((the color identity is Green and the type contains bird) or (the color identity is Red and the type contains goblin))",
+            "((the color identity is Green ({G}) and the type contains bird) or (the color identity is Red ({R}) and the type contains goblin))",
         ),
         # NOT queries
         ("-power>3", "not (the power > 3)"),
@@ -50,8 +50,8 @@ import pytest
         ("toughness<=2", "the toughness ≤ 2"),
         ("power!=3", "the power is not 3"),
         # Color codes
-        ("c=w", "the color is White"),
-        ("c=b", "the color is Black"),
+        ("c=w", "the color is White ({W})"),
+        ("c=b", "the color is Black ({B})"),
         # Sets
         ("set:war", "the set contains war"),
         # Artist
@@ -198,17 +198,19 @@ def test_explain_color_combinations(parse_query) -> None:
     argnames=["query_str", "expected_explanation"],
     argvalues=[
         # Repeated/scrambled letters dedupe and land in canonical WUBRG order, not input order.
-        ("c=brgb", "the color is Black/Red/Green"),
-        ("id=brgb", "the color identity is Black/Red/Green"),
-        ("c=gwbur", "the color is White/Blue/Black/Red/Green"),
+        ("c=brgb", "the color is Black/Red/Green ({B}{R}{G})"),
+        ("id=brgb", "the color identity is Black/Red/Green ({B}{R}{G})"),
+        ("id=rug", "the color identity is Blue/Red/Green ({U}{R}{G})"),
+        ("c=gwbur", "the color is White/Blue/Black/Red/Green ({W}{U}{B}{R}{G})"),
         # Guild/shard/wedge names show the letters they spell alongside the name, as
         # {G}{U}{R}-style bracket tokens the frontend renders into mana-font icons (#990).
         ("c=temur", "the color is Temur ({G}{U}{R})"),
         ("id=temur", "the color identity is Temur ({G}{U}{R})"),
         ("c=azorius", "the color is Azorius ({W}{U})"),
         # Single-color names expand the same as bare letter codes.
-        ("c=blue", "the color is Blue"),
-        ("c=colorless", "the color is Colorless"),
+        ("c=blue", "the color is Blue ({U})"),
+        ("c=colorless", "the color is Colorless ({C})"),
+        ("id=green", "the color identity is Green ({G})"),
     ],
 )
 def test_explain_color_dedup_and_names(parse_query, query_str: str, expected_explanation: str) -> None:


### PR DESCRIPTION
## Summary
- Extend search feedback so letter codes (`id=g`, `id=rug`), color names (`id=green`), and guild/shard/wedge aliases (`id=temur`) all include `{W}`-style mana tokens in parentheses.
- Add `_color_codes_to_explanation()` to centralize the formatting; the frontend already renders these tokens as mana-font icons via `convertManaSymbols()`.

## Test plan
- [x] `python -m pytest api/parsing/tests/test_explanation.py`
- [x] `python -m ruff check`
- [ ] Search `id=g`, `id=rug`, and `id=temur` in the UI and confirm feedback shows mana icons for all three