### PR TITLE
Rust Perf Audit: Five Measured Fixes In Card Engine And Shared Cache

### DIFF
--- a/card_engine/src/bench_card_ids_dispatch.rs
+++ b/card_engine/src/bench_card_ids_dispatch.rs
@@ -1,0 +1,86 @@
+//! Micro-benchmark for perf-audit finding #1: `PreparedCandidates::card_ids` returned
+//! `Box<dyn ExactSizeIterator<Item = u32>>`, so every `.next()` in P3's and P4's per-card match
+//! loops (`run_query_streamed`, `exec_gathered_scan` — up to `n_cards` iterations each) went
+//! through a vtable instead of a monomorphized call the compiler can inline.
+//!
+//! `bench_iter_dispatch.rs` measured the same class of overhead for `run_query`'s card_ids
+//! before the `PreparedCandidates` split; that call site has since moved (this module targets
+//! the current one) and its benchmark needs a corpus store this repo doesn't ship, so this one
+//! is self-contained — synthetic ids, no archive.
+//!
+//! **First attempt at this benchmark was wrong.** Constructing the `Box<dyn ...>` and consuming
+//! it in the same closure let LLVM see straight through the allocation and devirtualize both
+//! arms identically -- the "boxed" arm came back tied with, and sometimes faster than, the
+//! concrete one, which is not physically possible (the boxed arm does strictly more work: a heap
+//! allocation plus indirect calls). In production the box crosses a real function boundary
+//! (`prep.card_ids(ctx)` is built in one function, `run_query_streamed`/`exec_gathered_scan`
+//! consume it in another, neither trivially inlined into the other), so this version forces the
+//! same shape with `#[inline(never)]` consumer functions that take the iterator as an opaque
+//! parameter, matching bench_iter_dispatch's cross-function pattern.
+//!
+//! Two shapes, matching the two arms of `CardIdIter`: a narrowed `List` (the common case once a
+//! query narrows) and a full-corpus `Range` (the `None` narrowing arm).
+//!
+//!     cargo test --release bench_card_ids_dispatch -- --ignored --nocapture
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use super::CardIdIter;
+
+const ITERS: usize = 300;
+const N: u32 = 31_508; // production corpus card count, per other bench modules' comments
+
+#[inline(never)]
+fn consume_boxed(it: Box<dyn ExactSizeIterator<Item = u32> + '_>) -> u64 {
+    let mut acc = 0u64;
+    for cid in it {
+        acc = acc.wrapping_add(u64::from(black_box(cid)));
+    }
+    acc
+}
+
+#[inline(never)]
+fn consume_concrete(it: CardIdIter<'_>) -> u64 {
+    let mut acc = 0u64;
+    for cid in it {
+        acc = acc.wrapping_add(u64::from(black_box(cid)));
+    }
+    acc
+}
+
+fn time_ns(mut kernel: impl FnMut() -> u64) -> f64 {
+    let mut best = u128::MAX;
+    let mut out = 0;
+    for _ in 0..ITERS {
+        let t0 = Instant::now();
+        out = black_box(kernel());
+        best = best.min(t0.elapsed().as_nanos());
+    }
+    black_box(out);
+    best as f64
+}
+
+#[test]
+#[ignore]
+fn bench_card_ids_dispatch() {
+    let ids: Vec<u32> = (0..N).collect();
+
+    // ─── List shape (narrowed candidates) ───
+    let boxed_list = time_ns(|| consume_boxed(Box::new(black_box(ids.iter().copied()))));
+    let concrete_list = time_ns(|| consume_concrete(CardIdIter::List(black_box(ids.iter().copied()))));
+    println!(
+        "List   (narrowed):   boxed={boxed_list:>9.0} ns   concrete={concrete_list:>9.0} ns   ratio={:.2}x   overhead={:.3} ns/card",
+        boxed_list / concrete_list,
+        (boxed_list - concrete_list) / f64::from(N),
+    );
+
+    // ─── Range shape (unnarrowed: every card) ───
+    let boxed_range = time_ns(|| consume_boxed(Box::new(black_box(0..N))));
+    let concrete_range = time_ns(|| consume_concrete(CardIdIter::Range(black_box(0..N))));
+    println!(
+        "Range  (unnarrowed): boxed={boxed_range:>9.0} ns   concrete={concrete_range:>9.0} ns   ratio={:.2}x   overhead={:.3} ns/card",
+        boxed_range / concrete_range,
+        (boxed_range - concrete_range) / f64::from(N),
+    );
+}

--- a/card_engine/src/bench_match_layout.rs
+++ b/card_engine/src/bench_match_layout.rs
@@ -1,0 +1,109 @@
+//! Scoping probe for perf-audit finding #5, which shipped as a follow-up commit: `Match` used to
+//! be `(u128, u32, u32)`, padded to 32 bytes (u128's 16-byte alignment), even though `page_cmp`
+//! only ever read the top 64 bits of the key -- the low 32 (`sc`/prefer_score) were computed and
+//! stored but never read by any comparator (verified two ways before removing it: a static trace
+//! of every `Match` consumer, all of which go through `page_cmp`; then, because that trace turned
+//! out to have a wrinkle worth not trusting blindly -- a test helper's doc comment claimed a full
+//! 3-key comparison was "the exact comparator select_page uses" -- an empirical check: zeroing
+//! the third key and running the full 160-test suite, which passed unchanged). `sort_key_bits`
+//! now returns `u64` and `Match` is `(u64, u32, u32)`, 16 bytes with no padding.
+//!
+//! This measures whether that size halving actually moves the two operations
+//! `select_page`/`prune_to_smallest` perform on `Vec<Match>` (`select_nth_unstable_by`,
+//! `sort_unstable_by`) at the sizes they really run at -- run BEFORE the fix landed, against a
+//! synthetic wide/narrow pair standing in for the old and new layouts, to decide whether the
+//! fix was worth the risk in the first place; kept as a regression check.
+//!
+//!     cargo test --release bench_match_layout -- --ignored --nocapture
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng};
+
+const ITERS: usize = 200;
+// GATHER_PRUNE_CHUNK is 4096; a page-plus-chunk buffer at a typical page size is in this range.
+const N: usize = 4096 + 175;
+const K: usize = 175; // typical page size (limit), per other bench modules' comments
+
+fn gen_wide(n: usize, seed: u64) -> Vec<(u128, u32, u32)> {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    (0..n as u32).map(|i| (u128::from(rng.random::<u64>()), i / 8, i)).collect()
+}
+
+fn gen_narrow(wide: &[(u128, u32, u32)]) -> Vec<(u64, u32, u32)> {
+    // Same (key, cid, pid) content, key truncated to the top 64 bits -- exactly what
+    // sort_key_bits would produce directly instead of packing into a u128.
+    wide.iter().map(|&(k, c, p)| ((k >> 64) as u64, c, p)).collect()
+}
+
+fn wide_cmp(a: &(u128, u32, u32), b: &(u128, u32, u32)) -> std::cmp::Ordering {
+    (a.0 >> 64).cmp(&(b.0 >> 64)).then_with(|| a.1.cmp(&b.1)).then_with(|| a.2.cmp(&b.2))
+}
+
+fn narrow_cmp(a: &(u64, u32, u32), b: &(u64, u32, u32)) -> std::cmp::Ordering {
+    a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)).then_with(|| a.2.cmp(&b.2))
+}
+
+fn time_ns(mut kernel: impl FnMut() -> usize) -> f64 {
+    let mut best = u128::MAX;
+    let mut out = 0;
+    for _ in 0..ITERS {
+        let t0 = Instant::now();
+        out = black_box(kernel());
+        best = best.min(t0.elapsed().as_nanos());
+    }
+    black_box(out);
+    best as f64
+}
+
+#[test]
+#[ignore]
+fn bench_match_layout() {
+    println!(
+        "sizes: wide (u128,u32,u32) = {} B, narrow (u64,u32,u32) = {} B",
+        std::mem::size_of::<(u128, u32, u32)>(),
+        std::mem::size_of::<(u64, u32, u32)>(),
+    );
+
+    // Base data generated ONCE; each timed iteration clones it (the per-iteration cost a real
+    // caller would also pay in some form — moving/copying elements — so it's fair to both
+    // arms, and reflects the size difference the same way production swaps/memmoves would).
+    let base_wide_n = gen_wide(N, 1);
+    let base_narrow_n = gen_narrow(&base_wide_n);
+    let base_wide_k = gen_wide(K, 2);
+    let base_narrow_k = gen_narrow(&base_wide_k);
+
+    // select_nth_unstable_by, as prune_to_smallest / select_page's first quickselect does.
+    let wide_select = time_ns(|| {
+        let mut v = base_wide_n.clone();
+        v.select_nth_unstable_by(K, wide_cmp);
+        v.len()
+    });
+    let narrow_select = time_ns(|| {
+        let mut v = base_narrow_n.clone();
+        v.select_nth_unstable_by(K, narrow_cmp);
+        v.len()
+    });
+    println!(
+        "select_nth_unstable_by(k={K}, n={N}): wide={wide_select:.0} ns   narrow={narrow_select:.0} ns   ratio={:.2}x",
+        wide_select / narrow_select
+    );
+
+    // sort_unstable_by over the page slice, as select_page's final sort does.
+    let wide_sort = time_ns(|| {
+        let mut v = base_wide_k.clone();
+        v.sort_unstable_by(wide_cmp);
+        v.len()
+    });
+    let narrow_sort = time_ns(|| {
+        let mut v = base_narrow_k.clone();
+        v.sort_unstable_by(narrow_cmp);
+        v.len()
+    });
+    println!(
+        "sort_unstable_by(n={K}):               wide={wide_sort:.0} ns   narrow={narrow_sort:.0} ns   ratio={:.2}x",
+        wide_sort / narrow_sort
+    );
+}

--- a/card_engine/src/legality.rs
+++ b/card_engine/src/legality.rs
@@ -4,7 +4,8 @@
 // card's JSONB omits reads as not_legal. 32 formats fit; Scryfall ships 22.
 
 use std::collections::HashMap;
-use std::sync::{OnceLock, RwLock};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock, RwLock};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use rkyv::Archived;
@@ -17,8 +18,43 @@ pub(crate) const MAX_FORMATS: usize = 32;
 
 static FORMAT_SHIFTS: OnceLock<RwLock<HashMap<String, u8>>> = OnceLock::new();
 
+/// Mirrors `format_shifts().len()`, updated under the same write lock that grows the map.
+/// Lets `format_shifts_sorted()` detect staleness without taking a lock on the map itself.
+static FORMAT_COUNT: AtomicUsize = AtomicUsize::new(0);
+
 pub(crate) fn format_shifts() -> &'static RwLock<HashMap<String, u8>> {
     FORMAT_SHIFTS.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// Alphabetically sorted `(format, shift)` snapshot of the registry, rebuilt only when
+/// `FORMAT_COUNT` has moved since the last build. The registry is append-only (new formats
+/// get the next free shift; existing ones never change), so a stale-but-shorter snapshot is
+/// simply missing the newest formats, never wrong about the ones it has -- safe to keep
+/// serving while a concurrent rebuild is in flight.
+type SortedFormats = Arc<[(String, u8)]>;
+
+fn format_shifts_sorted() -> SortedFormats {
+    static SORTED: OnceLock<RwLock<(usize, SortedFormats)>> = OnceLock::new();
+    let cache = SORTED.get_or_init(|| RwLock::new((0, Arc::from([] as [(String, u8); 0]))));
+    let current = FORMAT_COUNT.load(Ordering::Acquire);
+
+    if let Ok(guard) = cache.read()
+        && guard.0 == current
+    {
+        return guard.1.clone();
+    }
+    let Ok(mut guard) = cache.write() else { return Arc::from([]) };
+    if guard.0 == current {
+        return guard.1.clone(); // rebuilt by another thread while we waited for the write lock
+    }
+    let mut entries: Vec<(String, u8)> = format_shifts()
+        .read()
+        .map(|m| m.iter().map(|(k, v)| (k.clone(), *v)).collect())
+        .unwrap_or_default();
+    entries.sort();
+    let built: Arc<[(String, u8)]> = Arc::from(entries);
+    *guard = (current, built.clone());
+    built
 }
 
 /// Bit shift for a format already seen in loaded data; None matches nothing.
@@ -40,6 +76,7 @@ pub(crate) fn format_shift_or_assign(format: &str) -> Option<u8> {
     }
     let shift = (shifts.len() * 2) as u8;
     shifts.insert(format.to_string(), shift);
+    FORMAT_COUNT.store(shifts.len(), Ordering::Release);
     Some(shift)
 }
 
@@ -77,18 +114,14 @@ pub(crate) fn jsonb_obj_to_legality_bits(d: &Bound<PyDict>, key: &str) -> u64 {
 /// as "not_legal", exactly as the encoder treated it.
 pub(crate) fn legality_bits_to_pydict<'a>(py: Python<'a>, bits: u64) -> PyResult<pyo3::Bound<'a, PyDict>> {
     let dict = PyDict::new(py);
-    if let Ok(shifts) = format_shifts().read() {
-        let mut entries: Vec<(String, u8)> = shifts.iter().map(|(k, v)| (k.clone(), *v)).collect();
-        entries.sort();
-        for (format, shift) in entries {
-            let word = match (bits >> shift) & 0b11 {
-                LEGALITY_LEGAL => "legal",
-                LEGALITY_RESTRICTED => "restricted",
-                LEGALITY_BANNED => "banned",
-                _ => "not_legal",
-            };
-            dict.set_item(format, word)?;
-        }
+    for (format, shift) in format_shifts_sorted().iter() {
+        let word = match (bits >> shift) & 0b11 {
+            LEGALITY_LEGAL => "legal",
+            LEGALITY_RESTRICTED => "restricted",
+            LEGALITY_BANNED => "banned",
+            _ => "not_legal",
+        };
+        dict.set_item(format.as_str(), word)?;
     }
     Ok(dict)
 }
@@ -104,5 +137,74 @@ pub(crate) fn sync_format_shifts(archived: &Archived<HashMap<String, u8>>) {
         for (format, shift) in archived.iter() {
             shifts.insert(format.as_str().to_string(), *shift);
         }
+        FORMAT_COUNT.store(shifts.len(), Ordering::Release);
+    }
+}
+
+/// Perf-audit finding #4: `legality_bits_to_pydict` used to clone the whole format registry
+/// into a fresh `Vec` and sort it on every call -- once per output row whenever `legalities`
+/// is requested. Compares that against the cached, pre-sorted `Arc<[(String, u8)]>` snapshot
+/// `format_shifts_sorted()` now serves, over a registry sized like the real one (22 formats,
+/// per this module's header comment).
+///
+///     cargo test --release bench_legality_dict_cost -- --ignored --nocapture
+#[cfg(test)]
+mod bench_legality_dict_cost {
+    use std::hint::black_box;
+    use std::time::Instant;
+
+    use super::{format_shift_or_assign, format_shifts, format_shifts_sorted};
+
+    const ITERS: usize = 200_000;
+    const FORMATS: &[&str] = &[
+        "standard", "pioneer", "modern", "legacy", "pauper", "vintage", "penny", "commander",
+        "oathbreaker", "standardbrawl", "brawl", "alchemy", "paupercommander", "duel", "oldschool",
+        "premodern", "predh", "historic", "timeless", "gladiator", "explorer", "future",
+    ];
+
+    fn seed_registry() {
+        for f in FORMATS {
+            format_shift_or_assign(f);
+        }
+        assert_eq!(format_shifts().read().unwrap().len(), FORMATS.len());
+    }
+
+    #[test]
+    #[ignore]
+    fn bench_legality_dict_cost() {
+        seed_registry();
+        let bits: u64 = 0x5555_5555; // arbitrary — content doesn't affect either path's cost
+
+        // Pre-fix behavior: clone every (String, u8) entry out of the map into a fresh Vec, sort it.
+        let start = Instant::now();
+        for _ in 0..ITERS {
+            let shifts = format_shifts().read().unwrap();
+            let mut entries: Vec<(String, u8)> = shifts.iter().map(|(k, v)| (k.clone(), *v)).collect();
+            entries.sort();
+            black_box(&entries);
+            for (_, shift) in &entries {
+                black_box((black_box(bits) >> shift) & 0b11);
+            }
+        }
+        let clone_sort_ns = start.elapsed().as_nanos() as f64 / ITERS as f64;
+
+        // Fixed: reuse the cached, pre-sorted Arc snapshot.
+        let start = Instant::now();
+        for _ in 0..ITERS {
+            let entries = format_shifts_sorted();
+            black_box(&entries);
+            for (_, shift) in entries.iter() {
+                black_box((black_box(bits) >> shift) & 0b11);
+            }
+        }
+        let cached_ns = start.elapsed().as_nanos() as f64 / ITERS as f64;
+
+        println!("clone+sort per row (pre-fix): {clone_sort_ns:.1} ns/call");
+        println!("cached Arc snapshot (fixed):  {cached_ns:.1} ns/call");
+        println!(
+            "delta: {:.1} ns/call ({:.0}% reduction)",
+            clone_sort_ns - cached_ns,
+            100.0 * (clone_sort_ns - cached_ns) / clone_sort_ns
+        );
     }
 }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -8316,19 +8316,54 @@ struct PreparedCandidates {
     proven_conjuncts: u64,
 }
 
+/// The two shapes `PreparedCandidates::card_ids` can hand back: the narrowed list, or every
+/// card in the corpus. A concrete enum rather than `Box<dyn ExactSizeIterator<...>>` so P3's
+/// and P4's per-card loops — both hot, up to `n_cards` iterations — call a monomorphized
+/// `next()` the compiler can inline instead of going through a vtable on every card.
+enum CardIdIter<'s> {
+    List(std::iter::Copied<std::slice::Iter<'s, u32>>),
+    Range(std::ops::Range<u32>),
+}
+
+impl Iterator for CardIdIter<'_> {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<u32> {
+        match self {
+            CardIdIter::List(it) => it.next(),
+            CardIdIter::Range(it) => it.next(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            CardIdIter::List(it) => it.size_hint(),
+            CardIdIter::Range(it) => it.size_hint(),
+        }
+    }
+}
+
+impl ExactSizeIterator for CardIdIter<'_> {
+    fn len(&self) -> usize {
+        match self {
+            CardIdIter::List(it) => it.len(),
+            CardIdIter::Range(it) => it.len(),
+        }
+    }
+}
+
 impl PreparedCandidates {
     /// The card ids to visit: the narrowed list if one was materialized, else
-    /// every card. Boxed because the two arms are different iterator types and
-    /// both P3 and P4 want the same either-or — previously spelled out
+    /// every card. Both P3 and P4 want the same either-or — previously spelled out
     /// identically at the head of each.
     ///
     /// `ExactSizeIterator` rather than `Iterator`: both arms know their length (a `Vec` and a `Range`),
     /// so an executor that wants the candidate count before its loop can ask for it instead of being
     /// handed the count alongside the iterator and trusting the two to agree.
-    fn card_ids<'s>(&'s self, ctx: &QueryCtx) -> Box<dyn ExactSizeIterator<Item = u32> + 's> {
+    fn card_ids<'s>(&'s self, ctx: &QueryCtx) -> CardIdIter<'s> {
         match &self.candidate_cards {
-            Some(v) => Box::new(v.iter().copied()),
-            None => Box::new(0..ctx.n_cards()),
+            Some(v) => CardIdIter::List(v.iter().copied()),
+            None => CardIdIter::Range(0..ctx.n_cards()),
         }
     }
 }
@@ -11480,7 +11515,7 @@ fn run_query_streamed<'a>(
     // whole residual is settled, this says which parts of it are.
     proven_conjuncts: u64,
     walk: &[Archived<u32>],
-    card_ids: Box<dyn ExactSizeIterator<Item = u32> + '_>,
+    card_ids: CardIdIter<'_>,
     existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     // First of the three phase boundaries — everything down to the match loop is `ns_setup`, which
@@ -12931,3 +12966,5 @@ mod bench_streamed_loop;
 mod bench_membership_check;
 #[cfg(test)]
 mod bench_expand_materialize;
+#[cfg(test)]
+mod bench_card_ids_dispatch;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5519,12 +5519,20 @@ fn f32_sort_bits(v: f32) -> u32 {
 
 /// Order-preserving integer sort key, computed once per match instead of inside the
 /// comparator: primary column (direction folded in by negation, missing sorts last),
-/// then edhrec rank ascending (missing last), then prefer score descending (missing
-/// last). Card-level columns read the OracleCard; printing-level columns (rarity,
-/// usd) read the chosen printing, matching the pre-split semantics where the
-/// group's representative printing supplied them. Full ties fall back to printing
-/// store order in `select_page`.
-fn sort_key_bits(card: &AOracleCard, p: &APrinting, sort_col: SortCol, descending: bool) -> u128 {
+/// then edhrec rank ascending (missing last). Card-level columns read the OracleCard;
+/// printing-level columns (rarity, usd) read the chosen printing, matching the
+/// pre-split semantics where the group's representative printing supplied them.
+/// Full ties fall back to printing store order in `select_page`.
+///
+/// Used to pack a THIRD key here too (prefer score descending), but `page_cmp` -- the only
+/// comparator any `Match` consumer uses -- never read it: it must not decide across cards,
+/// because the two sides comparing a match cannot agree on it (see `page_cmp`'s own doc, kept
+/// below). Confirmed dead by zeroing it and running the full fuzz suite (`force_plan_differential
+/// _agreement`, `fuzz_row_identity_matches_reference`, the naive-reference printing-range tests)
+/// before removing it -- all 160 tests passed unchanged. Returning `u64` instead of `u128` halves
+/// `Match`'s size (`(u64, u32, u32)` is 16 bytes with no padding, against `(u128, u32, u32)`'s 32
+/// -- `u128` forces 16-byte alignment) for every executor that builds a `Vec<Match>`.
+fn sort_key_bits(card: &AOracleCard, p: &APrinting, sort_col: SortCol, descending: bool) -> u64 {
     let primary: Option<f32> = match sort_col {
         SortCol::Cmc        => card.cmc.as_ref().map(|v| f32::from(*v)),
         SortCol::Power      => card.creature_power.as_ref().map(|v| f32::from(*v)),
@@ -5540,19 +5548,21 @@ fn sort_key_bits(card: &AOracleCard, p: &APrinting, sort_col: SortCol, descendin
     };
     let pk = primary.map_or(u32::MAX, |v| f32_sort_bits(if descending { -v } else { v }));
     let e = card.edhrec_rank.as_ref().map(|v| u32::from(*v)).unwrap_or(u32::MAX);
-    let sc = p.prefer_score.as_ref().map_or(u32::MAX, |v| f32_sort_bits(-f32::from(*v)));
-    ((pk as u128) << 64) | ((e as u128) << 32) | (sc as u128)
+    ((pk as u64) << 32) | (e as u64)
 }
 
 /// One query match: (sort key, card index, printing index). Ties on the sort key
 /// break by printing index — printing store order, the same tie order the
 /// pre-split pointer comparison produced.
-type Match = (u128, u32, u32);
+type Match = (u64, u32, u32);
 
-/// The page comparator (`select_page`'s order): sort key, then pid. pid is unique,
+/// The page comparator (`select_page`'s order): sort key, then card, then pid. pid is unique,
 /// so this is a total order over `Match`.
 fn page_cmp(a: &Match, b: &Match) -> std::cmp::Ordering {
-    // Keys 1-2 only (`>> 32` drops key 3, prefer_score), then CARD, then printing.
+    // `sort_key_bits` no longer packs a third key (prefer_score) -- see its doc for why keeping
+    // it around a comparator that dropped it was pure waste. What follows is the reasoning that
+    // conclusion rests on, preserved because it is what makes this the RIGHT order rather than
+    // just AN order:
     //
     // Key 3 must not decide across cards, because the two sides cannot agree on it. The prebuilt
     // permutation bakes in `printings[offsets[i]]`'s prefer_score -- the first STORED printing, chosen
@@ -5563,14 +5573,14 @@ fn page_cmp(a: &Match, b: &Match) -> std::cmp::Ordering {
     //
     // `cid` is filter-independent and total, so both sides can reach it. Within a card this changes
     // nothing: printings are stored prefer-desc, so ascending pid already IS descending prefer_score.
-    (a.0 >> 32).cmp(&(b.0 >> 32)).then_with(|| a.1.cmp(&b.1)).then_with(|| a.2.cmp(&b.2))
+    a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)).then_with(|| a.2.cmp(&b.2))
 }
 
 /// Number of matches the gather buffer may grow *past* the page (`offset+limit`)
 /// before it is pruned back down (see `exec_gathered_scan`). Bounds the buffer at
-/// ~`page + CHUNK` ≈ 128KB of `Match` (32 B each — `u128`'s 16-byte alignment pads
-/// the trailing two `u32`s) — L2-resident — on whole-corpus results, while leaving
-/// any gather that never reaches this size byte-for-byte the un-pruned path.
+/// ~`page + CHUNK` ≈ 64KB of `Match` (16 B each, no padding) — L2-resident — on
+/// whole-corpus results, while leaving any gather that never reaches this size
+/// byte-for-byte the un-pruned path.
 /// Amortized O(1)/match (a prune every CHUNK matches costs O(page+CHUNK)).
 const GATHER_PRUNE_CHUNK: usize = 4096;
 
@@ -12968,3 +12978,5 @@ mod bench_membership_check;
 mod bench_expand_materialize;
 #[cfg(test)]
 mod bench_card_ids_dispatch;
+#[cfg(test)]
+mod bench_match_layout;

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2893,19 +2893,19 @@ fn arith_tuple_narrowing_matches_reference() {
 fn build_gather_matches(n: usize, ordering: u32) -> Vec<Match> {
     (0..n)
         .map(|i| {
-            let key: u128 = match ordering {
+            let key: u64 = match ordering {
                 // splitmix-style scramble: deterministic, no ordering structure
                 0 => {
-                    let mut x = (i as u128).wrapping_add(0x9E37_79B9_7F4A_7C15);
+                    let mut x = (i as u64).wrapping_add(0x9E37_79B9_7F4A_7C15);
                     x ^= x >> 30;
                     x = x.wrapping_mul(0xBF58_476D_1CE4_E5B9);
                     x ^= x >> 27;
                     x
                 }
-                1 => i as u128,           // ascending: after the 1st prune every later match is rejected
-                2 => (n - 1 - i) as u128, // descending: every later match beats the cutoff → prune repeatedly
-                3 => 0,                   // all ties: page_cmp must break by pid
-                _ => (i % 8) as u128,     // clustered / heavy ties
+                1 => i as u64,           // ascending: after the 1st prune every later match is rejected
+                2 => (n - 1 - i) as u64, // descending: every later match beats the cutoff → prune repeatedly
+                3 => 0,                  // all ties: page_cmp must break by pid
+                _ => (i % 8) as u64,     // clustered / heavy ties
             };
             (key, i as u32, i as u32) // (sort_key, cid, pid)
         })
@@ -3006,15 +3006,16 @@ fn fuzz_corpus_has_both_divergent_and_invariant_formats() {
 /// - `total` equality,
 /// - `scryfall_id` multiset equality — same *rows*,
 /// - **2-key ordering** equality — the `(primary, edhrec_rank)` value
-///   sequence (top 64 bits of `sort_key_bits`).
+///   sequence (`sort_key_bits`' whole output).
 ///
 /// The 2-key value sequence is the ordering-parity contract (#702): plans agree
-/// on the two SQL-defined keys they're guaranteed to, and diverge only past
-/// them (key 3, prefer_score, and below — see the `PREFERS` comment below and
-/// docs/issues/00702). Comparing the 2-key *value* sequence, not the row
-/// sequence, is what tolerates that key-3 slop while still catching any real
-/// mis-ordering: tied rows share their (key1, key2) value, so the sequence is
-/// identical even when they interleave.
+/// on the two SQL-defined keys they're guaranteed to. They used to diverge past
+/// them, on a third key (prefer_score) `sort_key_bits` no longer computes at all — see its doc
+/// for why that key was dead everywhere a real comparator read it — but the value-sequence
+/// comparison predates that removal and is kept: it is still what tolerates ties within a
+/// (key1, key2) value interleaving in either row order, whatever produces them. Comparing the
+/// 2-key *value* sequence, not the row sequence, is what does that: tied rows share their
+/// (key1, key2) value, so the sequence is identical even when they interleave.
 ///
 /// Hand-built specs guarantee P1 (`PrintingRangeScan`) and P2
 /// (`PlanePopcountOrder`) coverage — the random generator rarely emits a bare
@@ -3191,16 +3192,18 @@ fn force_plan_differential_agreement() {
     };
 
     // Ordering-parity contract (#702): plans agree on the SQL-defined keys 1-2
-    // (primary sort column, then edhrec_rank) — the top 64 bits of
-    // sort_key_bits. Key 3 (prefer_score) and beyond are unspecified across
-    // plans: the permutation bakes in the *default* representative's
-    // prefer_score, so under a non-default prefer the perm-based plans can order
-    // a key-3 tie differently from the gathered path (a known, pre-existing
-    // divergence — see docs/issues/00702-engine-plan-selection-layer.md).
+    // (primary sort column, then edhrec_rank) — sort_key_bits' whole u64 output. A tie on those
+    // is unspecified across plans: the permutation bakes in the *default* representative's
+    // prefer_score, so under a non-default prefer the perm-based plans can order a tie
+    // differently from the gathered path (a known, pre-existing divergence — see
+    // docs/issues/00702-engine-plan-selection-layer.md). This is independent of prefer_score
+    // ever having been a THIRD sort_key_bits component (it was, and dead everywhere it was
+    // read; see sort_key_bits' doc) -- the divergence lives in build_sort_permutations' own
+    // tiebreak, not in a key page_cmp ever consulted.
     // Comparing the 2-key VALUE sequence is stable across that: tied rows share
     // their (key1, key2) value, so the sequence is identical even when they
     // interleave. Exercised under a default AND a non-default prefer — 2-key
-    // parity holds at both (3-key would not, at non-default prefer).
+    // parity holds at both.
     const PREFERS: [&str; 2] = ["default", "usd_low"];
 
     for (spec, orderby, direction) in &cases {
@@ -3214,9 +3217,11 @@ fn force_plan_differential_agreement() {
         // a bound that changed any plan's answer is equally wrong.
         let sort_bound = sort_col_bound(&fuzz_bound_filter(spec, archived), sort_col);
         bounded_cases[usize::from(descending)] += usize::from(!sort_bound.is_unbounded());
-        // (key1, key2) = the top 64 bits of sort_key_bits; drop the low 32 (key 3).
-        let key2_seq = |page: &[(&Archived<OracleCard>, &Archived<Printing>)]| -> Vec<u128> {
-            page.iter().map(|&(c, p)| sort_key_bits(c, p, sort_col, descending) >> 32).collect()
+        // (key1, key2) = sort_key_bits' whole u64 output. It used to carry a third key
+        // (prefer_score) that this comparison dropped with a `>> 32`; that key was dead in every
+        // real comparator too (see sort_key_bits' doc) and has since been removed at the source.
+        let key2_seq = |page: &[(&Archived<OracleCard>, &Archived<Printing>)]| -> Vec<u64> {
+            page.iter().map(|&(c, p)| sort_key_bits(c, p, sort_col, descending)).collect()
         };
         for &prefer in &PREFERS {
             for &mode in &modes {
@@ -10892,7 +10897,7 @@ fn printing_range_fixture(seed: u64, n_cards: usize) -> CardData {
 fn naive_printing_page(
     archived: &Archived<CardData>, leaf: &FilterExpr, sc: SortCol, desc: bool, offset: usize, limit: usize,
 ) -> Vec<u128> {
-    let mut all: Vec<(u128, u32, u32)> = Vec::new();
+    let mut all: Vec<(u64, u32, u32)> = Vec::new();
     for cid in 0..archived.cards.len() as u32 {
         let card = &archived.cards[cid as usize];
         let start = u32::from(archived.offsets[cid as usize]) as usize;
@@ -11253,7 +11258,7 @@ fn gather_artwork_kernel_costs() {
     let bench_mode = |mode: Mode| -> u128 {
         let mut group_best: Vec<Option<(u32, f64)>> = vec![None; max_groups];
         let mut touched: Vec<u16> = Vec::new();
-        let mut out: Vec<(u128, u32, u32)> = Vec::with_capacity(4096);
+        let mut out: Vec<(u64, u32, u32)> = Vec::with_capacity(4096);
         let mut best = u128::MAX;
         for it in 0..(WARMUP + ITERS) {
             out.clear();

--- a/shared_cache/src/gen_cache.rs
+++ b/shared_cache/src/gen_cache.rs
@@ -11,6 +11,14 @@ use crate::types::{CachedResponse, RawSlot};
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
+/// Key hash + body fingerprint computed by `fast_check`, threaded into `set` so a cache write
+/// doesn't hash the key and sample the body a second time for the same call.
+pub struct PendingWrite {
+    hash: u64,
+    content_vh: u64,
+    new_body_len: u32,
+}
+
 struct SurvivorEntry {
     hash: u64,
     expiry_ns: u64,
@@ -628,18 +636,22 @@ impl GenerationalSharedCache {
         None // filter false positive
     }
 
-    /// Returns `true` if `key` is already cached with identical content — caller can skip `set()`.
+    /// Returns `None` if `key` is already cached with identical content — caller can skip `set()`.
+    /// Otherwise returns the key hash and body fingerprint `fast_check` had to compute anyway,
+    /// so a subsequent `set()` call for the same write doesn't hash the key and sample the body
+    /// a second time.
     /// Checks filter (lock-free) → active page under lock → sealed pages lock-free.
     /// Call this from the binding layer before extracting expensive fields (headers, counts).
-    pub fn fast_check(&mut self, key: &[u8], body: Option<&[u8]>) -> bool {
+    pub fn fast_check(&mut self, key: &[u8], body: Option<&[u8]>) -> Option<PendingWrite> {
         let hash = normalize_hash(xxh3_64(key));
         let new_body_len = body.map_or(u32::MAX, |b| b.len() as u32);
         let content_vh = sampled_body_hash(body);
+        let pending = PendingWrite { hash, content_vh, new_body_len };
 
         fence(Ordering::Acquire);
-        if !self.filter().lookup(hash) { return false; }
+        if !self.filter().lookup(hash) { return Some(pending); }
 
-        if !try_lock(&self.mmap) { return false; }
+        if !try_lock(&self.mmap) { return Some(pending); }
         let active_idx = self.active_idx();
         let active_snap = self.do_probe(active_idx, hash, key).map(|(_, _, si)| {
             let s = unsafe { &*self.slot_ptr(active_idx, si) };
@@ -648,7 +660,8 @@ impl GenerationalSharedCache {
         unlock(&self.mmap);
 
         if let Some((stored_len, stored_vh)) = active_snap {
-            return stored_len == new_body_len && content_vh == stored_vh;
+            let up_to_date = stored_len == new_body_len && content_vh == stored_vh;
+            return if up_to_date { None } else { Some(pending) };
         }
 
         for i in 1..self.n_pages {
@@ -658,11 +671,11 @@ impl GenerationalSharedCache {
             if let Some((_, _, si)) = self.do_probe(page_idx, hash, key) {
                 let s = unsafe { &*self.slot_ptr(page_idx, si) };
                 let matches = s.body_len == new_body_len && content_vh == s.value_hash;
-                if self.page_generation(page_idx) != gen_before { return false; }
-                return matches;
+                if self.page_generation(page_idx) != gen_before { return Some(pending); }
+                return if matches { None } else { Some(pending) };
             }
         }
-        false
+        Some(pending)
     }
 
     // too_many_arguments: this is the crate's public cache-write surface and mirrors the HTTP
@@ -672,6 +685,7 @@ impl GenerationalSharedCache {
     pub fn set(
         &mut self,
         key: &[u8],
+        pending: PendingWrite,
         status: &str,
         headers: Vec<(String, String)>,
         body: Option<&[u8]>,
@@ -679,9 +693,7 @@ impl GenerationalSharedCache {
         total_cards: Option<i64>,
         ttl_secs: Option<f64>,
     ) {
-        let hash = normalize_hash(xxh3_64(key));
-        let new_body_len = body.map_or(u32::MAX, |b| b.len() as u32);
-        let content_vh = sampled_body_hash(body);
+        let PendingWrite { hash, content_vh, new_body_len } = pending;
 
         let body_owned = body.map(|b| b.to_vec());
         let cr = CachedResponse { status: status.to_owned(), headers, body: body_owned, result_count, total_cards };
@@ -837,5 +849,64 @@ impl GenerationalSharedCache {
         let found = self.do_probe(active_idx, hash, key).is_some();
         unlock(&self.mmap);
         found
+    }
+}
+
+/// Micro-benchmark for the fast_check→set hashing duplication (perf-audit finding #3).
+///
+/// Before this fix, `SharedCache::set` (lib.rs) called `fast_check` to decide whether a write is
+/// needed, then — on the "content changed" branch — called `set`, which independently
+/// recomputed `normalize_hash(xxh3_64(key))` and `sampled_body_hash(body)`: the exact two values
+/// `fast_check` had just computed for the same call. This times that duplicated hashing work
+/// directly (no mmap, no lock, no rkyv), isolating just the arithmetic the fix removes.
+///
+///     cargo test --release bench_hash_reuse -- --ignored --nocapture
+#[cfg(test)]
+mod bench_hash_reuse {
+    use std::hint::black_box;
+    use std::time::Instant;
+
+    use super::{normalize_hash, sampled_body_hash, xxh3_64};
+
+    const ITERS: usize = 500_000;
+
+    #[test]
+    #[ignore]
+    fn bench_hash_reuse() {
+        let key = b"q:f:modern+is:permanent+cmc>=6&page=2&order=cmc&dir=asc";
+        let body = vec![0x42u8; 24 * 1024]; // representative cached search-response body size
+
+        // Baseline: current-before-fix behavior — hash key + sample body TWICE per write
+        // (once in fast_check, once in set).
+        let start = Instant::now();
+        let mut sink: u64 = 0;
+        for _ in 0..ITERS {
+            let h1 = normalize_hash(xxh3_64(black_box(key)));
+            let v1 = sampled_body_hash(Some(black_box(body.as_slice())));
+            let h2 = normalize_hash(xxh3_64(black_box(key)));
+            let v2 = sampled_body_hash(Some(black_box(body.as_slice())));
+            sink ^= h1 ^ v1 ^ h2 ^ v2;
+        }
+        let dup_ns = start.elapsed().as_nanos() as f64 / ITERS as f64;
+        black_box(sink);
+
+        // Fixed: hash key + sample body ONCE, reused via PendingWrite.
+        let start = Instant::now();
+        let mut sink2: u64 = 0;
+        for _ in 0..ITERS {
+            let h1 = normalize_hash(xxh3_64(black_box(key)));
+            let v1 = sampled_body_hash(Some(black_box(body.as_slice())));
+            sink2 ^= h1 ^ v1;
+        }
+        let once_ns = start.elapsed().as_nanos() as f64 / ITERS as f64;
+        black_box(sink2);
+
+        println!("dup  (fast_check + set, pre-fix): {dup_ns:.1} ns/call");
+        println!("once (hoisted via PendingWrite):  {once_ns:.1} ns/call");
+        println!(
+            "delta: {:.1} ns/call ({:.0}% of the pre-fix cost)",
+            dup_ns - once_ns,
+            100.0 * (dup_ns - once_ns) / dup_ns
+        );
     }
 }

--- a/shared_cache/src/lib.rs
+++ b/shared_cache/src/lib.rs
@@ -69,15 +69,17 @@ impl SharedCache {
         let body_obj = value.getattr("body")?;
         let body_bytes: Option<Bound<PyBytes>> = body_obj.extract()?;
         let body: Option<&[u8]> = body_bytes.as_ref().map(|b| b.as_bytes());
-        // Skip rkyv + headers extraction entirely when content is unchanged.
-        if self.inner.fast_check(key, body) {
+        // Skip rkyv + headers extraction entirely when content is unchanged. When it isn't,
+        // fast_check's key hash and body fingerprint are reused by set() below instead of
+        // being recomputed.
+        let Some(pending) = self.inner.fast_check(key, body) else {
             return Ok(());
-        }
+        };
         let status: String = value.getattr("status")?.extract()?;
         let headers: Vec<(String, String)> = value.getattr("headers")?.extract()?;
         let result_count: Option<i64> = value.getattr("result_count")?.extract()?;
         let total_cards: Option<i64> = value.getattr("total_cards")?.extract()?;
-        self.inner.set(key, &status, headers, body, result_count, total_cards, ttl);
+        self.inner.set(key, pending, &status, headers, body, result_count, total_cards, ttl);
         Ok(())
     }
 

--- a/shared_cache/src/region.rs
+++ b/shared_cache/src/region.rs
@@ -2,6 +2,7 @@ use std::fs::OpenOptions;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use memmap2::MmapMut;
 
@@ -147,9 +148,24 @@ pub fn read_value_seq(slot: *const u8) -> u32 {
 
 // ── Spinlock ──────────────────────────────────────────────────────────────────
 
+/// This process's pid, read via a syscall once and cached: it cannot change for the life of
+/// the process, and unlike Linux glibc (which caches `getpid()` itself post-2.25), macOS libc
+/// makes every `std::process::id()` call a real trap into the kernel.
+fn current_pid() -> u32 {
+    static PID: OnceLock<u32> = OnceLock::new();
+    *PID.get_or_init(std::process::id) // u32; PID 0 is unused on POSIX, safe as unlocked sentinel
+}
+
 pub fn try_lock(mmap: &MmapMut) -> bool {
     let lock = unsafe { &*(mmap.as_ptr() as *const AtomicU32) };
-    let my_pid = std::process::id(); // u32; PID 0 is unused on POSIX, safe as unlocked sentinel
+    let my_pid = current_pid();
+
+    // Uncontended fast path: no clock read. The overwhelming majority of calls land here, and
+    // `Instant::now()` is only needed to police a timeout on the contended path below.
+    if lock.compare_exchange(0, my_pid, Ordering::Acquire, Ordering::Relaxed).is_ok() {
+        return true;
+    }
+
     let deadline = Instant::now() + LOCK_TIMEOUT;
     loop {
         if lock.compare_exchange(0, my_pid, Ordering::Acquire, Ordering::Relaxed).is_ok() {
@@ -223,4 +239,59 @@ pub fn open_mmap(
     under_lock(&mut mmap);
     unsafe { libc::flock(fd, libc::LOCK_UN) };
     Ok(mmap)
+}
+
+/// Perf-audit finding #6: `try_lock` computed `std::process::id()` and `Instant::now()`
+/// unconditionally, even on the uncontended fast path where neither is needed until the first
+/// CAS attempt fails. Times the uncontended case (the common one -- no other thread ever holds
+/// the lock here) before vs after deferring both.
+///
+///     cargo test --release bench_try_lock_fast_path -- --ignored --nocapture
+#[cfg(test)]
+mod bench_try_lock_fast_path {
+    use std::hint::black_box;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Instant;
+
+    use super::{try_lock, unlock};
+    use memmap2::MmapMut;
+
+    const ITERS: usize = 500_000;
+
+    /// Pre-fix try_lock: recomputes pid + deadline on every call, even when uncontended.
+    #[inline(never)]
+    fn try_lock_prefix(mmap: &MmapMut) -> bool {
+        let lock = unsafe { &*(mmap.as_ptr() as *const AtomicU32) };
+        let my_pid = black_box(std::process::id());
+        let _deadline = black_box(Instant::now() + std::time::Duration::from_millis(1));
+        lock.compare_exchange(0, my_pid, Ordering::Acquire, Ordering::Relaxed).is_ok()
+    }
+
+    #[test]
+    #[ignore]
+    fn bench_try_lock_fast_path() {
+        let mmap = MmapMut::map_anon(4096).expect("anon mmap");
+
+        let start = Instant::now();
+        for _ in 0..ITERS {
+            assert!(black_box(try_lock_prefix(black_box(&mmap))));
+            unlock(&mmap);
+        }
+        let prefix_ns = start.elapsed().as_nanos() as f64 / ITERS as f64;
+
+        let start = Instant::now();
+        for _ in 0..ITERS {
+            assert!(black_box(try_lock(black_box(&mmap))));
+            unlock(&mmap);
+        }
+        let fixed_ns = start.elapsed().as_nanos() as f64 / ITERS as f64;
+
+        println!("pre-fix (pid + clock every call): {prefix_ns:.1} ns/call");
+        println!("fixed   (cached pid, no clock):   {fixed_ns:.1} ns/call");
+        println!(
+            "delta: {:.1} ns/call ({:.0}% reduction)",
+            prefix_ns - fixed_ns,
+            100.0 * (prefix_ns - fixed_ns) / prefix_ns
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Five independently-measured performance fixes from a Rust perf audit of `card_engine` and `shared_cache`, each its own commit with a kernel micro-benchmark run before and after.

- Shared cache: hash the key and sample the body once per write instead of twice (`fast_check` + `set` recomputed the same hashes) — measured 51-53% reduction on the isolated hashing cost, stable across 3 runs.
- Legalities field: cache the sorted format registry instead of cloning and sorting it on every output row — measured 98-99% reduction (~600-700ns/row down to ~10.5ns), the largest win in this set.
- `PreparedCandidates::card_ids`: replace `Box<dyn ExactSizeIterator>` with a concrete 2-variant enum so P3/P4's per-card match loops call a monomorphized `next()` instead of going through a vtable — measured ~1.1-1.2ns/card after fixing a flawed first benchmark attempt that let LLVM devirtualize the box away entirely.
- Shared cache: defer `try_lock`'s clock read to the contended path only, and cache the pid via a process-lifetime `OnceLock` instead of a syscall per call — measured 74-75% reduction on the uncontended lock/unlock cycle.
- `Match`: drop a third sort key (`prefer_score`) that every real comparator already ignored, shrinking the type from 32 to 16 bytes. Verified the key was dead two ways — a static trace of every consumer, then an empirical check (zero it and run the full 160-test suite) — before removing it. Measured 1.3-1.4x faster `select_nth_unstable_by` at the buffer sizes `select_page`/`prune_to_smallest` actually run at.

One additional candidate (`plan_cost`'s unconditional `printings_walked` call) was measured and declined: isolated cost ~0.4ns/call, far below anything a routing-decision benchmark could resolve.

Four more candidates from the same audit are documented but not implemented — see the untracked `docs/issues/local-rust-perf-audit-remaining-findings.md` on the author's machine (a body-copy reduction in `gen_cache` that touches the cross-process wire format, plus three lower-priority/reload-time-only items).

## Test plan

- [x] `cargo test --release` passes (160 passed, 0 failed) in both `card_engine` and `shared_cache` after every commit
- [x] `cargo clippy --release` clean after every commit
- [x] Each fix has a dedicated `#[ignore]`d kernel micro-benchmark (`cargo test --release bench_<name> -- --ignored --nocapture`) run 3x before and after, included in the commit message
- [x] No behavior change intended in any commit; the `Match` layout change was additionally verified by zeroing the removed key and re-running the full suite before touching the type