### PR TITLE
Remove Redundant Pre-Flatten Pass In flatten_and_deduplicate_compounds

### DIFF
--- a/api/parsing/rewrite.py
+++ b/api/parsing/rewrite.py
@@ -399,9 +399,13 @@ def flatten_and_deduplicate_compounds(query: Query) -> Query:
     """Flatten nested AND/OR chains, drop duplicate operands, unwrap singleton compounds.
 
     A single bottom-up pass merges same-type children, dedupes with order-insensitive keys
-    (``AND(cmc<2, c=w)`` equals ``AND(c=w, cmc<2)`` under a shared OR), then unwraps.
+    (``AND(cmc<2, c=w)`` equals ``AND(c=w, cmc<2)`` under a shared OR), then unwraps. No separate
+    pre-flatten is needed: ``_normalize_compound_operands`` already merges a same-type child into
+    its parent's operand list as part of its own bottom-up walk (the ``isinstance(normalized, cls)``
+    branch below), which is exactly what ``flatten_nested_operations`` does -- so calling it first
+    would just flatten the same chains twice, rebuilding every node with nothing left to change.
     """
-    root, changed = _normalize_compound_operands(flatten_nested_operations(query.root))
+    root, changed = _normalize_compound_operands(query.root)
     if not changed:
         return query
     return Query(root)


### PR DESCRIPTION
## Summary
`flatten_and_deduplicate_compounds` called `flatten_nested_operations(query.root)` before `_normalize_compound_operands`, on every single search request. But `_normalize_compound_operands`'s own bottom-up walk already merges a same-type child into its parent's operand list (the `isinstance(normalized, cls)` branch) -- exactly what `flatten_nested_operations` does -- so the pre-call rebuilt the whole tree a second time with nothing left to change by the time the real dedup pass ran.

Both parsers (`hand_parser.parse_str_to_query`, the legacy `pyparsing_based`) already return canonically flattened output, and the two rewrite passes that can introduce non-flat nesting (`negate_not_prefix`, `expand_derived_predicates`) already re-flatten themselves conditionally, only when they actually changed something. `flatten_and_deduplicate_compounds` was the one place still doing the flatten unconditionally.

## Measurement
Paired microbenchmark (same process, same build, alternating order) over 4,000 parsed+rewritten queries from a realistic traffic mix (`client.query_sampler.QuerySampler(mode="realistic")`), timing just the flatten/dedupe step:

| | median/query |
|---|---|
| old (pre-flatten + normalize) | 0.850us |
| new (normalize only) | 0.601us |

~1.4x on this specific step. This runs on every search request regardless of backend (engine or SQL), but the absolute per-request saving (~0.25us) is small in isolation -- the value here is mostly removing genuinely dead work, not moving end-to-end p50/p90/p99.

## Test plan
- [x] `pytest api/parsing/tests/` (2361 passed)
- [x] `pytest` full non-Docker suite (3370 passed)
- [x] `ruff check` / `ruff format --check`